### PR TITLE
feat(verify): aegis verify ledger CLI + verifier engine (issue #5)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,7 +16,9 @@ path = "src/main.rs"
 
 [dependencies]
 aegis-identity = { path = "../identity" }
+aegis-ledger-writer = { path = "../ledger-writer" }
 clap = { version = "4", features = ["derive"] }
+serde_json = "1"
 hex = "0.4"
 dirs = "5"
 anyhow = "1"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,21 +1,23 @@
 //! `aegis` — Aegis-Node command-line interface.
 //!
-//! Phase 1a ships the `identity` subcommand surface required by issue #2:
+//! Phase 1a ships:
 //!
 //! ```text
 //! aegis identity init   --trust-domain <td>
 //! aegis identity issue  <workload-name> --instance <i>
 //!                       --model-digest <hex> --manifest-digest <hex>
 //!                       --config-digest <hex>
+//! aegis verify          <ledger-path> [--format text|json]
 //! ```
 //!
-//! Future phases extend this with `aegis verify` (issue #5) and `aegis run`.
+//! Future phases extend this with `aegis run`, `aegis identity verify`, etc.
 
 use std::path::PathBuf;
 
 use aegis_identity::{Digest, DigestTriple, LocalCa};
+use aegis_ledger_writer::{verify_file, VerifyError};
 use anyhow::{Context, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Parser)]
 #[command(name = "aegis", version, about = "Aegis-Node CLI")]
@@ -31,6 +33,23 @@ enum Command {
         #[command(subcommand)]
         sub: IdentityCommand,
     },
+    /// Walk a Trajectory Ledger file and verify the SHA-256 hash chain (F9).
+    Verify(VerifyArgs),
+}
+
+#[derive(Debug, Args)]
+struct VerifyArgs {
+    /// Path to the .jsonl ledger file.
+    path: PathBuf,
+    /// Output format. `json` is intended for CI/CD consumption.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    format: OutputFormat,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    Text,
+    Json,
 }
 
 #[derive(Debug, Subcommand)]
@@ -85,6 +104,7 @@ fn main() -> Result<()> {
             IdentityCommand::Init(args) => cmd_init(args),
             IdentityCommand::Issue(args) => cmd_issue(args),
         },
+        Command::Verify(args) => cmd_verify(args),
     }
 }
 
@@ -141,4 +161,44 @@ fn resolve_identity_dir(override_dir: Option<PathBuf>) -> Result<PathBuf> {
 
 fn parse_digest_arg(name: &'static str, hex_str: &str) -> Result<Digest> {
     Digest::from_hex(hex_str).with_context(|| format!("--{name} must be a 64-char hex SHA-256"))
+}
+
+fn cmd_verify(args: VerifyArgs) -> Result<()> {
+    match verify_file(&args.path) {
+        Ok(summary) => {
+            match args.format {
+                OutputFormat::Text => {
+                    let session = summary.session_id.as_deref().unwrap_or("(empty)");
+                    let range = match (summary.first_timestamp, summary.last_timestamp) {
+                        (Some(a), Some(b)) => format!("{a}..{b}"),
+                        _ => "(no entries)".to_string(),
+                    };
+                    println!(
+                        "ledger ok: session={session} entries={} root={} time={range}",
+                        summary.entry_count, summary.root_hash_hex
+                    );
+                }
+                OutputFormat::Json => {
+                    let out = serde_json::json!({ "ok": true, "summary": summary });
+                    println!("{}", serde_json::to_string(&out)?);
+                }
+            }
+            Ok(())
+        }
+        Err(VerifyError::Break(brk)) => {
+            match args.format {
+                OutputFormat::Text => {
+                    eprintln!("ledger break: {brk:?}");
+                }
+                OutputFormat::Json => {
+                    let out = serde_json::json!({ "ok": false, "break": brk });
+                    println!("{}", serde_json::to_string(&out)?);
+                }
+            }
+            std::process::exit(1);
+        }
+        Err(VerifyError::Io(e)) => {
+            Err(e).with_context(|| format!("opening ledger file {}", args.path.display()))
+        }
+    }
 }

--- a/crates/ledger-writer/src/lib.rs
+++ b/crates/ledger-writer/src/lib.rs
@@ -29,7 +29,9 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 pub mod error;
+pub mod verify;
 pub use error::{Error, Result};
+pub use verify::{verify_file, verify_reader, VerifyBreak, VerifyError, VerifySummary};
 
 /// JSON-LD `@context` URI for v1 ledger entries.
 pub const LEDGER_CONTEXT: &str = "https://aegis-node.dev/schemas/ledger/v1";

--- a/crates/ledger-writer/src/verify.rs
+++ b/crates/ledger-writer/src/verify.rs
@@ -212,12 +212,10 @@ pub fn verify_reader<R: BufRead>(mut reader: R) -> Result<VerifySummary, VerifyE
 }
 
 fn required_str<'a>(v: &'a Value, field: &str, line: u64) -> Result<&'a str, VerifyError> {
-    v.get(field)
-        .and_then(|x| x.as_str())
-        .ok_or_else(|| {
-            VerifyError::Break(VerifyBreak::MissingField {
-                line,
-                field: field.to_string(),
-            })
+    v.get(field).and_then(|x| x.as_str()).ok_or_else(|| {
+        VerifyError::Break(VerifyBreak::MissingField {
+            line,
+            field: field.to_string(),
         })
+    })
 }

--- a/crates/ledger-writer/src/verify.rs
+++ b/crates/ledger-writer/src/verify.rs
@@ -1,0 +1,223 @@
+//! Trajectory Ledger verifier — the dual of the writer.
+//!
+//! Walks every line, recomputes `SHA-256(line[N])`, and checks that
+//! `line[N+1].prevHash == that hash` (genesis-zero anchors line 0). Also
+//! validates the v1 `@context`, monotonic sequence numbers, consistent
+//! `sessionId`, and parseable `timestamp` fields — i.e. the same invariants
+//! the writer holds when emitting.
+//!
+//! Used by the `aegis verify` CLI (issue #5) and by future runtime checks
+//! (e.g. F9 self-audit at session close before ledger root is published).
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::{hash_line, GENESIS_PREV_HASH, LEDGER_CONTEXT};
+
+/// Successful verification: chain intact, all entries well-formed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifySummary {
+    /// Session ID shared by every entry (None for an empty ledger).
+    pub session_id: Option<String>,
+    pub entry_count: u64,
+    /// Hex-encoded root hash (last entry's hash, or genesis if empty).
+    pub root_hash_hex: String,
+    pub first_timestamp: Option<DateTime<Utc>>,
+    pub last_timestamp: Option<DateTime<Utc>>,
+}
+
+/// Concrete reason the chain is broken. `line` is the 0-indexed line in
+/// the file at which the problem was first detected.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VerifyBreak {
+    InvalidJson {
+        line: u64,
+        error: String,
+    },
+    MissingField {
+        line: u64,
+        field: String,
+    },
+    BadContext {
+        line: u64,
+        got: String,
+    },
+    SequenceMismatch {
+        line: u64,
+        expected: u64,
+        got: u64,
+    },
+    PrevHashMismatch {
+        line: u64,
+        expected_hex: String,
+        got_hex: String,
+    },
+    SessionIdMismatch {
+        line: u64,
+        expected: String,
+        got: String,
+    },
+    BadTimestamp {
+        line: u64,
+        value: String,
+    },
+    BadHexField {
+        line: u64,
+        field: String,
+        value: String,
+    },
+}
+
+/// Top-level verify error: I/O failure (file unreadable) vs a chain break.
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("ledger break at line {}", break_line(.0))]
+    Break(VerifyBreak),
+}
+
+fn break_line(b: &VerifyBreak) -> u64 {
+    match b {
+        VerifyBreak::InvalidJson { line, .. }
+        | VerifyBreak::MissingField { line, .. }
+        | VerifyBreak::BadContext { line, .. }
+        | VerifyBreak::SequenceMismatch { line, .. }
+        | VerifyBreak::PrevHashMismatch { line, .. }
+        | VerifyBreak::SessionIdMismatch { line, .. }
+        | VerifyBreak::BadTimestamp { line, .. }
+        | VerifyBreak::BadHexField { line, .. } => *line,
+    }
+}
+
+/// Verify a ledger file. See [`verify_reader`] for invariants checked.
+pub fn verify_file<P: AsRef<Path>>(path: P) -> Result<VerifySummary, VerifyError> {
+    let f = File::open(path)?;
+    verify_reader(BufReader::new(f))
+}
+
+/// Verify a ledger from any [`BufRead`]. Streams line-by-line; suitable
+/// for very large ledgers without loading everything into memory.
+pub fn verify_reader<R: BufRead>(mut reader: R) -> Result<VerifySummary, VerifyError> {
+    let mut line_buf = String::new();
+    let mut prev_hash = GENESIS_PREV_HASH;
+    let mut next_seq: u64 = 0;
+    let mut session_id: Option<String> = None;
+    let mut first_ts: Option<DateTime<Utc>> = None;
+    let mut last_ts: Option<DateTime<Utc>> = None;
+
+    loop {
+        line_buf.clear();
+        let n = reader.read_line(&mut line_buf)?;
+        if n == 0 {
+            break;
+        }
+        let line_idx = next_seq;
+        // The writer writes `line + b"\n"`; the bytes that were hashed are
+        // exactly `line` (without the trailing LF).
+        let line = line_buf.strip_suffix('\n').unwrap_or(&line_buf);
+
+        let v: Value = serde_json::from_str(line).map_err(|e| {
+            VerifyError::Break(VerifyBreak::InvalidJson {
+                line: line_idx,
+                error: e.to_string(),
+            })
+        })?;
+
+        let ctx = required_str(&v, "@context", line_idx)?;
+        if ctx != LEDGER_CONTEXT {
+            return Err(VerifyError::Break(VerifyBreak::BadContext {
+                line: line_idx,
+                got: ctx.to_string(),
+            }));
+        }
+
+        let sid = required_str(&v, "sessionId", line_idx)?;
+        match &session_id {
+            None => session_id = Some(sid.to_string()),
+            Some(existing) if existing != sid => {
+                return Err(VerifyError::Break(VerifyBreak::SessionIdMismatch {
+                    line: line_idx,
+                    expected: existing.clone(),
+                    got: sid.to_string(),
+                }));
+            }
+            _ => {}
+        }
+
+        let seq = v
+            .get("sequenceNumber")
+            .and_then(|x| x.as_u64())
+            .ok_or_else(|| {
+                VerifyError::Break(VerifyBreak::MissingField {
+                    line: line_idx,
+                    field: "sequenceNumber".to_string(),
+                })
+            })?;
+        if seq != next_seq {
+            return Err(VerifyError::Break(VerifyBreak::SequenceMismatch {
+                line: line_idx,
+                expected: next_seq,
+                got: seq,
+            }));
+        }
+
+        let prev_hex = required_str(&v, "prevHash", line_idx)?;
+        let prev_bytes = hex::decode(prev_hex).map_err(|_| {
+            VerifyError::Break(VerifyBreak::BadHexField {
+                line: line_idx,
+                field: "prevHash".to_string(),
+                value: prev_hex.to_string(),
+            })
+        })?;
+        if prev_bytes.as_slice() != prev_hash {
+            return Err(VerifyError::Break(VerifyBreak::PrevHashMismatch {
+                line: line_idx,
+                expected_hex: hex::encode(prev_hash),
+                got_hex: prev_hex.to_string(),
+            }));
+        }
+
+        let ts_str = required_str(&v, "timestamp", line_idx)?;
+        let ts: DateTime<Utc> = ts_str.parse::<DateTime<Utc>>().map_err(|_| {
+            VerifyError::Break(VerifyBreak::BadTimestamp {
+                line: line_idx,
+                value: ts_str.to_string(),
+            })
+        })?;
+        if first_ts.is_none() {
+            first_ts = Some(ts);
+        }
+        last_ts = Some(ts);
+
+        prev_hash = hash_line(line.as_bytes());
+        next_seq = next_seq.saturating_add(1);
+    }
+
+    Ok(VerifySummary {
+        session_id,
+        entry_count: next_seq,
+        root_hash_hex: hex::encode(prev_hash),
+        first_timestamp: first_ts,
+        last_timestamp: last_ts,
+    })
+}
+
+fn required_str<'a>(v: &'a Value, field: &str, line: u64) -> Result<&'a str, VerifyError> {
+    v.get(field)
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| {
+            VerifyError::Break(VerifyBreak::MissingField {
+                line,
+                field: field.to_string(),
+            })
+        })
+}

--- a/crates/ledger-writer/tests/verify_integration.rs
+++ b/crates/ledger-writer/tests/verify_integration.rs
@@ -1,0 +1,184 @@
+//! End-to-end tests for the ledger verifier.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fs;
+use std::io::Write;
+
+use aegis_ledger_writer::{
+    verify_file, verify_reader, Entry, EntryType, LedgerWriter, VerifyBreak, VerifyError,
+    GENESIS_PREV_HASH,
+};
+use chrono::{TimeZone, Utc};
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+fn fixed_uuids() -> Box<dyn FnMut() -> Uuid + Send> {
+    let mut counter: u128 = 0;
+    Box::new(move || {
+        counter += 1;
+        let mut arr = counter.to_be_bytes();
+        arr[6] = (arr[6] & 0x0F) | 0x70;
+        arr[8] = (arr[8] & 0x3F) | 0x80;
+        Uuid::from_bytes(arr)
+    })
+}
+
+fn write_three_entries(path: &std::path::Path) -> [u8; 32] {
+    let mut writer = LedgerWriter::create_with_uuid_generator(
+        path,
+        "session-verify".to_string(),
+        fixed_uuids(),
+    )
+    .unwrap();
+    let ts = Utc.with_ymd_and_hms(2026, 4, 28, 0, 0, 0).unwrap();
+    let agent_hash = [0xAAu8; 32];
+    for i in 0..3u64 {
+        let mut p = Map::new();
+        p.insert("idx".to_string(), Value::Number(i.into()));
+        writer
+            .append(Entry {
+                session_id: "session-verify".to_string(),
+                entry_type: EntryType::SessionStart,
+                agent_identity_hash: agent_hash,
+                timestamp: ts,
+                payload: p,
+            })
+            .unwrap();
+    }
+    writer.close().unwrap()
+}
+
+#[test]
+fn verify_known_good_fixture() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("good.jsonl");
+    let root = write_three_entries(&path);
+
+    let summary = verify_file(&path).unwrap();
+    assert_eq!(summary.session_id.as_deref(), Some("session-verify"));
+    assert_eq!(summary.entry_count, 3);
+    assert_eq!(summary.root_hash_hex, hex::encode(root));
+    assert!(summary.first_timestamp.is_some());
+    assert!(summary.last_timestamp.is_some());
+}
+
+#[test]
+fn verify_empty_ledger() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.jsonl");
+    fs::write(&path, b"").unwrap();
+    let summary = verify_file(&path).unwrap();
+    assert_eq!(summary.entry_count, 0);
+    assert_eq!(summary.root_hash_hex, hex::encode(GENESIS_PREV_HASH));
+    assert!(summary.session_id.is_none());
+}
+
+#[test]
+fn detects_payload_tamper_at_next_line() {
+    // Tamper a byte in line 1's payload. The tamper changes SHA(line 1),
+    // so line 2's prev_hash check fails — that's the position the verifier
+    // reports (issue #5 acceptance criterion).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tampered.jsonl");
+    write_three_entries(&path);
+
+    let original = fs::read_to_string(&path).unwrap();
+    let mut lines: Vec<String> = original.lines().map(|s| s.to_string()).collect();
+    // Flip an "idx":1 to "idx":9 inside line 1's JSON.
+    lines[1] = lines[1].replacen("\"idx\":1", "\"idx\":9", 1);
+    let mut f = fs::File::create(&path).unwrap();
+    for line in &lines {
+        f.write_all(line.as_bytes()).unwrap();
+        f.write_all(b"\n").unwrap();
+    }
+    drop(f);
+
+    match verify_file(&path) {
+        Err(VerifyError::Break(VerifyBreak::PrevHashMismatch { line, .. })) => {
+            assert_eq!(line, 2, "tamper of line 1 must surface at line 2");
+        }
+        other => panic!("expected PrevHashMismatch at line 2, got {other:?}"),
+    }
+}
+
+#[test]
+fn detects_sequence_skip() {
+    // Hand-craft a single line whose sequenceNumber is wrong. We can't go
+    // through LedgerWriter to do this, since it always emits monotonic
+    // sequences — that's exactly the invariant we're testing.
+    let line = serde_json::json!({
+        "@context": "https://aegis-node.dev/schemas/ledger/v1",
+        "entryId": "00000000-0000-7000-8000-000000000001",
+        "sessionId": "s",
+        "sequenceNumber": 7u64,
+        "entryType": "session_start",
+        "timestamp": "2026-04-28T00:00:00.000000000Z",
+        "agentIdentityHash": "00".repeat(32),
+        "prevHash": hex::encode(GENESIS_PREV_HASH),
+    })
+    .to_string()
+        + "\n";
+
+    let err = verify_reader(line.as_bytes()).unwrap_err();
+    match err {
+        VerifyError::Break(VerifyBreak::SequenceMismatch { line, expected, got }) => {
+            assert_eq!(line, 0);
+            assert_eq!(expected, 0);
+            assert_eq!(got, 7);
+        }
+        other => panic!("expected SequenceMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn detects_bad_context() {
+    let line = serde_json::json!({
+        "@context": "https://example.com/wrong",
+        "entryId": "00000000-0000-7000-8000-000000000001",
+        "sessionId": "s",
+        "sequenceNumber": 0u64,
+        "entryType": "session_start",
+        "timestamp": "2026-04-28T00:00:00.000000000Z",
+        "agentIdentityHash": "00".repeat(32),
+        "prevHash": hex::encode(GENESIS_PREV_HASH),
+    })
+    .to_string()
+        + "\n";
+    let err = verify_reader(line.as_bytes()).unwrap_err();
+    assert!(matches!(err, VerifyError::Break(VerifyBreak::BadContext { line: 0, .. })));
+}
+
+#[test]
+fn detects_invalid_json() {
+    let bytes = b"{not valid json}\n";
+    let err = verify_reader(&bytes[..]).unwrap_err();
+    assert!(matches!(err, VerifyError::Break(VerifyBreak::InvalidJson { line: 0, .. })));
+}
+
+#[test]
+fn last_entry_tamper_changes_root_only() {
+    // Note: tampering the *last* entry changes its hash but there's no
+    // line N+1 to expose the chain break — detection requires comparing
+    // to a known-pinned root (out of scope for `aegis verify`'s self-check).
+    // This test documents that behavior: verify still returns Ok, just
+    // with a different root_hash_hex than the original.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("last.jsonl");
+    let original_root = write_three_entries(&path);
+
+    let original = fs::read_to_string(&path).unwrap();
+    let mut lines: Vec<String> = original.lines().map(|s| s.to_string()).collect();
+    let last_idx = lines.len() - 1;
+    lines[last_idx] = lines[last_idx].replacen("\"idx\":2", "\"idx\":99", 1);
+    let mut f = fs::File::create(&path).unwrap();
+    for line in &lines {
+        f.write_all(line.as_bytes()).unwrap();
+        f.write_all(b"\n").unwrap();
+    }
+    drop(f);
+
+    let summary = verify_file(&path).unwrap();
+    assert_eq!(summary.entry_count, 3);
+    assert_ne!(summary.root_hash_hex, hex::encode(original_root));
+}

--- a/crates/ledger-writer/tests/verify_integration.rs
+++ b/crates/ledger-writer/tests/verify_integration.rs
@@ -25,12 +25,9 @@ fn fixed_uuids() -> Box<dyn FnMut() -> Uuid + Send> {
 }
 
 fn write_three_entries(path: &std::path::Path) -> [u8; 32] {
-    let mut writer = LedgerWriter::create_with_uuid_generator(
-        path,
-        "session-verify".to_string(),
-        fixed_uuids(),
-    )
-    .unwrap();
+    let mut writer =
+        LedgerWriter::create_with_uuid_generator(path, "session-verify".to_string(), fixed_uuids())
+            .unwrap();
     let ts = Utc.with_ymd_and_hms(2026, 4, 28, 0, 0, 0).unwrap();
     let agent_hash = [0xAAu8; 32];
     for i in 0..3u64 {
@@ -122,7 +119,11 @@ fn detects_sequence_skip() {
 
     let err = verify_reader(line.as_bytes()).unwrap_err();
     match err {
-        VerifyError::Break(VerifyBreak::SequenceMismatch { line, expected, got }) => {
+        VerifyError::Break(VerifyBreak::SequenceMismatch {
+            line,
+            expected,
+            got,
+        }) => {
             assert_eq!(line, 0);
             assert_eq!(expected, 0);
             assert_eq!(got, 7);
@@ -146,14 +147,20 @@ fn detects_bad_context() {
     .to_string()
         + "\n";
     let err = verify_reader(line.as_bytes()).unwrap_err();
-    assert!(matches!(err, VerifyError::Break(VerifyBreak::BadContext { line: 0, .. })));
+    assert!(matches!(
+        err,
+        VerifyError::Break(VerifyBreak::BadContext { line: 0, .. })
+    ));
 }
 
 #[test]
 fn detects_invalid_json() {
     let bytes = b"{not valid json}\n";
     let err = verify_reader(&bytes[..]).unwrap_err();
-    assert!(matches!(err, VerifyError::Break(VerifyBreak::InvalidJson { line: 0, .. })));
+    assert!(matches!(
+        err,
+        VerifyError::Break(VerifyBreak::InvalidJson { line: 0, .. })
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- New \`verify\` module in \`crates/ledger-writer\`: streaming chain walker that returns \`VerifySummary\` or a typed \`VerifyBreak\`.
- New \`aegis verify <path> [--format text|json]\` CLI subcommand. Exit 0 on ok, 1 on break.
- Integration tests prove the tamper-detection acceptance criterion from issue #5.

## Acceptance criteria mapping (issue #5)
- [x] \`aegis verify <path>\` reads the ledger and walks every \`prev_hash\` link.
- [x] On success: prints summary (entry count, root hash, time range), exit 0.
- [x] On break: prints the position and expected vs actual hash, exit 1.
- [x] JSON output mode \`--format json\` for machine consumption.
- [x] Integration test: tamper one entry's content → verify reports the break at exactly that position.

## Why \`verify\` lives in \`ledger-writer\`
Verifier and writer share the chain-semantics invariants frozen by the Compatibility Charter (genesis-zero, \`SHA-256(line)\` chain, JCS canonicalization, v1 \`@context\`). Co-locating them means a future change to canonicalization can't drift between the two — both compile against the same constants and helpers.

## Tamper-detection note
Tampering the *last* entry changes the root hash but not any chain link a self-verifier can check (no line N+1 exists). One test documents this: \`verify\` returns Ok with a different \`root_hash_hex\`. Detection of last-entry tamper requires comparing to an externally-pinned root — that's the auditor's job, not \`aegis verify\`'s self-check.

## Test plan
- [ ] CI green on Rust workflow (fmt + clippy + test).
- [ ] Tests cover: known-good fixture, empty ledger → genesis root, mid-chain payload tamper → \`PrevHashMismatch\` at next line, sequence skip, bad \`@context\`, invalid JSON, last-entry tamper changes root only.

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)