### PR TITLE
feat(policy, network-gate): F2 decision engine + outbound TCP gate (issue #7 partial)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/identity",
     "crates/cli",
     "crates/access-log",
+    "crates/policy",
 ]
 
 [workspace.package]

--- a/crates/network-gate/Cargo.toml
+++ b/crates/network-gate/Cargo.toml
@@ -11,3 +11,5 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aegis-policy = { path = "../policy" }
+thiserror = "1"

--- a/crates/network-gate/src/lib.rs
+++ b/crates/network-gate/src/lib.rs
@@ -1,3 +1,68 @@
 //! Aegis-Node network gate.
 //!
-//! Runtime-level network-deny enforcement per ADR-008 (F6). Phase 0 scaffold.
+//! Runtime-level network-deny enforcement per ADR-008 (F6) and ADR-004 (F2).
+//! This crate provides thin wrappers around `std::net` that consult a
+//! [`aegis_policy::Policy`] before allowing a connect/bind. Code that uses
+//! [`AegisTcpStream::connect`] (and future [`AegisTcpListener`], etc.) gets
+//! deny-by-default network behavior; code that calls `std::net` directly is
+//! out of scope — sandbox layers (issue #7's filesystem follow-up + future
+//! seccomp hardening) are what stop bypass attempts.
+//!
+//! Phase 1a wraps only outbound TCP connect. Inbound listeners, UDP, and
+//! exec gating land with the rest of the F2 enforcer.
+
+use std::net::{TcpStream, ToSocketAddrs};
+
+use aegis_policy::{Decision, NetworkProto, Policy};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("network policy denied: {reason}")]
+    Denied { reason: String },
+
+    #[error("network policy requires approval: {reason}")]
+    RequireApproval { reason: String },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Outbound TCP gate. Constructed with a borrowed [`Policy`]; the policy
+/// stays alive for as long as the gate handle does.
+pub struct AegisTcpStream;
+
+impl AegisTcpStream {
+    /// Policy-checked drop-in replacement for `TcpStream::connect`.
+    /// `proto` lets the caller declare semantic intent (HTTPS vs plain
+    /// TCP) so the manifest's allowlist can match by protocol.
+    pub fn connect(
+        policy: &Policy,
+        host: &str,
+        port: u16,
+        proto: NetworkProto,
+    ) -> Result<TcpStream> {
+        match policy.check_network_outbound(host, port, proto) {
+            Decision::Allow => {}
+            Decision::Deny { reason } => return Err(Error::Denied { reason }),
+            Decision::RequireApproval { reason } => {
+                return Err(Error::RequireApproval { reason })
+            }
+        }
+
+        let addr = (host, port);
+        let stream = addr
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("could not resolve {host}:{port}"),
+                )
+            })
+            .and_then(TcpStream::connect)?;
+        Ok(stream)
+    }
+}

--- a/crates/network-gate/src/lib.rs
+++ b/crates/network-gate/src/lib.rs
@@ -47,9 +47,7 @@ impl AegisTcpStream {
         match policy.check_network_outbound(host, port, proto) {
             Decision::Allow => {}
             Decision::Deny { reason } => return Err(Error::Denied { reason }),
-            Decision::RequireApproval { reason } => {
-                return Err(Error::RequireApproval { reason })
-            }
+            Decision::RequireApproval { reason } => return Err(Error::RequireApproval { reason }),
         }
 
         let addr = (host, port);

--- a/crates/network-gate/tests/integration.rs
+++ b/crates/network-gate/tests/integration.rs
@@ -1,0 +1,83 @@
+//! End-to-end tests for the AegisTcpStream wrapper.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+use aegis_network_gate::{AegisTcpStream, Error};
+use aegis_policy::{NetworkProto, Policy};
+
+fn policy_with_outbound(yaml_outbound: &str) -> Policy {
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "x", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://td/agent/x/1" }}
+tools:
+  network:
+    outbound: {yaml_outbound}
+"#
+    );
+    Policy::from_yaml_bytes(yaml.as_bytes()).unwrap()
+}
+
+#[test]
+fn deny_mode_blocks_connect() {
+    let p = policy_with_outbound("deny");
+    let err = AegisTcpStream::connect(&p, "127.0.0.1", 1, NetworkProto::Tcp).unwrap_err();
+    assert!(matches!(err, Error::Denied { .. }));
+}
+
+#[test]
+fn missing_network_section_blocks_connect() {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools: {}
+"#;
+    let p = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap();
+    let err = AegisTcpStream::connect(&p, "127.0.0.1", 1, NetworkProto::Tcp).unwrap_err();
+    assert!(matches!(err, Error::Denied { .. }));
+}
+
+#[test]
+fn allowlist_match_permits_connect() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = thread::spawn(move || {
+        let (mut s, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 4];
+        let _ = s.read(&mut buf);
+        s.write_all(b"ok\n").unwrap();
+    });
+
+    let outbound = format!(
+        r#"
+      allowlist:
+        - host: "127.0.0.1"
+          port: {port}
+          protocol: "tcp""#
+    );
+    let p = policy_with_outbound(&outbound);
+    let mut stream = AegisTcpStream::connect(&p, "127.0.0.1", port, NetworkProto::Tcp).unwrap();
+    stream.write_all(b"ping").unwrap();
+    let mut resp = [0u8; 3];
+    stream.read_exact(&mut resp).unwrap();
+    assert_eq!(&resp, b"ok\n");
+
+    server.join().unwrap();
+}
+
+#[test]
+fn allowlist_miss_blocks_connect() {
+    let outbound = r#"
+      allowlist:
+        - host: "127.0.0.1"
+          port: 65000
+          protocol: "tcp""#;
+    let p = policy_with_outbound(outbound);
+    // Different port than the allowlist entry.
+    let err = AegisTcpStream::connect(&p, "127.0.0.1", 1, NetworkProto::Tcp).unwrap_err();
+    assert!(matches!(err, Error::Denied { .. }));
+}

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aegis-policy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+aegis-ledger-writer = { path = "../ledger-writer" }
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
+thiserror = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/policy/src/decision.rs
+++ b/crates/policy/src/decision.rs
@@ -1,0 +1,53 @@
+//! Decision: the answer to a single permission check.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of a [`crate::Policy`] check. Allow lets the operation proceed;
+/// Deny halts and (in the runtime) emits an `EntryType::Violation`;
+/// RequireApproval routes through the F3 Human Approval Gate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "decision", rename_all = "snake_case")]
+pub enum Decision {
+    Allow,
+    Deny { reason: String },
+    RequireApproval { reason: String },
+}
+
+impl Decision {
+    pub fn is_allow(&self) -> bool {
+        matches!(self, Decision::Allow)
+    }
+
+    pub fn is_deny(&self) -> bool {
+        matches!(self, Decision::Deny { .. })
+    }
+
+    pub fn is_approval(&self) -> bool {
+        matches!(self, Decision::RequireApproval { .. })
+    }
+
+    pub fn deny<S: Into<String>>(reason: S) -> Self {
+        Decision::Deny {
+            reason: reason.into(),
+        }
+    }
+
+    pub fn approval<S: Into<String>>(reason: S) -> Self {
+        Decision::RequireApproval {
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Network protocol kind, used by [`crate::Policy::check_network_outbound`].
+/// Mirrors the schema's `networkPolicy.allowlist[].protocol` enum plus
+/// "any" for callers that don't yet know the wire protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkProto {
+    Http,
+    Https,
+    Tcp,
+    Udp,
+    Any,
+}

--- a/crates/policy/src/error.rs
+++ b/crates/policy/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("yaml: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    #[error("ledger: {0}")]
+    Ledger(#[from] aegis_ledger_writer::Error),
+
+    #[error("serialization: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    #[error("manifest does not support extends: in Phase 1a (got {0} parents)")]
+    ExtendsUnsupported(usize),
+}

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -1,0 +1,27 @@
+//! Aegis-Node manifest enforcement engine (F2 per ADR-004 + ADR-008 + ADR-009).
+//!
+//! Compiles a parsed Permission Manifest into a [`Policy`] that answers
+//! `Allow / Deny / RequireApproval` for each I/O attempt the runtime
+//! mediates. Closed-by-default: the manifest must affirmatively grant an
+//! operation; silence is denial.
+//!
+//! Phase 1a accepts single-file manifests (no `extends:` resolution). The
+//! Go validator (`pkg/manifest`) owns extends and narrowing checks; the
+//! resolved manifest is what should reach this engine. Once the control
+//! plane lands, `Policy::from_resolved_json` will be the canonical entry
+//! point and the YAML loader becomes a CLI/dev convenience.
+
+pub mod decision;
+pub mod error;
+pub mod manifest;
+mod policy;
+mod violation;
+
+pub use decision::{Decision, NetworkProto};
+pub use error::{Error, Result};
+pub use manifest::{
+    Agent, ApiGrant, ApprovalClass, Filesystem, Identity, Manifest, Network, NetworkAllowEntry,
+    NetworkMode, NetworkPolicy, NetworkProtocol, Tools, WriteAction, WriteGrant,
+};
+pub use policy::Policy;
+pub use violation::{emit_violation, ViolationEvent};

--- a/crates/policy/src/manifest.rs
+++ b/crates/policy/src/manifest.rs
@@ -76,9 +76,7 @@ pub struct Network {
 #[serde(untagged)]
 pub enum NetworkPolicy {
     Mode(NetworkMode),
-    Allowlist {
-        allowlist: Vec<NetworkAllowEntry>,
-    },
+    Allowlist { allowlist: Vec<NetworkAllowEntry> },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/policy/src/manifest.rs
+++ b/crates/policy/src/manifest.rs
@@ -1,0 +1,147 @@
+//! Rust mirror of the Permission Manifest schema (v1).
+//!
+//! Single source of truth for the schema lives at
+//! `schemas/manifest/v1/manifest.schema.json` and is enforced by the Go
+//! validator (`pkg/manifest`). This module deserializes the same shape on
+//! the Rust side so the runtime can compile a [`crate::Policy`] from disk.
+//!
+//! Phase 1a parses single-file manifests (no `extends:` resolution). Once
+//! the control plane lands, the resolved manifest will arrive as JSON over
+//! the gRPC channel and this module's loader becomes a fallback for local
+//! dev/CLI use.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    pub agent: Agent,
+    pub identity: Identity,
+    #[serde(default)]
+    pub extends: Vec<String>,
+    pub tools: Tools,
+    #[serde(default, rename = "write_grants")]
+    pub write_grants: Vec<WriteGrant>,
+    #[serde(default, rename = "approval_required_for")]
+    pub approval_required_for: Vec<ApprovalClass>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Agent {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Identity {
+    #[serde(rename = "spiffeId")]
+    pub spiffe_id: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Tools {
+    #[serde(default)]
+    pub filesystem: Option<Filesystem>,
+    #[serde(default)]
+    pub network: Option<Network>,
+    #[serde(default)]
+    pub apis: Vec<ApiGrant>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Filesystem {
+    #[serde(default)]
+    pub read: Vec<String>,
+    #[serde(default)]
+    pub write: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Network {
+    #[serde(default)]
+    pub outbound: Option<NetworkPolicy>,
+    #[serde(default)]
+    pub inbound: Option<NetworkPolicy>,
+}
+
+/// `oneOf {string, object}` from the schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NetworkPolicy {
+    Mode(NetworkMode),
+    Allowlist {
+        allowlist: Vec<NetworkAllowEntry>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkMode {
+    Deny,
+    Allow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkAllowEntry {
+    pub host: String,
+    #[serde(default)]
+    pub port: Option<u16>,
+    #[serde(default)]
+    pub protocol: Option<NetworkProtocol>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkProtocol {
+    Http,
+    Https,
+    Tcp,
+    Udp,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApiGrant {
+    pub name: String,
+    #[serde(default)]
+    pub methods: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WriteGrant {
+    pub resource: String,
+    pub actions: Vec<WriteAction>,
+    #[serde(default)]
+    pub duration: Option<String>,
+    #[serde(default, rename = "expires_at")]
+    pub expires_at: Option<String>,
+    #[serde(default, rename = "approval_required")]
+    pub approval_required: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteAction {
+    Write,
+    Delete,
+    Update,
+    Create,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalClass {
+    AnyWrite,
+    AnyDelete,
+    AnyNetworkOutbound,
+    AnyExec,
+}

--- a/crates/policy/src/policy.rs
+++ b/crates/policy/src/policy.rs
@@ -125,12 +125,7 @@ impl Policy {
         )
     }
 
-    pub fn check_network_inbound(
-        &self,
-        host: &str,
-        port: u16,
-        protocol: NetworkProto,
-    ) -> Decision {
+    pub fn check_network_inbound(&self, host: &str, port: u16, protocol: NetworkProto) -> Decision {
         let policy = self
             .manifest
             .tools
@@ -153,9 +148,10 @@ impl Policy {
 
     fn find_write_grant(&self, path: &Path, want: WriteAction) -> Option<&WriteGrant> {
         let p = path.to_string_lossy();
-        self.manifest.write_grants.iter().find(|g| {
-            g.resource == p && g.actions.iter().any(|a| *a == want)
-        })
+        self.manifest
+            .write_grants
+            .iter()
+            .find(|g| g.resource == p && g.actions.iter().any(|a| *a == want))
     }
 
     fn write_decision(&self, path: &Path, g: &WriteGrant, action: WriteAction) -> Decision {
@@ -164,7 +160,11 @@ impl Policy {
             _ => ApprovalClass::AnyWrite,
         };
         if g.approval_required
-            || self.manifest.approval_required_for.iter().any(|c| *c == class)
+            || self
+                .manifest
+                .approval_required_for
+                .iter()
+                .any(|c| *c == class)
         {
             return Decision::approval(format!(
                 "{:?} on {} requires approval per write_grant",
@@ -175,15 +175,14 @@ impl Policy {
         Decision::Allow
     }
 
-    fn upgrade_for_approval(
-        &self,
-        base: Decision,
-        class: ApprovalClass,
-        reason: &str,
-    ) -> Decision {
+    fn upgrade_for_approval(&self, base: Decision, class: ApprovalClass, reason: &str) -> Decision {
         match base {
             Decision::Allow
-                if self.manifest.approval_required_for.iter().any(|c| *c == class) =>
+                if self
+                    .manifest
+                    .approval_required_for
+                    .iter()
+                    .any(|c| *c == class) =>
             {
                 Decision::approval(reason)
             }
@@ -228,9 +227,9 @@ fn network_decision(
     };
     match policy {
         NetworkPolicy::Mode(NetworkMode::Allow) => Decision::Allow,
-        NetworkPolicy::Mode(NetworkMode::Deny) => Decision::deny(format!(
-            "network {direction} denied: manifest sets deny"
-        )),
+        NetworkPolicy::Mode(NetworkMode::Deny) => {
+            Decision::deny(format!("network {direction} denied: manifest sets deny"))
+        }
         NetworkPolicy::Allowlist { allowlist } => {
             if allowlist
                 .iter()

--- a/crates/policy/src/policy.rs
+++ b/crates/policy/src/policy.rs
@@ -151,7 +151,7 @@ impl Policy {
         self.manifest
             .write_grants
             .iter()
-            .find(|g| g.resource == p && g.actions.iter().any(|a| *a == want))
+            .find(|g| g.resource == p && g.actions.contains(&want))
     }
 
     fn write_decision(&self, path: &Path, g: &WriteGrant, action: WriteAction) -> Decision {
@@ -159,13 +159,7 @@ impl Policy {
             WriteAction::Delete => ApprovalClass::AnyDelete,
             _ => ApprovalClass::AnyWrite,
         };
-        if g.approval_required
-            || self
-                .manifest
-                .approval_required_for
-                .iter()
-                .any(|c| *c == class)
-        {
+        if g.approval_required || self.manifest.approval_required_for.contains(&class) {
             return Decision::approval(format!(
                 "{:?} on {} requires approval per write_grant",
                 action,
@@ -177,13 +171,7 @@ impl Policy {
 
     fn upgrade_for_approval(&self, base: Decision, class: ApprovalClass, reason: &str) -> Decision {
         match base {
-            Decision::Allow
-                if self
-                    .manifest
-                    .approval_required_for
-                    .iter()
-                    .any(|c| *c == class) =>
-            {
+            Decision::Allow if self.manifest.approval_required_for.contains(&class) => {
                 Decision::approval(reason)
             }
             other => other,

--- a/crates/policy/src/policy.rs
+++ b/crates/policy/src/policy.rs
@@ -1,0 +1,283 @@
+//! Compiled enforcement state — answers `Allow / Deny / RequireApproval` for
+//! a single I/O attempt without re-parsing the manifest each time.
+
+use std::path::Path;
+
+use crate::decision::{Decision, NetworkProto};
+use crate::error::{Error, Result};
+use crate::manifest::{
+    ApprovalClass, Manifest, NetworkAllowEntry, NetworkMode, NetworkPolicy, NetworkProtocol,
+    WriteAction, WriteGrant,
+};
+
+/// Closed-by-default policy engine. All `check_*` methods return `Deny`
+/// when the manifest is silent — never inferred. Approval-class membership
+/// upgrades an Allow to a RequireApproval.
+#[derive(Debug, Clone)]
+pub struct Policy {
+    manifest: Manifest,
+}
+
+impl Policy {
+    /// Load + parse a manifest YAML from disk. Refuses manifests that use
+    /// `extends:` — Phase 1a expects pre-resolved input. Run the resolution
+    /// in Go (`pkg/manifest`) and pass the resolved form here.
+    pub fn from_yaml_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let bytes = std::fs::read(path)?;
+        Self::from_yaml_bytes(&bytes)
+    }
+
+    pub fn from_yaml_bytes(bytes: &[u8]) -> Result<Self> {
+        let manifest: Manifest = serde_yaml::from_slice(bytes)?;
+        if !manifest.extends.is_empty() {
+            return Err(Error::ExtendsUnsupported(manifest.extends.len()));
+        }
+        Ok(Self { manifest })
+    }
+
+    pub fn from_manifest(manifest: Manifest) -> Self {
+        Self { manifest }
+    }
+
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    /// Filesystem read: closed-by-default, allowed iff path is at-or-under
+    /// some `tools.filesystem.read` entry.
+    pub fn check_filesystem_read(&self, path: &Path) -> Decision {
+        let allowed = self
+            .manifest
+            .tools
+            .filesystem
+            .as_ref()
+            .map(|f| paths_cover(path, &f.read))
+            .unwrap_or(false);
+        if !allowed {
+            return Decision::deny(format!(
+                "filesystem read of {} not granted by manifest",
+                path.display()
+            ));
+        }
+        Decision::Allow
+    }
+
+    /// Filesystem write: closed-by-default. Allowed iff a matching write
+    /// grant exists OR `tools.filesystem.write` covers the path. If the
+    /// grant requires approval, returns `RequireApproval`; if the manifest
+    /// also lists `any_write` in `approval_required_for`, same result.
+    pub fn check_filesystem_write(&self, path: &Path) -> Decision {
+        if let Some(g) = self.find_write_grant(path, WriteAction::Write) {
+            return self.write_decision(path, g, WriteAction::Write);
+        }
+        let covered = self
+            .manifest
+            .tools
+            .filesystem
+            .as_ref()
+            .map(|f| paths_cover(path, &f.write))
+            .unwrap_or(false);
+        if covered {
+            return self.upgrade_for_approval(
+                Decision::Allow,
+                ApprovalClass::AnyWrite,
+                "any_write requires approval",
+            );
+        }
+        Decision::deny(format!(
+            "filesystem write of {} not granted by manifest",
+            path.display()
+        ))
+    }
+
+    /// Filesystem delete: only allowed via a write grant whose `actions`
+    /// includes `delete`. `approval_required_for: [any_delete]` upgrades.
+    pub fn check_filesystem_delete(&self, path: &Path) -> Decision {
+        if let Some(g) = self.find_write_grant(path, WriteAction::Delete) {
+            return self.write_decision(path, g, WriteAction::Delete);
+        }
+        Decision::deny(format!(
+            "filesystem delete of {} not granted by any write_grant",
+            path.display()
+        ))
+    }
+
+    /// Network outbound: closed-by-default. Per ADR-008 the absence of a
+    /// network policy means deny. `any_network_outbound` upgrades to
+    /// approval.
+    pub fn check_network_outbound(
+        &self,
+        host: &str,
+        port: u16,
+        protocol: NetworkProto,
+    ) -> Decision {
+        let policy = self
+            .manifest
+            .tools
+            .network
+            .as_ref()
+            .and_then(|n| n.outbound.as_ref());
+        let base = network_decision(policy, host, port, protocol, "outbound");
+        self.upgrade_for_approval(
+            base,
+            ApprovalClass::AnyNetworkOutbound,
+            "any_network_outbound requires approval",
+        )
+    }
+
+    pub fn check_network_inbound(
+        &self,
+        host: &str,
+        port: u16,
+        protocol: NetworkProto,
+    ) -> Decision {
+        let policy = self
+            .manifest
+            .tools
+            .network
+            .as_ref()
+            .and_then(|n| n.inbound.as_ref());
+        network_decision(policy, host, port, protocol, "inbound")
+    }
+
+    /// Exec: v1 schema has no exec-grant primitive. Always denied. A future
+    /// schema version will introduce explicit exec grants — this method
+    /// will gain a corresponding manifest lookup at that point.
+    pub fn check_exec(&self, program: &Path) -> Decision {
+        let _ = program;
+        Decision::deny(
+            "exec is not grantable in manifest schema v1; future schema will add exec_grants"
+                .to_string(),
+        )
+    }
+
+    fn find_write_grant(&self, path: &Path, want: WriteAction) -> Option<&WriteGrant> {
+        let p = path.to_string_lossy();
+        self.manifest.write_grants.iter().find(|g| {
+            g.resource == p && g.actions.iter().any(|a| *a == want)
+        })
+    }
+
+    fn write_decision(&self, path: &Path, g: &WriteGrant, action: WriteAction) -> Decision {
+        let class = match action {
+            WriteAction::Delete => ApprovalClass::AnyDelete,
+            _ => ApprovalClass::AnyWrite,
+        };
+        if g.approval_required
+            || self.manifest.approval_required_for.iter().any(|c| *c == class)
+        {
+            return Decision::approval(format!(
+                "{:?} on {} requires approval per write_grant",
+                action,
+                path.display()
+            ));
+        }
+        Decision::Allow
+    }
+
+    fn upgrade_for_approval(
+        &self,
+        base: Decision,
+        class: ApprovalClass,
+        reason: &str,
+    ) -> Decision {
+        match base {
+            Decision::Allow
+                if self.manifest.approval_required_for.iter().any(|c| *c == class) =>
+            {
+                Decision::approval(reason)
+            }
+            other => other,
+        }
+    }
+}
+
+/// Returns true if `path` is at-or-under any of `parents`. "/data" covers
+/// "/data/x" and "/data" itself but not "/data2".
+fn paths_cover(path: &Path, parents: &[String]) -> bool {
+    let p = path.to_string_lossy();
+    for parent in parents {
+        if parent == p.as_ref() {
+            return true;
+        }
+        if parent == "/" {
+            return true;
+        }
+        let with_slash = format!("{parent}/");
+        if p.starts_with(&with_slash) {
+            return true;
+        }
+    }
+    false
+}
+
+fn network_decision(
+    policy: Option<&NetworkPolicy>,
+    host: &str,
+    port: u16,
+    protocol: NetworkProto,
+    direction: &str,
+) -> Decision {
+    let policy = match policy {
+        Some(p) => p,
+        None => {
+            return Decision::deny(format!(
+                "network {direction} denied: manifest has no policy"
+            ));
+        }
+    };
+    match policy {
+        NetworkPolicy::Mode(NetworkMode::Allow) => Decision::Allow,
+        NetworkPolicy::Mode(NetworkMode::Deny) => Decision::deny(format!(
+            "network {direction} denied: manifest sets deny"
+        )),
+        NetworkPolicy::Allowlist { allowlist } => {
+            if allowlist
+                .iter()
+                .any(|e| matches_allow_entry(e, host, port, protocol))
+            {
+                Decision::Allow
+            } else {
+                Decision::deny(format!(
+                    "network {direction} {host}:{port} not in manifest allowlist"
+                ))
+            }
+        }
+    }
+}
+
+fn matches_allow_entry(
+    e: &NetworkAllowEntry,
+    host: &str,
+    port: u16,
+    protocol: NetworkProto,
+) -> bool {
+    if e.host != host {
+        return false;
+    }
+    if let Some(p) = e.port {
+        if p != port {
+            return false;
+        }
+    }
+    if let Some(proto) = e.protocol {
+        if !proto_compatible(proto, protocol) {
+            return false;
+        }
+    }
+    true
+}
+
+fn proto_compatible(allowed: NetworkProtocol, actual: NetworkProto) -> bool {
+    match (allowed, actual) {
+        (_, NetworkProto::Any) => true,
+        (NetworkProtocol::Http, NetworkProto::Http) => true,
+        (NetworkProtocol::Https, NetworkProto::Https) => true,
+        (NetworkProtocol::Tcp, NetworkProto::Tcp) => true,
+        (NetworkProtocol::Udp, NetworkProto::Udp) => true,
+        // HTTP/HTTPS are TCP under the hood; an allowlist entry that says
+        // "https" should not match a callsite that says "tcp" because the
+        // semantic intent differs.
+        _ => false,
+    }
+}

--- a/crates/policy/src/violation.rs
+++ b/crates/policy/src/violation.rs
@@ -62,10 +62,7 @@ pub fn emit_violation(
     event: ViolationEvent,
 ) -> Result<EntryRecord> {
     let mut payload = Map::new();
-    payload.insert(
-        "violationReason".to_string(),
-        Value::String(event.reason),
-    );
+    payload.insert("violationReason".to_string(), Value::String(event.reason));
     if let Some(uri) = event.resource_uri {
         payload.insert("resourceUri".to_string(), Value::String(uri));
     }

--- a/crates/policy/src/violation.rs
+++ b/crates/policy/src/violation.rs
@@ -1,0 +1,85 @@
+//! `EntryType::Violation` emit helper.
+//!
+//! When the runtime sees a `Decision::Deny` (or a fatal mismatch like F1's
+//! digest-rebind), it MUST record a Violation entry in the ledger before
+//! halting. This module owns that single responsibility — emit only.
+//!
+//! Halt is left to the caller: a library that calls `process::exit` makes
+//! the runtime un-testable and forces every consumer to use a sandbox to
+//! exercise the path. The runtime decides; this crate writes.
+
+use aegis_ledger_writer::{Entry, EntryRecord, EntryType, LedgerWriter};
+use chrono::{DateTime, Utc};
+use serde_json::{Map, Value};
+
+use crate::decision::NetworkProto;
+use crate::error::Result;
+
+/// One violation event. Kept narrow on purpose — the audit trail wants
+/// reasoning, resource, and access kind, all of which the JSON-LD `v1`
+/// `@context` already names.
+#[derive(Debug, Clone)]
+pub struct ViolationEvent {
+    pub reason: String,
+    /// Optional resource URI for context (file path, network address, …).
+    pub resource_uri: Option<String>,
+    /// Optional access type (read/write/network_outbound/exec/…) — a
+    /// snake_case string matching the F4 `accessType` term.
+    pub access_type: Option<String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl ViolationEvent {
+    /// Build a Violation describing a denied network connect attempt.
+    pub fn for_network(
+        host: &str,
+        port: u16,
+        proto: NetworkProto,
+        reason: impl Into<String>,
+        timestamp: DateTime<Utc>,
+    ) -> Self {
+        let scheme = match proto {
+            NetworkProto::Http => "http",
+            NetworkProto::Https => "https",
+            NetworkProto::Udp => "udp",
+            NetworkProto::Tcp | NetworkProto::Any => "tcp",
+        };
+        Self {
+            reason: reason.into(),
+            resource_uri: Some(format!("{scheme}://{host}:{port}")),
+            access_type: Some("network_outbound".to_string()),
+            timestamp,
+        }
+    }
+}
+
+/// Append exactly one `EntryType::Violation` ledger entry. Returns the
+/// writer's record so the runtime can correlate the violation with the
+/// halt it's about to perform.
+pub fn emit_violation(
+    writer: &mut LedgerWriter,
+    agent_identity_hash: [u8; 32],
+    event: ViolationEvent,
+) -> Result<EntryRecord> {
+    let mut payload = Map::new();
+    payload.insert(
+        "violationReason".to_string(),
+        Value::String(event.reason),
+    );
+    if let Some(uri) = event.resource_uri {
+        payload.insert("resourceUri".to_string(), Value::String(uri));
+    }
+    if let Some(at) = event.access_type {
+        payload.insert("accessType".to_string(), Value::String(at));
+    }
+
+    let session_id = writer.session_id().to_string();
+    let record = writer.append(Entry {
+        session_id,
+        entry_type: EntryType::Violation,
+        agent_identity_hash,
+        timestamp: event.timestamp,
+        payload,
+    })?;
+    Ok(record)
+}

--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -5,9 +5,7 @@
 use std::path::Path;
 
 use aegis_ledger_writer::{EntryType, LedgerWriter};
-use aegis_policy::{
-    emit_violation, Decision, NetworkProto, Policy, ViolationEvent,
-};
+use aegis_policy::{emit_violation, Decision, NetworkProto, Policy, ViolationEvent};
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
 
@@ -56,7 +54,9 @@ fn read_only_manifest_denies_all_writes() {
     assert!(p
         .check_filesystem_write(Path::new("/data/reports/x"))
         .is_deny());
-    assert!(p.check_filesystem_delete(Path::new("/data/reports/x")).is_deny());
+    assert!(p
+        .check_filesystem_delete(Path::new("/data/reports/x"))
+        .is_deny());
 }
 
 #[test]
@@ -114,10 +114,7 @@ extends: ["base.yaml"]
 tools: {}
 "#;
     let err = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap_err();
-    assert!(matches!(
-        err,
-        aegis_policy::Error::ExtendsUnsupported(1)
-    ));
+    assert!(matches!(err, aegis_policy::Error::ExtendsUnsupported(1)));
 }
 
 #[test]

--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -1,0 +1,187 @@
+//! End-to-end tests for the policy engine.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+
+use aegis_ledger_writer::{EntryType, LedgerWriter};
+use aegis_policy::{
+    emit_violation, Decision, NetworkProto, Policy, ViolationEvent,
+};
+use chrono::{TimeZone, Utc};
+use serde_json::Value;
+
+fn read_only_research() -> Policy {
+    Policy::from_yaml_file(Path::new(
+        "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+    ))
+    .unwrap()
+}
+
+fn single_write_target() -> Policy {
+    Policy::from_yaml_file(Path::new(
+        "../../schemas/manifest/v1/examples/single-write-target.manifest.yaml",
+    ))
+    .unwrap()
+}
+
+#[test]
+fn read_only_manifest_grants_read_under_listed_paths() {
+    let p = read_only_research();
+    assert!(p
+        .check_filesystem_read(Path::new("/data/reports/q1.md"))
+        .is_allow());
+    assert!(p
+        .check_filesystem_read(Path::new("/data/papers/abstract.txt"))
+        .is_allow());
+    // Path covered exactly equals an entry.
+    assert!(p
+        .check_filesystem_read(Path::new("/data/reports"))
+        .is_allow());
+}
+
+#[test]
+fn read_only_manifest_denies_paths_outside_grants() {
+    let p = read_only_research();
+    assert!(p.check_filesystem_read(Path::new("/etc/passwd")).is_deny());
+    // Boundary check: /data2 must not match /data/.
+    assert!(p
+        .check_filesystem_read(Path::new("/data2/secret"))
+        .is_deny());
+}
+
+#[test]
+fn read_only_manifest_denies_all_writes() {
+    let p = read_only_research();
+    assert!(p
+        .check_filesystem_write(Path::new("/data/reports/x"))
+        .is_deny());
+    assert!(p.check_filesystem_delete(Path::new("/data/reports/x")).is_deny());
+}
+
+#[test]
+fn read_only_manifest_denies_network() {
+    let p = read_only_research();
+    assert!(p
+        .check_network_outbound("api.example.com", 443, NetworkProto::Https)
+        .is_deny());
+    assert!(p
+        .check_network_inbound("0.0.0.0", 8080, NetworkProto::Tcp)
+        .is_deny());
+}
+
+#[test]
+fn write_grant_with_approval_returns_approval() {
+    let p = single_write_target();
+    // The write_grant explicitly sets approval_required: true.
+    let dec = p.check_filesystem_write(Path::new("/data/output/daily-report.md"));
+    assert!(dec.is_approval(), "got {dec:?}");
+}
+
+#[test]
+fn write_outside_grant_is_denied() {
+    let p = single_write_target();
+    assert!(p
+        .check_filesystem_write(Path::new("/data/output/other.md"))
+        .is_deny());
+}
+
+#[test]
+fn approval_required_for_any_write_upgrades_decision() {
+    // Build a tiny manifest that explicitly grants /tmp write but adds
+    // any_write to approval_required_for. The grant's approval_required
+    // is false; the upgrade comes from approval_required_for alone.
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools:
+  filesystem:
+    read: ["/tmp"]
+    write: ["/tmp"]
+approval_required_for: ["any_write"]
+"#;
+    let p = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap();
+    let dec = p.check_filesystem_write(Path::new("/tmp/scratch"));
+    assert!(dec.is_approval(), "got {dec:?}");
+}
+
+#[test]
+fn extends_in_phase_1a_is_unsupported() {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+extends: ["base.yaml"]
+tools: {}
+"#;
+    let err = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap_err();
+    assert!(matches!(
+        err,
+        aegis_policy::Error::ExtendsUnsupported(1)
+    ));
+}
+
+#[test]
+fn allowlist_matches_host_port_protocol() {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools:
+  network:
+    outbound:
+      allowlist:
+        - host: "api.example.com"
+          port: 443
+          protocol: "https"
+"#;
+    let p = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap();
+    assert!(p
+        .check_network_outbound("api.example.com", 443, NetworkProto::Https)
+        .is_allow());
+    // Port mismatch.
+    assert!(p
+        .check_network_outbound("api.example.com", 80, NetworkProto::Https)
+        .is_deny());
+    // Host mismatch.
+    assert!(p
+        .check_network_outbound("evil.example.com", 443, NetworkProto::Https)
+        .is_deny());
+    // Protocol mismatch (https in manifest, plain tcp at callsite).
+    assert!(p
+        .check_network_outbound("api.example.com", 443, NetworkProto::Tcp)
+        .is_deny());
+}
+
+#[test]
+fn exec_is_always_denied_in_v1() {
+    let p = read_only_research();
+    let dec = p.check_exec(Path::new("/usr/bin/ffmpeg"));
+    assert!(dec.is_deny(), "got {dec:?}");
+}
+
+#[test]
+fn emit_violation_appends_violation_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("violations.jsonl");
+    let mut writer = LedgerWriter::create(&path, "session-policy".to_string()).unwrap();
+
+    let ts = Utc.with_ymd_and_hms(2026, 4, 28, 12, 0, 0).unwrap();
+    let event = ViolationEvent::for_network(
+        "evil.example.com",
+        443,
+        NetworkProto::Https,
+        "host not in allowlist",
+        ts,
+    );
+    let rec = emit_violation(&mut writer, [0xCCu8; 32], event).unwrap();
+    assert_eq!(rec.sequence_number, 0);
+    writer.close().unwrap();
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    let v: Value = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert_eq!(v["entryType"], "violation");
+    assert_eq!(v["violationReason"], "host not in allowlist");
+    assert_eq!(v["resourceUri"], "https://evil.example.com:443");
+    assert_eq!(v["accessType"], "network_outbound");
+
+    let _ = EntryType::Violation; // sanity
+}

--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 
 use aegis_ledger_writer::{EntryType, LedgerWriter};
-use aegis_policy::{emit_violation, Decision, NetworkProto, Policy, ViolationEvent};
+use aegis_policy::{emit_violation, NetworkProto, Policy, ViolationEvent};
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
 


### PR DESCRIPTION
## Summary
- New \`crates/policy\`: closed-by-default decision engine. \`Policy::check_*\` answers Allow / Deny / RequireApproval for filesystem read/write/delete, network in/outbound, and exec.
- New violation emit helper: writes an \`EntryType::Violation\` ledger entry; halt is the runtime's call.
- \`crates/network-gate\` now exposes \`AegisTcpStream::connect\` — a policy-checked drop-in for \`TcpStream::connect\`.

## Acceptance criteria mapping (issue #7)
- [x] \`crates/network-gate\` enforces network policy at the \`std::net\` wrapper layer (outbound TCP only — inbound + UDP follow up with the rest).
- [ ] **Filesystem syscalls** (open/read/write/truncate/rename/unlink) check the manifest before proceeding — *deferred*. \`Policy::check_filesystem_*\` is ready; the syscall wrappers (\`AegisFile\` etc.) need their own design slice.
- [ ] **Exec is gated on explicit manifest grant** — *partial*. v1 schema has no exec-grant primitive; \`check_exec\` returns Deny unconditionally. Future schema version will add \`exec_grants\` and this method picks it up.
- [x] **Violations write a ledger entry with EntryType=ENTRY_TYPE_VIOLATION** — \`emit_violation\` ships and is tested. Halt is left to the runtime (libraries shouldn't \`process::exit\`).
- [ ] **Cross-language conformance harness** — *deferred*. The Go validator (\`pkg/manifest\`) and the Rust enforcer (this PR) now both exist; the agreement battery is its own piece of plumbing and will land as a separate PR.

## Closed-by-default semantics
Every \`check_*\` returns Deny when the manifest is silent. \`approval_required_for\` upgrades Allow → RequireApproval; never the other way.

## Phase 1a constraint: no \`extends:\`
\`Policy::from_yaml_*\` rejects manifests with \`extends:\`. The Go validator owns extends resolution + narrowing checks; the resolved manifest is what should reach this engine. Once the control plane gRPC channel lands, \`Policy::from_resolved_json\` becomes canonical and YAML loading stays as dev/CLI convenience.

## Test plan
- [ ] CI green on Rust workflow.
- [ ] Both example manifests round-trip and produce expected decisions.
- [ ] AegisTcpStream allowlist match talks to a real localhost listener.
- [ ] Allowlist-miss / deny-mode / missing-network-section all block.
- [ ] \`emit_violation\` produces a parseable \`entryType: violation\` entry.

Refs #7 (closes after follow-up issues for fs wrappers, exec gating, and conformance harness land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)