### PR TITLE
test(ledger-writer): pin golden root hash for issue #1

### DIFF
--- a/crates/ledger-writer/tests/integration.rs
+++ b/crates/ledger-writer/tests/integration.rs
@@ -167,7 +167,7 @@ fn fixture_root_matches_pinned_golden() {
     // verifier (issue #5 `aegis verify`) will disagree with this writer —
     // i.e. the chain semantics frozen by the Compatibility Charter changed.
     const GOLDEN_ROOT_HEX: &str =
-        "0000000000000000000000000000000000000000000000000000000000000000";
+        "a3c72aee194b645e524c76b492a11a9347dd393da83bb7792dc6ae8d32c7dba2";
     let root = run_fixture();
     let actual = hex::encode(root);
     assert_eq!(

--- a/crates/ledger-writer/tests/integration.rs
+++ b/crates/ledger-writer/tests/integration.rs
@@ -160,6 +160,22 @@ fn deterministic_with_fixed_uuids_and_timestamps() {
     assert_eq!(root_a, root_b);
 }
 
+#[test]
+fn fixture_root_matches_pinned_golden() {
+    // Golden fixture per issue #1 acceptance criteria: a known sequence of
+    // entries produces a known root hash. Drift here means a downstream
+    // verifier (issue #5 `aegis verify`) will disagree with this writer —
+    // i.e. the chain semantics frozen by the Compatibility Charter changed.
+    const GOLDEN_ROOT_HEX: &str =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+    let root = run_fixture();
+    let actual = hex::encode(root);
+    assert_eq!(
+        actual, GOLDEN_ROOT_HEX,
+        "fixture root drift: actual={actual}"
+    );
+}
+
 fn run_fixture() -> [u8; 32] {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("fixture.jsonl");


### PR DESCRIPTION
## Summary
Adds the golden-fixture conformance test required by issue #1's last acceptance criterion: a known sequence of entries produces a known root hash. Catches coordinated drift between the writer and a future verifier (#5).

This PR is **expected to fail** on first push — the placeholder hex is `0x00..00` so CI prints the actual root in the assert message. The next commit pins it.

## Test plan
- [ ] Read the actual hex from the failed `cargo fmt + clippy + test` job log.
- [ ] Push a follow-up commit replacing the placeholder.
- [ ] CI green → merge.

Refs #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)