### PR TITLE
feat(identity): SPIFFE-compatible local CA + X.509-SVID issuance (issue #2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/network-gate",
     "crates/ledger-writer",
     "crates/identity",
+    "crates/cli",
 ]
 
 [workspace.package]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aegis-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "aegis"
+path = "src/main.rs"
+
+[dependencies]
+aegis-identity = { path = "../identity" }
+clap = { version = "4", features = ["derive"] }
+hex = "0.4"
+dirs = "5"
+anyhow = "1"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,0 +1,149 @@
+//! `aegis` — Aegis-Node command-line interface.
+//!
+//! Phase 1a ships the `identity` subcommand surface required by issue #2:
+//!
+//! ```text
+//! aegis identity init   --trust-domain <td>
+//! aegis identity issue  <workload-name> --instance <i>
+//!                       --model-digest <hex> --manifest-digest <hex>
+//!                       --config-digest <hex>
+//! ```
+//!
+//! Future phases extend this with `aegis verify` (issue #5) and `aegis run`.
+
+use std::path::PathBuf;
+
+use aegis_identity::{Digest, DigestTriple, LocalCa};
+use anyhow::{Context, Result};
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(name = "aegis", version, about = "Aegis-Node CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Workload identity management (SPIFFE-compatible local CA, F1).
+    Identity {
+        #[command(subcommand)]
+        sub: IdentityCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentityCommand {
+    /// One-time setup of the local CA under `$XDG_CONFIG_HOME/aegis/identity`.
+    Init(InitArgs),
+    /// Issue a fresh X.509-SVID for `<workload-name>`.
+    Issue(IssueArgs),
+}
+
+#[derive(Debug, Args)]
+struct InitArgs {
+    /// SPIFFE trust domain to embed in issued SVIDs (e.g. `aegis-node.local`).
+    #[arg(long)]
+    trust_domain: String,
+
+    /// Override the default config dir.
+    #[arg(long)]
+    config_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct IssueArgs {
+    /// Workload name (path segment of the SPIFFE ID).
+    workload_name: String,
+
+    /// Instance identifier (last path segment of the SPIFFE ID).
+    #[arg(long)]
+    instance: String,
+
+    /// SHA-256 digest of the model artifact, as a 64-char hex string.
+    #[arg(long)]
+    model_digest: String,
+
+    /// SHA-256 digest of the resolved Permission Manifest.
+    #[arg(long)]
+    manifest_digest: String,
+
+    /// SHA-256 digest of the runtime configuration.
+    #[arg(long)]
+    config_digest: String,
+
+    /// Override the default config dir.
+    #[arg(long)]
+    config_dir: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Identity { sub } => match sub {
+            IdentityCommand::Init(args) => cmd_init(args),
+            IdentityCommand::Issue(args) => cmd_issue(args),
+        },
+    }
+}
+
+fn cmd_init(args: InitArgs) -> Result<()> {
+    let dir = resolve_identity_dir(args.config_dir)?;
+    LocalCa::init(&dir, &args.trust_domain).with_context(|| {
+        format!(
+            "initializing local CA at {} for trust domain {:?}",
+            dir.display(),
+            args.trust_domain
+        )
+    })?;
+    println!(
+        "initialized Aegis-Node local CA at {} (trust_domain={})",
+        dir.display(),
+        args.trust_domain
+    );
+    Ok(())
+}
+
+fn cmd_issue(args: IssueArgs) -> Result<()> {
+    let dir = resolve_identity_dir(args.config_dir)?;
+    let ca = LocalCa::load(&dir)
+        .with_context(|| format!("loading local CA from {}", dir.display()))?;
+
+    let digests = DigestTriple {
+        model: parse_digest_arg("model-digest", &args.model_digest)?,
+        manifest: parse_digest_arg("manifest-digest", &args.manifest_digest)?,
+        config: parse_digest_arg("config-digest", &args.config_digest)?,
+    };
+
+    let svid = ca
+        .issue_svid(&args.workload_name, &args.instance, digests)
+        .with_context(|| {
+            format!(
+                "issuing SVID for {}/{}",
+                args.workload_name, args.instance
+            )
+        })?;
+
+    // The CLI prints both PEMs to stdout in a labeled, machine-friendly form.
+    // Callers (control plane, scripts) split on the labels to consume them.
+    println!("# spiffe_id: {}", svid.spiffe_id);
+    println!("# model_digest: {}", svid.digests.model.hex());
+    println!("# manifest_digest: {}", svid.digests.manifest.hex());
+    println!("# config_digest: {}", svid.digests.config.hex());
+    println!("{}", svid.cert_pem);
+    println!("{}", svid.key_pem);
+    Ok(())
+}
+
+fn resolve_identity_dir(override_dir: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(p) = override_dir {
+        return Ok(p);
+    }
+    let base = dirs::config_dir().context("could not resolve user config dir")?;
+    Ok(base.join("aegis").join("identity"))
+}
+
+fn parse_digest_arg(name: &'static str, hex_str: &str) -> Result<Digest> {
+    Digest::from_hex(hex_str).with_context(|| format!("--{name} must be a 64-char hex SHA-256"))
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -107,8 +107,8 @@ fn cmd_init(args: InitArgs) -> Result<()> {
 
 fn cmd_issue(args: IssueArgs) -> Result<()> {
     let dir = resolve_identity_dir(args.config_dir)?;
-    let ca = LocalCa::load(&dir)
-        .with_context(|| format!("loading local CA from {}", dir.display()))?;
+    let ca =
+        LocalCa::load(&dir).with_context(|| format!("loading local CA from {}", dir.display()))?;
 
     let digests = DigestTriple {
         model: parse_digest_arg("model-digest", &args.model_digest)?,
@@ -118,12 +118,7 @@ fn cmd_issue(args: IssueArgs) -> Result<()> {
 
     let svid = ca
         .issue_svid(&args.workload_name, &args.instance, digests)
-        .with_context(|| {
-            format!(
-                "issuing SVID for {}/{}",
-                args.workload_name, args.instance
-            )
-        })?;
+        .with_context(|| format!("issuing SVID for {}/{}", args.workload_name, args.instance))?;
 
     // The CLI prints both PEMs to stdout in a labeled, machine-friendly form.
     // Callers (control plane, scripts) split on the labels to consume them.

--- a/crates/identity/Cargo.toml
+++ b/crates/identity/Cargo.toml
@@ -11,3 +11,12 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem", "ring"] }
+x509-parser = "0.16"
+time = { version = "0.3", features = ["std"] }
+hex = "0.4"
+thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/identity/Cargo.toml
+++ b/crates/identity/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem", "ring"] }
+rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem", "ring", "x509-parser"] }
 x509-parser = "0.16"
 time = { version = "0.3", features = ["std"] }
 hex = "0.4"

--- a/crates/identity/src/ca.rs
+++ b/crates/identity/src/ca.rs
@@ -201,16 +201,15 @@ fn write_file(path: &Path, contents: &[u8], _mode: u32) -> Result<()> {
 /// command) to extract the digest triple from an X.509-SVID PEM. The cert
 /// must contain the digest-binding extension or this returns an error.
 pub fn extract_digest_triple_from_pem(cert_pem: &str) -> Result<DigestTriple> {
+    use x509_parser::parse_x509_certificate;
     use x509_parser::pem::Pem;
-    use x509_parser::prelude::FromDer;
-    use x509_parser::x509::X509Certificate;
 
     let pem = Pem::iter_from_buffer(cert_pem.as_bytes())
         .next()
         .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
         .map_err(|e| Error::CertParse(e.to_string()))?;
     let (_, cert) =
-        X509Certificate::from_der(&pem.contents).map_err(|e| Error::CertParse(e.to_string()))?;
+        parse_x509_certificate(&pem.contents).map_err(|e| Error::CertParse(e.to_string()))?;
 
     let oid_str = oid_components_to_dotted(DIGEST_BINDING_OID);
     let ext = cert
@@ -226,16 +225,15 @@ pub fn extract_digest_triple_from_pem(cert_pem: &str) -> Result<DigestTriple> {
 /// leaf cert's URI SAN.
 pub fn extract_spiffe_id_from_pem(cert_pem: &str) -> Result<SpiffeId> {
     use x509_parser::extensions::{GeneralName, ParsedExtension};
+    use x509_parser::parse_x509_certificate;
     use x509_parser::pem::Pem;
-    use x509_parser::prelude::FromDer;
-    use x509_parser::x509::X509Certificate;
 
     let pem = Pem::iter_from_buffer(cert_pem.as_bytes())
         .next()
         .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
         .map_err(|e| Error::CertParse(e.to_string()))?;
     let (_, cert) =
-        X509Certificate::from_der(&pem.contents).map_err(|e| Error::CertParse(e.to_string()))?;
+        parse_x509_certificate(&pem.contents).map_err(|e| Error::CertParse(e.to_string()))?;
 
     for ext in cert.extensions() {
         if let ParsedExtension::SubjectAlternativeName(san) = ext.parsed_extension() {

--- a/crates/identity/src/ca.rs
+++ b/crates/identity/src/ca.rs
@@ -35,6 +35,7 @@ const SVID_VALIDITY_HOURS: i64 = 24;
 
 /// File-backed local CA. Holds the issuer cert + key in memory, ready to
 /// stamp leaf SVIDs.
+#[derive(Debug)]
 pub struct LocalCa {
     dir: PathBuf,
     trust_domain: String,

--- a/crates/identity/src/ca.rs
+++ b/crates/identity/src/ca.rs
@@ -1,0 +1,262 @@
+//! File-backed local CA for issuing Aegis workload identities.
+//!
+//! Per ADR-003 (F1) the local CLI ships a built-in lightweight CA so a
+//! developer can run `aegis identity init` once and have a working SPIFFE
+//! trust domain on disk without standing up SPIRE. Phase 2 swaps this for
+//! SPIRE workload attestation; the on-disk artifacts stay user-private.
+//!
+//! Layout under `<dir>`:
+//!
+//! ```text
+//! ca.crt           PEM root certificate, mode 0644
+//! ca.key           PEM PKCS#8 private key, mode 0600
+//! trust_domain     plain-text trust domain string
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, CustomExtension, DnType, Ia5String, IsCa,
+    KeyPair, SanType,
+};
+use time::{Duration, OffsetDateTime};
+
+use crate::error::{Error, Result};
+use crate::spiffe::SpiffeId;
+use crate::svid::{DigestTriple, X509Svid, DIGEST_BINDING_OID};
+
+const CA_CERT_FILE: &str = "ca.crt";
+const CA_KEY_FILE: &str = "ca.key";
+const TRUST_DOMAIN_FILE: &str = "trust_domain";
+
+const CA_VALIDITY_YEARS: i64 = 10;
+const SVID_VALIDITY_HOURS: i64 = 24;
+
+/// File-backed local CA. Holds the issuer cert + key in memory, ready to
+/// stamp leaf SVIDs.
+pub struct LocalCa {
+    dir: PathBuf,
+    trust_domain: String,
+    ca_cert: Certificate,
+    ca_key: KeyPair,
+}
+
+impl LocalCa {
+    /// First-time setup. Creates `dir`, generates a fresh CA, persists it.
+    /// Refuses to overwrite an existing CA — re-init would silently break
+    /// every previously issued SVID.
+    pub fn init<P: AsRef<Path>>(dir: P, trust_domain: &str) -> Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        let cert_path = dir.join(CA_CERT_FILE);
+        if cert_path.exists() {
+            return Err(Error::CaAlreadyInitialized(dir.display().to_string()));
+        }
+        validate_trust_domain_for_ca(trust_domain)?;
+        fs::create_dir_all(&dir)?;
+
+        let now = OffsetDateTime::now_utc();
+        let mut params = CertificateParams::default();
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.not_before = now - Duration::minutes(5);
+        params.not_after = now + Duration::days(365 * CA_VALIDITY_YEARS);
+        params.distinguished_name.push(DnType::CommonName, "Aegis-Node Local CA");
+        params.distinguished_name.push(
+            DnType::OrganizationName,
+            format!("Aegis-Node trust domain {trust_domain}"),
+        );
+
+        let ca_key = KeyPair::generate()?;
+        let ca_cert = params.self_signed(&ca_key)?;
+
+        write_file(&cert_path, ca_cert.pem().as_bytes(), 0o644)?;
+        write_file(
+            &dir.join(CA_KEY_FILE),
+            ca_key.serialize_pem().as_bytes(),
+            0o600,
+        )?;
+        write_file(
+            &dir.join(TRUST_DOMAIN_FILE),
+            trust_domain.as_bytes(),
+            0o644,
+        )?;
+
+        Ok(Self {
+            dir,
+            trust_domain: trust_domain.to_string(),
+            ca_cert,
+            ca_key,
+        })
+    }
+
+    /// Load an existing CA from disk. The cert is reconstituted from PEM and
+    /// re-signed in memory with the loaded key — issued leaves chain back via
+    /// issuer DN + key, so the on-disk PEM is the authority.
+    pub fn load<P: AsRef<Path>>(dir: P) -> Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        let cert_path = dir.join(CA_CERT_FILE);
+        let key_path = dir.join(CA_KEY_FILE);
+        let td_path = dir.join(TRUST_DOMAIN_FILE);
+        if !cert_path.exists() || !key_path.exists() || !td_path.exists() {
+            return Err(Error::CaNotInitialized(dir.display().to_string()));
+        }
+
+        let ca_pem = fs::read_to_string(&cert_path)?;
+        let key_pem = fs::read_to_string(&key_path)?;
+        let trust_domain = fs::read_to_string(&td_path)?.trim().to_string();
+        validate_trust_domain_for_ca(&trust_domain)?;
+
+        let ca_key = KeyPair::from_pem(&key_pem)?;
+        let ca_params = CertificateParams::from_ca_cert_pem(&ca_pem)?;
+        let ca_cert = ca_params.self_signed(&ca_key)?;
+
+        Ok(Self {
+            dir,
+            trust_domain,
+            ca_cert,
+            ca_key,
+        })
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub fn trust_domain(&self) -> &str {
+        &self.trust_domain
+    }
+
+    /// Issue a fresh X.509-SVID for the named workload + instance, binding
+    /// the (model, manifest, config) digest triple into a custom extension.
+    pub fn issue_svid(
+        &self,
+        workload_name: &str,
+        instance: &str,
+        digests: DigestTriple,
+    ) -> Result<X509Svid> {
+        let spiffe_id = SpiffeId::new(&self.trust_domain, workload_name, instance)?;
+        let now = OffsetDateTime::now_utc();
+
+        let mut params = CertificateParams::default();
+        params.not_before = now - Duration::minutes(5);
+        params.not_after = now + Duration::hours(SVID_VALIDITY_HOURS);
+        params.distinguished_name.push(DnType::CommonName, workload_name);
+        params.subject_alt_names = vec![SanType::URI(
+            Ia5String::try_from(spiffe_id.uri()).map_err(|e| {
+                Error::CertParse(format!("SPIFFE URI not IA5-encodable: {e}"))
+            })?,
+        )];
+
+        let mut ext = CustomExtension::from_oid_content(
+            DIGEST_BINDING_OID,
+            digests.encode().to_vec(),
+        );
+        ext.set_criticality(true);
+        params.custom_extensions.push(ext);
+
+        let leaf_key = KeyPair::generate()?;
+        let leaf = params.signed_by(&leaf_key, &self.ca_cert, &self.ca_key)?;
+
+        Ok(X509Svid {
+            spiffe_id,
+            digests,
+            cert_pem: leaf.pem(),
+            key_pem: leaf_key.serialize_pem(),
+        })
+    }
+
+    /// PEM of the CA root certificate. Useful for trust-bundle distribution.
+    pub fn root_cert_pem(&self) -> String {
+        self.ca_cert.pem()
+    }
+}
+
+fn validate_trust_domain_for_ca(td: &str) -> Result<()> {
+    // Reuse SpiffeId's validator by attempting to construct a sentinel ID.
+    SpiffeId::new(td, "ca", "root").map(|_| ())
+}
+
+#[cfg(unix)]
+fn write_file(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create_new(true).write(true).mode(mode);
+    let mut f = opts.open(path)?;
+    use std::io::Write;
+    f.write_all(contents)?;
+    f.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_file(path: &Path, contents: &[u8], _mode: u32) -> Result<()> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create_new(true).write(true);
+    let mut f = opts.open(path)?;
+    use std::io::Write;
+    f.write_all(contents)?;
+    f.sync_all()?;
+    Ok(())
+}
+
+/// Helper used by issued-cert verifiers (and the future `aegis identity verify`
+/// command) to extract the digest triple from an X.509-SVID PEM. The cert
+/// must contain the digest-binding extension or this returns an error.
+pub fn extract_digest_triple_from_pem(cert_pem: &str) -> Result<DigestTriple> {
+    use x509_parser::pem::Pem;
+    use x509_parser::prelude::FromDer;
+    use x509_parser::x509::X509Certificate;
+
+    let pem = Pem::iter_from_buffer(cert_pem.as_bytes())
+        .next()
+        .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
+        .map_err(|e| Error::CertParse(e.to_string()))?;
+    let (_, cert) = X509Certificate::from_der(&pem.contents)
+        .map_err(|e| Error::CertParse(e.to_string()))?;
+
+    let oid_str = oid_components_to_dotted(DIGEST_BINDING_OID);
+    let ext = cert
+        .extensions()
+        .iter()
+        .find(|e| e.oid.to_id_string() == oid_str)
+        .ok_or_else(|| Error::CertParse(format!("missing digest-binding extension {oid_str}")))?;
+
+    DigestTriple::decode(ext.value)
+}
+
+/// Like `extract_digest_triple_from_pem` but for the SPIFFE ID encoded in the
+/// leaf cert's URI SAN.
+pub fn extract_spiffe_id_from_pem(cert_pem: &str) -> Result<SpiffeId> {
+    use x509_parser::extensions::{GeneralName, ParsedExtension};
+    use x509_parser::pem::Pem;
+    use x509_parser::prelude::FromDer;
+    use x509_parser::x509::X509Certificate;
+
+    let pem = Pem::iter_from_buffer(cert_pem.as_bytes())
+        .next()
+        .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
+        .map_err(|e| Error::CertParse(e.to_string()))?;
+    let (_, cert) = X509Certificate::from_der(&pem.contents)
+        .map_err(|e| Error::CertParse(e.to_string()))?;
+
+    for ext in cert.extensions() {
+        if let ParsedExtension::SubjectAlternativeName(san) = ext.parsed_extension() {
+            for name in &san.general_names {
+                if let GeneralName::URI(uri) = name {
+                    return SpiffeId::parse(uri);
+                }
+            }
+        }
+    }
+    Err(Error::CertParse("no URI SAN found".to_string()))
+}
+
+fn oid_components_to_dotted(parts: &[u64]) -> String {
+    parts
+        .iter()
+        .map(|n| n.to_string())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+

--- a/crates/identity/src/ca.rs
+++ b/crates/identity/src/ca.rs
@@ -60,7 +60,9 @@ impl LocalCa {
         params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
         params.not_before = now - Duration::minutes(5);
         params.not_after = now + Duration::days(365 * CA_VALIDITY_YEARS);
-        params.distinguished_name.push(DnType::CommonName, "Aegis-Node Local CA");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Aegis-Node Local CA");
         params.distinguished_name.push(
             DnType::OrganizationName,
             format!("Aegis-Node trust domain {trust_domain}"),
@@ -75,11 +77,7 @@ impl LocalCa {
             ca_key.serialize_pem().as_bytes(),
             0o600,
         )?;
-        write_file(
-            &dir.join(TRUST_DOMAIN_FILE),
-            trust_domain.as_bytes(),
-            0o644,
-        )?;
+        write_file(&dir.join(TRUST_DOMAIN_FILE), trust_domain.as_bytes(), 0o644)?;
 
         Ok(Self {
             dir,
@@ -140,17 +138,16 @@ impl LocalCa {
         let mut params = CertificateParams::default();
         params.not_before = now - Duration::minutes(5);
         params.not_after = now + Duration::hours(SVID_VALIDITY_HOURS);
-        params.distinguished_name.push(DnType::CommonName, workload_name);
+        params
+            .distinguished_name
+            .push(DnType::CommonName, workload_name);
         params.subject_alt_names = vec![SanType::URI(
-            Ia5String::try_from(spiffe_id.uri()).map_err(|e| {
-                Error::CertParse(format!("SPIFFE URI not IA5-encodable: {e}"))
-            })?,
+            Ia5String::try_from(spiffe_id.uri())
+                .map_err(|e| Error::CertParse(format!("SPIFFE URI not IA5-encodable: {e}")))?,
         )];
 
-        let mut ext = CustomExtension::from_oid_content(
-            DIGEST_BINDING_OID,
-            digests.encode().to_vec(),
-        );
+        let mut ext =
+            CustomExtension::from_oid_content(DIGEST_BINDING_OID, digests.encode().to_vec());
         ext.set_criticality(true);
         params.custom_extensions.push(ext);
 
@@ -212,8 +209,8 @@ pub fn extract_digest_triple_from_pem(cert_pem: &str) -> Result<DigestTriple> {
         .next()
         .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
         .map_err(|e| Error::CertParse(e.to_string()))?;
-    let (_, cert) = X509Certificate::from_der(&pem.contents)
-        .map_err(|e| Error::CertParse(e.to_string()))?;
+    let (_, cert) =
+        X509Certificate::from_der(&pem.contents).map_err(|e| Error::CertParse(e.to_string()))?;
 
     let oid_str = oid_components_to_dotted(DIGEST_BINDING_OID);
     let ext = cert
@@ -237,8 +234,8 @@ pub fn extract_spiffe_id_from_pem(cert_pem: &str) -> Result<SpiffeId> {
         .next()
         .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
         .map_err(|e| Error::CertParse(e.to_string()))?;
-    let (_, cert) = X509Certificate::from_der(&pem.contents)
-        .map_err(|e| Error::CertParse(e.to_string()))?;
+    let (_, cert) =
+        X509Certificate::from_der(&pem.contents).map_err(|e| Error::CertParse(e.to_string()))?;
 
     for ext in cert.extensions() {
         if let ParsedExtension::SubjectAlternativeName(san) = ext.parsed_extension() {
@@ -259,4 +256,3 @@ fn oid_components_to_dotted(parts: &[u64]) -> String {
         .collect::<Vec<_>>()
         .join(".")
 }
-

--- a/crates/identity/src/ca.rs
+++ b/crates/identity/src/ca.rs
@@ -35,12 +35,20 @@ const SVID_VALIDITY_HOURS: i64 = 24;
 
 /// File-backed local CA. Holds the issuer cert + key in memory, ready to
 /// stamp leaf SVIDs.
-#[derive(Debug)]
 pub struct LocalCa {
     dir: PathBuf,
     trust_domain: String,
     ca_cert: Certificate,
     ca_key: KeyPair,
+}
+
+impl std::fmt::Debug for LocalCa {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalCa")
+            .field("dir", &self.dir)
+            .field("trust_domain", &self.trust_domain)
+            .finish_non_exhaustive()
+    }
 }
 
 impl LocalCa {

--- a/crates/identity/src/error.rs
+++ b/crates/identity/src/error.rs
@@ -1,0 +1,30 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("certificate generation: {0}")]
+    Rcgen(#[from] rcgen::Error),
+
+    #[error("certificate parse: {0}")]
+    CertParse(String),
+
+    #[error("invalid SPIFFE ID {input:?}: {reason}")]
+    InvalidSpiffeId { input: String, reason: &'static str },
+
+    #[error("invalid trust domain {0:?}")]
+    InvalidTrustDomain(String),
+
+    #[error("CA already initialized at {0}")]
+    CaAlreadyInitialized(String),
+
+    #[error("CA not initialized at {0}")]
+    CaNotInitialized(String),
+
+    #[error("digest must be 32 bytes (got {0})")]
+    InvalidDigestLength(usize),
+}

--- a/crates/identity/src/lib.rs
+++ b/crates/identity/src/lib.rs
@@ -1,4 +1,24 @@
 //! Aegis-Node workload identity.
 //!
-//! SPIFFE-compatible workload identity, model+manifest+config digest binding,
-//! per ADR-003 (F1). Phase 0 scaffold.
+//! SPIFFE-compatible workload identity per ADR-003 (F1). This crate owns:
+//!
+//! - SPIFFE ID parsing in the strict Aegis form
+//!   `spiffe://<trust-domain>/agent/<workload>/<instance>` ([`SpiffeId`]).
+//! - A file-backed local CA ([`LocalCa`]) for one-time-init / repeat-issue,
+//!   used by the `aegis` CLI on developer laptops.
+//! - X.509-SVID issuance ([`X509Svid`]) with the SPIFFE URI in the SAN and
+//!   a `(model, manifest, config)` SHA-256 digest triple bound into a custom
+//!   extension. Any digest change invalidates the identity (per ADR-003).
+//!
+//! Phase 0 ships the local-CA flavor only. Phase 2 swaps `LocalCa` for SPIRE
+//! workload-attestation; the SVID format on the wire stays identical.
+
+mod ca;
+pub mod error;
+mod spiffe;
+mod svid;
+
+pub use ca::{extract_digest_triple_from_pem, extract_spiffe_id_from_pem, LocalCa};
+pub use error::{Error, Result};
+pub use spiffe::SpiffeId;
+pub use svid::{Digest, DigestTriple, X509Svid, DIGEST_BINDING_LEN, DIGEST_BINDING_OID};

--- a/crates/identity/src/spiffe.rs
+++ b/crates/identity/src/spiffe.rs
@@ -1,0 +1,188 @@
+//! SPIFFE ID parsing and emission for Aegis-Node workload identity.
+//!
+//! Per ADR-003 (F1) the canonical Aegis SPIFFE ID is:
+//!
+//! ```text
+//! spiffe://<trust-domain>/agent/<workload-name>/<instance>
+//! ```
+//!
+//! This module enforces that exact shape — the strict format means a verifier
+//! never has to guess whether an identity belongs to an Aegis-Node agent.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+const SCHEME: &str = "spiffe://";
+const AGENT_SEGMENT: &str = "agent";
+
+/// SPIFFE workload identity. Always Aegis-shaped:
+/// `spiffe://<trust-domain>/agent/<workload>/<instance>`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SpiffeId {
+    trust_domain: String,
+    workload_name: String,
+    instance: String,
+}
+
+impl SpiffeId {
+    /// Build a SPIFFE ID from components. Validates trust domain and segments.
+    pub fn new(trust_domain: &str, workload_name: &str, instance: &str) -> Result<Self> {
+        validate_trust_domain(trust_domain)?;
+        validate_segment(workload_name, "workload-name")?;
+        validate_segment(instance, "instance")?;
+        Ok(Self {
+            trust_domain: trust_domain.to_string(),
+            workload_name: workload_name.to_string(),
+            instance: instance.to_string(),
+        })
+    }
+
+    /// Parse a SPIFFE URI string. Strict: only the Aegis-shaped form is
+    /// accepted. Reject anything else so audit code never has to special-case.
+    pub fn parse(input: &str) -> Result<Self> {
+        let rest = input.strip_prefix(SCHEME).ok_or(Error::InvalidSpiffeId {
+            input: input.to_string(),
+            reason: "missing spiffe:// scheme",
+        })?;
+
+        let mut parts = rest.splitn(4, '/');
+        let trust_domain = parts.next().ok_or(Error::InvalidSpiffeId {
+            input: input.to_string(),
+            reason: "missing trust domain",
+        })?;
+        let agent_seg = parts.next().ok_or(Error::InvalidSpiffeId {
+            input: input.to_string(),
+            reason: "missing path",
+        })?;
+        let workload = parts.next().ok_or(Error::InvalidSpiffeId {
+            input: input.to_string(),
+            reason: "missing workload-name segment",
+        })?;
+        let instance = parts.next().ok_or(Error::InvalidSpiffeId {
+            input: input.to_string(),
+            reason: "missing instance segment",
+        })?;
+
+        if agent_seg != AGENT_SEGMENT {
+            return Err(Error::InvalidSpiffeId {
+                input: input.to_string(),
+                reason: "first path segment must be 'agent'",
+            });
+        }
+        if instance.contains('/') {
+            return Err(Error::InvalidSpiffeId {
+                input: input.to_string(),
+                reason: "trailing path segments not allowed",
+            });
+        }
+
+        Self::new(trust_domain, workload, instance)
+    }
+
+    pub fn trust_domain(&self) -> &str {
+        &self.trust_domain
+    }
+
+    pub fn workload_name(&self) -> &str {
+        &self.workload_name
+    }
+
+    pub fn instance(&self) -> &str {
+        &self.instance
+    }
+
+    /// Render the canonical URI form.
+    pub fn uri(&self) -> String {
+        format!(
+            "{}{}/{}/{}/{}",
+            SCHEME, self.trust_domain, AGENT_SEGMENT, self.workload_name, self.instance
+        )
+    }
+}
+
+impl fmt::Display for SpiffeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.uri())
+    }
+}
+
+fn validate_trust_domain(td: &str) -> Result<()> {
+    if td.is_empty() || td.len() > 255 {
+        return Err(Error::InvalidTrustDomain(td.to_string()));
+    }
+    let ok = td
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '-' | '_'));
+    if !ok {
+        return Err(Error::InvalidTrustDomain(td.to_string()));
+    }
+    Ok(())
+}
+
+fn validate_segment(seg: &str, _label: &'static str) -> Result<()> {
+    if seg.is_empty() || seg.len() > 63 {
+        return Err(Error::InvalidSpiffeId {
+            input: seg.to_string(),
+            reason: "path segment must be 1..=63 chars",
+        });
+    }
+    let ok = seg
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '~'));
+    if !ok {
+        return Err(Error::InvalidSpiffeId {
+            input: seg.to_string(),
+            reason: "path segment has disallowed character",
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_roundtrip() {
+        let s = "spiffe://aegis-node.local/agent/research/inst-001";
+        let id = SpiffeId::parse(s).unwrap();
+        assert_eq!(id.trust_domain(), "aegis-node.local");
+        assert_eq!(id.workload_name(), "research");
+        assert_eq!(id.instance(), "inst-001");
+        assert_eq!(id.uri(), s);
+    }
+
+    #[test]
+    fn parse_rejects_non_agent_path() {
+        let err = SpiffeId::parse("spiffe://td/svc/x/y").unwrap_err();
+        assert!(matches!(err, Error::InvalidSpiffeId { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_extra_segments() {
+        let err = SpiffeId::parse("spiffe://td/agent/wl/inst/extra").unwrap_err();
+        assert!(matches!(err, Error::InvalidSpiffeId { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_missing_scheme() {
+        let err = SpiffeId::parse("td/agent/wl/inst").unwrap_err();
+        assert!(matches!(err, Error::InvalidSpiffeId { .. }));
+    }
+
+    #[test]
+    fn rejects_uppercase_trust_domain() {
+        let err = SpiffeId::new("Aegis.Local", "wl", "i").unwrap_err();
+        assert!(matches!(err, Error::InvalidTrustDomain(_)));
+    }
+
+    #[test]
+    fn rejects_empty_segment() {
+        let err = SpiffeId::new("td", "", "i").unwrap_err();
+        assert!(matches!(err, Error::InvalidSpiffeId { .. }));
+    }
+}

--- a/crates/identity/src/svid.rs
+++ b/crates/identity/src/svid.rs
@@ -1,0 +1,92 @@
+//! X.509-SVID representation for issued workload identities.
+//!
+//! Per ADR-003 (F1) the SVID binds a SPIFFE ID to a SHA-256 digest triple
+//! `(model, manifest, config)`. The digest triple is carried in a single
+//! private custom X.509 extension; verifiers re-extract and compare it
+//! against live digests at every `CheckPermission`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::spiffe::SpiffeId;
+
+/// Aegis private digest-binding OID. **Placeholder** — slated for replacement
+/// once we register an OID under our enterprise arc; the Compatibility Charter
+/// freezes the *format* of this extension, not the OID, so changing it is a
+/// non-breaking on-disk change for unverified deployments.
+pub const DIGEST_BINDING_OID: &[u64] = &[1, 3, 6, 1, 4, 1, 99999, 1];
+
+/// Length of the digest-binding extension payload (model || manifest || config).
+pub const DIGEST_BINDING_LEN: usize = 32 * 3;
+
+/// SHA-256 digest of one bound artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Digest(pub [u8; 32]);
+
+impl Digest {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != 32 {
+            return Err(Error::InvalidDigestLength(bytes.len()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(bytes);
+        Ok(Self(arr))
+    }
+
+    pub fn from_hex(s: &str) -> Result<Self> {
+        let bytes = hex::decode(s).map_err(|_| Error::InvalidDigestLength(s.len() / 2))?;
+        Self::from_bytes(&bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub fn hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+/// Triple bound into every issued SVID. F1's "any digest changes → halt"
+/// invariant is enforced by comparing this triple to live digests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DigestTriple {
+    pub model: Digest,
+    pub manifest: Digest,
+    pub config: Digest,
+}
+
+impl DigestTriple {
+    /// Wire format inside the X.509 extension: model || manifest || config.
+    pub fn encode(&self) -> [u8; DIGEST_BINDING_LEN] {
+        let mut out = [0u8; DIGEST_BINDING_LEN];
+        out[..32].copy_from_slice(&self.model.0);
+        out[32..64].copy_from_slice(&self.manifest.0);
+        out[64..96].copy_from_slice(&self.config.0);
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != DIGEST_BINDING_LEN {
+            return Err(Error::InvalidDigestLength(bytes.len()));
+        }
+        let model = Digest::from_bytes(&bytes[..32])?;
+        let manifest = Digest::from_bytes(&bytes[32..64])?;
+        let config = Digest::from_bytes(&bytes[64..96])?;
+        Ok(Self {
+            model,
+            manifest,
+            config,
+        })
+    }
+}
+
+/// X.509-SVID issued by the local CA. Holds the leaf cert + private key as
+/// PEM strings; consumers deliver them to the runtime as a unit.
+#[derive(Debug, Clone)]
+pub struct X509Svid {
+    pub spiffe_id: SpiffeId,
+    pub digests: DigestTriple,
+    pub cert_pem: String,
+    pub key_pem: String,
+}

--- a/crates/identity/tests/integration.rs
+++ b/crates/identity/tests/integration.rs
@@ -1,0 +1,109 @@
+//! End-to-end tests for the local CA and X.509-SVID issuance.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use aegis_identity::{
+    extract_digest_triple_from_pem, extract_spiffe_id_from_pem, Digest, DigestTriple, Error,
+    LocalCa, SpiffeId,
+};
+
+const TRUST_DOMAIN: &str = "aegis-node.local";
+
+fn test_digests() -> DigestTriple {
+    DigestTriple {
+        model: Digest([0xAAu8; 32]),
+        manifest: Digest([0xBBu8; 32]),
+        config: Digest([0xCCu8; 32]),
+    }
+}
+
+#[test]
+fn init_then_load_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca = LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    assert_eq!(ca.trust_domain(), TRUST_DOMAIN);
+    drop(ca);
+
+    let loaded = LocalCa::load(dir.path()).unwrap();
+    assert_eq!(loaded.trust_domain(), TRUST_DOMAIN);
+}
+
+#[test]
+fn double_init_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    let err = LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap_err();
+    assert!(matches!(err, Error::CaAlreadyInitialized(_)));
+}
+
+#[test]
+fn load_uninitialized_dir_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = LocalCa::load(dir.path()).unwrap_err();
+    assert!(matches!(err, Error::CaNotInitialized(_)));
+}
+
+#[test]
+fn issued_svid_carries_spiffe_id_and_digests() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca = LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    let digests = test_digests();
+
+    let svid = ca.issue_svid("research", "inst-001", digests).unwrap();
+
+    let expected = SpiffeId::new(TRUST_DOMAIN, "research", "inst-001").unwrap();
+    assert_eq!(svid.spiffe_id, expected);
+
+    let parsed_id = extract_spiffe_id_from_pem(&svid.cert_pem).unwrap();
+    assert_eq!(parsed_id, expected);
+
+    let parsed_digests = extract_digest_triple_from_pem(&svid.cert_pem).unwrap();
+    assert_eq!(parsed_digests, digests);
+}
+
+#[test]
+fn separate_issuances_use_independent_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca = LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    let digests = test_digests();
+    let a = ca.issue_svid("research", "inst-001", digests).unwrap();
+    let b = ca.issue_svid("research", "inst-002", digests).unwrap();
+    assert_ne!(a.key_pem, b.key_pem);
+    assert_ne!(a.cert_pem, b.cert_pem);
+}
+
+#[test]
+fn loaded_ca_can_issue_svids() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    }
+    let ca = LocalCa::load(dir.path()).unwrap();
+    let svid = ca.issue_svid("research", "inst-load", test_digests()).unwrap();
+    let parsed = extract_spiffe_id_from_pem(&svid.cert_pem).unwrap();
+    assert_eq!(parsed.trust_domain(), TRUST_DOMAIN);
+    assert_eq!(parsed.workload_name(), "research");
+    assert_eq!(parsed.instance(), "inst-load");
+}
+
+#[test]
+fn rejects_invalid_workload_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca = LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    let err = ca
+        .issue_svid("bad workload", "inst-001", test_digests())
+        .unwrap_err();
+    assert!(matches!(err, Error::InvalidSpiffeId { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn ca_key_file_has_owner_only_permissions() {
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    let key_meta = std::fs::metadata(dir.path().join("ca.key")).unwrap();
+    let mode = key_meta.mode() & 0o777;
+    assert_eq!(mode, 0o600, "ca.key must be 0600 (got {mode:o})");
+}

--- a/crates/identity/tests/integration.rs
+++ b/crates/identity/tests/integration.rs
@@ -79,7 +79,9 @@ fn loaded_ca_can_issue_svids() {
         LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
     }
     let ca = LocalCa::load(dir.path()).unwrap();
-    let svid = ca.issue_svid("research", "inst-load", test_digests()).unwrap();
+    let svid = ca
+        .issue_svid("research", "inst-load", test_digests())
+        .unwrap();
     let parsed = extract_spiffe_id_from_pem(&svid.cert_pem).unwrap();
     assert_eq!(parsed.trust_domain(), TRUST_DOMAIN);
     assert_eq!(parsed.workload_name(), "research");


### PR DESCRIPTION
## Summary
- New `crates/identity`: strict SPIFFE ID parser, file-backed `LocalCa`, X.509-SVID issuance binding the `(model, manifest, config)` SHA-256 digest triple into a critical custom extension.
- New `crates/cli` exposing the `aegis` binary with `aegis identity init` and `aegis identity issue` subcommands.
- Implements F1 (ADR-003): closes the bulk of issue #2; Go FFI deferred to a follow-up since the Go control plane will shell out to the CLI in Phase 1a.

## Acceptance criteria mapping (issue #2)
- [x] CA is file-backed, single-tenant, lives under the user's config dir (`$XDG_CONFIG_HOME/aegis/identity` by default).
- [x] SPIFFE ID format `spiffe://<trust-domain>/agent/<workload-name>/<instance>` enforced strictly.
- [x] Issues X.509-SVIDs (URI SAN + critical digest-binding extension).
- [x] CLI: `aegis identity init` (one-time CA setup) and `aegis identity issue <workload-name>`.
- [x] Implementation in `crates/identity` (Rust).
- [ ] Go-callable surface — deferred to a follow-up. The Phase 1a Go control plane will shell out to `aegis identity issue`; in-process FFI lands when latency requirements demand it.

## Notes for reviewers
- **OID `1.3.6.1.4.1.99999.1`** for the digest binding is a placeholder under a private-enterprise-reserved-but-unallocated arc; the *format* (model‖manifest‖config, 96 bytes) is what the Compatibility Charter freezes, not the OID itself. Replacement happens before v1.0.0.
- **rcgen backend**: pinned to `ring` (no CMake/aws-lc-sys build dependency in CI).
- **Cert validity**: CA = 10y, leaf SVID = 24h. Rotation isn't wired yet — that arrives with issue #4 (digest-rebind on every CheckPermission).

## Test plan
- [ ] CI green on Rust workflow (fmt + clippy + test) — workspace picks up the new crates automatically.
- [ ] Integration tests cover: init/load round-trip, double-init refused, SVID carries expected SAN + digest triple, independent issuances → independent leaf keys, `ca.key` is `0600` on Unix.
- [ ] Manual: `cargo run -p aegis-cli -- identity init --trust-domain aegis-node.local --config-dir /tmp/aegis-id` → `cargo run -p aegis-cli -- identity issue research --instance inst-001 --model-digest <64hex> --manifest-digest <64hex> --config-digest <64hex> --config-dir /tmp/aegis-id` produces a parseable PEM.

Closes #2 once Go FFI follow-up is filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)