### PR TITLE
feat(identity, policy): F1 digest-rebind verification + violation halt (issue #4)

### DIFF
--- a/crates/identity/src/binding.rs
+++ b/crates/identity/src/binding.rs
@@ -1,0 +1,101 @@
+//! Digest-rebind verification for issued SVIDs (F1 per ADR-003).
+//!
+//! At every `CheckPermission` (and at session start), the runtime must
+//! verify that the live `(model, manifest, config)` digest triple still
+//! matches the one bound into the SVID at issuance time. Any drift means
+//! the agent's identity no longer attests to the artifacts it's running
+//! — the runtime halts.
+//!
+//! This module is the pure-comparison half of that check. The
+//! ledger-emit-and-halt half lives in `aegis-policy::check_identity_binding`
+//! so this crate stays free of write-side dependencies.
+
+use std::fmt;
+
+use crate::ca::extract_digest_triple_from_pem;
+use crate::error::Result;
+use crate::svid::{Digest, DigestTriple};
+
+/// Which of the three bound artifacts changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DigestField {
+    Model,
+    Manifest,
+    Config,
+}
+
+impl DigestField {
+    pub fn name(self) -> &'static str {
+        match self {
+            DigestField::Model => "model",
+            DigestField::Manifest => "manifest",
+            DigestField::Config => "config",
+        }
+    }
+}
+
+impl fmt::Display for DigestField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// One mismatched field, with both the bound and the live digest so an
+/// auditor can trace what changed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DigestMismatch {
+    pub field: DigestField,
+    pub bound: Digest,
+    pub live: Digest,
+}
+
+impl fmt::Display for DigestMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} digest changed (bound={}, live={})",
+            self.field,
+            self.bound.hex(),
+            self.live.hex()
+        )
+    }
+}
+
+/// Verify the SVID's bound digest triple against `live`. Returns:
+///
+/// - `Ok(None)` — full match, identity binding intact.
+/// - `Ok(Some(mismatch))` — the first field that drifted (order:
+///   model → manifest → config; deterministic so audit can replay).
+/// - `Err(_)` — the SVID itself was unparseable (cert format problem,
+///   not a binding violation).
+///
+/// Cheap: a string→DER parse plus three 32-byte compares. Fine to call
+/// per `CheckPermission`.
+pub fn verify_digest_binding(
+    cert_pem: &str,
+    live: &DigestTriple,
+) -> Result<Option<DigestMismatch>> {
+    let bound = extract_digest_triple_from_pem(cert_pem)?;
+    if bound.model != live.model {
+        return Ok(Some(DigestMismatch {
+            field: DigestField::Model,
+            bound: bound.model,
+            live: live.model,
+        }));
+    }
+    if bound.manifest != live.manifest {
+        return Ok(Some(DigestMismatch {
+            field: DigestField::Manifest,
+            bound: bound.manifest,
+            live: live.manifest,
+        }));
+    }
+    if bound.config != live.config {
+        return Ok(Some(DigestMismatch {
+            field: DigestField::Config,
+            bound: bound.config,
+            live: live.config,
+        }));
+    }
+    Ok(None)
+}

--- a/crates/identity/src/lib.rs
+++ b/crates/identity/src/lib.rs
@@ -13,11 +13,13 @@
 //! Phase 0 ships the local-CA flavor only. Phase 2 swaps `LocalCa` for SPIRE
 //! workload-attestation; the SVID format on the wire stays identical.
 
+mod binding;
 mod ca;
 pub mod error;
 mod spiffe;
 mod svid;
 
+pub use binding::{verify_digest_binding, DigestField, DigestMismatch};
 pub use ca::{extract_digest_triple_from_pem, extract_spiffe_id_from_pem, LocalCa};
 pub use error::{Error, Result};
 pub use spiffe::SpiffeId;

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aegis-identity = { path = "../identity" }
 aegis-ledger-writer = { path = "../ledger-writer" }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/crates/policy/src/error.rs
+++ b/crates/policy/src/error.rs
@@ -1,3 +1,4 @@
+use aegis_identity::DigestMismatch;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -13,9 +14,15 @@ pub enum Error {
     #[error("ledger: {0}")]
     Ledger(#[from] aegis_ledger_writer::Error),
 
+    #[error("identity: {0}")]
+    Identity(#[from] aegis_identity::Error),
+
     #[error("serialization: {0}")]
     Serde(#[from] serde_json::Error),
 
     #[error("manifest does not support extends: in Phase 1a (got {0} parents)")]
     ExtendsUnsupported(usize),
+
+    #[error("identity digest binding violated: {0}")]
+    IdentityRebind(DigestMismatch),
 }

--- a/crates/policy/src/identity_binding.rs
+++ b/crates/policy/src/identity_binding.rs
@@ -1,0 +1,58 @@
+//! F1 digest-rebind glue: verify the SVID's bound triple against live
+//! digests, and on mismatch emit an `EntryType::Violation` to the ledger.
+//!
+//! The runtime is expected to call this on session start and at every
+//! `CheckPermission` boundary. A returned `Error::IdentityRebind` MUST
+//! halt the agent — the ledger entry has already been written by the
+//! time this function returns the error.
+//!
+//! Why not split this off into a separate "halt" helper? Because the
+//! "emit then halt" sequence is the entire point of the F1 invariant:
+//! the audit record must exist before the process dies. Keeping them in
+//! one function makes "did we forget to log?" impossible.
+
+use aegis_identity::{verify_digest_binding, DigestTriple};
+use aegis_ledger_writer::LedgerWriter;
+use chrono::{DateTime, Utc};
+
+use crate::error::{Error, Result};
+use crate::violation::{emit_violation, ViolationEvent};
+
+/// Verify the SVID's `(model, manifest, config)` binding against the live
+/// triple. Returns `Ok(())` on match. On mismatch, writes a Violation
+/// entry to `writer` and returns `Error::IdentityRebind`. On SVID parse
+/// failure, returns `Error::Identity` without writing anything (a
+/// malformed cert is a different class of problem).
+pub fn check_identity_binding(
+    writer: &mut LedgerWriter,
+    agent_identity_hash: [u8; 32],
+    cert_pem: &str,
+    live: &DigestTriple,
+    timestamp: DateTime<Utc>,
+) -> Result<()> {
+    match verify_digest_binding(cert_pem, live)? {
+        None => Ok(()),
+        Some(mismatch) => {
+            let event = ViolationEvent {
+                reason: format!("identity digest binding violated: {mismatch}"),
+                resource_uri: Some(format!("digest-binding://{}", mismatch.field)),
+                access_type: None,
+                timestamp,
+            };
+            emit_violation(writer, agent_identity_hash, event)?;
+            Err(Error::IdentityRebind(mismatch))
+        }
+    }
+}
+
+/// Convenience wrapper that supplies `Utc::now()` for the violation
+/// timestamp. The test variant takes an explicit timestamp because
+/// fixture-driven runs want deterministic clocks.
+pub fn check_identity_binding_now(
+    writer: &mut LedgerWriter,
+    agent_identity_hash: [u8; 32],
+    cert_pem: &str,
+    live: &DigestTriple,
+) -> Result<()> {
+    check_identity_binding(writer, agent_identity_hash, cert_pem, live, Utc::now())
+}

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -13,12 +13,14 @@
 
 pub mod decision;
 pub mod error;
+mod identity_binding;
 pub mod manifest;
 mod policy;
 mod violation;
 
 pub use decision::{Decision, NetworkProto};
 pub use error::{Error, Result};
+pub use identity_binding::{check_identity_binding, check_identity_binding_now};
 pub use manifest::{
     Agent, ApiGrant, ApprovalClass, Filesystem, Identity, Manifest, Network, NetworkAllowEntry,
     NetworkMode, NetworkPolicy, NetworkProtocol, Tools, WriteAction, WriteGrant,

--- a/crates/policy/tests/identity_binding.rs
+++ b/crates/policy/tests/identity_binding.rs
@@ -1,0 +1,153 @@
+//! F1 conformance: substituting any of the three bound artifacts after
+//! identity issuance triggers a halt (Error::IdentityRebind) AND writes
+//! a Violation entry naming the offending field.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use aegis_identity::{Digest, DigestTriple, LocalCa};
+use aegis_ledger_writer::{EntryType, LedgerWriter};
+use aegis_policy::{check_identity_binding, Error};
+use chrono::{TimeZone, Utc};
+use serde_json::Value;
+
+const TRUST_DOMAIN: &str = "rebind-test.local";
+const AGENT_HASH: [u8; 32] = [0x42u8; 32];
+
+fn issue_with(triple: DigestTriple) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let ca = LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    let svid = ca.issue_svid("research", "inst-rebind", triple).unwrap();
+    (dir, svid.cert_pem)
+}
+
+fn fresh_writer() -> (tempfile::TempDir, LedgerWriter, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rebind.jsonl");
+    let writer = LedgerWriter::create(&path, "session-rebind".to_string()).unwrap();
+    (dir, writer, path)
+}
+
+fn ts() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 4, 28, 12, 0, 0).unwrap()
+}
+
+fn baseline_triple() -> DigestTriple {
+    DigestTriple {
+        model: Digest([0xAAu8; 32]),
+        manifest: Digest([0xBBu8; 32]),
+        config: Digest([0xCCu8; 32]),
+    }
+}
+
+#[test]
+fn matching_triple_passes_silently() {
+    let bound = baseline_triple();
+    let (_ca_dir, cert_pem) = issue_with(bound);
+    let (_w_dir, mut writer, _) = fresh_writer();
+
+    check_identity_binding(&mut writer, AGENT_HASH, &cert_pem, &bound, ts()).unwrap();
+    assert_eq!(writer.entry_count(), 0, "no violation should be written");
+}
+
+#[test]
+fn model_swap_triggers_halt_and_logs_violation() {
+    let bound = baseline_triple();
+    let (_ca_dir, cert_pem) = issue_with(bound);
+    let (_w_dir, mut writer, path) = fresh_writer();
+
+    let live = DigestTriple {
+        model: Digest([0xDEu8; 32]),
+        ..bound
+    };
+    let err = check_identity_binding(&mut writer, AGENT_HASH, &cert_pem, &live, ts()).unwrap_err();
+    let mismatch = match err {
+        Error::IdentityRebind(m) => m,
+        other => panic!("expected IdentityRebind, got {other:?}"),
+    };
+    assert_eq!(mismatch.field.name(), "model");
+    assert_eq!(mismatch.bound, bound.model);
+    assert_eq!(mismatch.live, live.model);
+
+    writer.close().unwrap();
+    assert_violation_written(&path, "model");
+}
+
+#[test]
+fn manifest_swap_triggers_halt_and_logs_violation() {
+    let bound = baseline_triple();
+    let (_ca_dir, cert_pem) = issue_with(bound);
+    let (_w_dir, mut writer, path) = fresh_writer();
+
+    let live = DigestTriple {
+        manifest: Digest([0x77u8; 32]),
+        ..bound
+    };
+    let err = check_identity_binding(&mut writer, AGENT_HASH, &cert_pem, &live, ts()).unwrap_err();
+    assert!(matches!(err, Error::IdentityRebind(ref m) if m.field.name() == "manifest"));
+    writer.close().unwrap();
+    assert_violation_written(&path, "manifest");
+}
+
+#[test]
+fn config_swap_triggers_halt_and_logs_violation() {
+    let bound = baseline_triple();
+    let (_ca_dir, cert_pem) = issue_with(bound);
+    let (_w_dir, mut writer, path) = fresh_writer();
+
+    let live = DigestTriple {
+        config: Digest([0x33u8; 32]),
+        ..bound
+    };
+    let err = check_identity_binding(&mut writer, AGENT_HASH, &cert_pem, &live, ts()).unwrap_err();
+    assert!(matches!(err, Error::IdentityRebind(ref m) if m.field.name() == "config"));
+    writer.close().unwrap();
+    assert_violation_written(&path, "config");
+}
+
+#[test]
+fn first_mismatch_wins_when_two_artifacts_change() {
+    // Order of detection is fixed (model → manifest → config) so the
+    // violation is deterministic and replay-driven audit can match.
+    let bound = baseline_triple();
+    let (_ca_dir, cert_pem) = issue_with(bound);
+    let (_w_dir, mut writer, _) = fresh_writer();
+
+    let live = DigestTriple {
+        model: Digest([0x11u8; 32]),
+        manifest: Digest([0x22u8; 32]),
+        config: bound.config,
+    };
+    let err = check_identity_binding(&mut writer, AGENT_HASH, &cert_pem, &live, ts()).unwrap_err();
+    assert!(matches!(err, Error::IdentityRebind(ref m) if m.field.name() == "model"));
+}
+
+#[test]
+fn malformed_cert_returns_identity_error_without_writing_violation() {
+    let (_w_dir, mut writer, _) = fresh_writer();
+    let live = baseline_triple();
+    let err = check_identity_binding(&mut writer, AGENT_HASH, "not a PEM block", &live, ts())
+        .unwrap_err();
+    // A bad cert is not a digest mismatch — we don't pollute the ledger
+    // with a violation we can't actually attribute to a real artifact swap.
+    assert!(matches!(err, Error::Identity(_)), "got {err:?}");
+    assert_eq!(writer.entry_count(), 0);
+}
+
+fn assert_violation_written(path: &std::path::Path, expected_field: &str) {
+    let content = std::fs::read_to_string(path).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines.len(), 1, "exactly one violation entry expected");
+    let v: Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(v["entryType"], "violation");
+    assert_eq!(
+        v["resourceUri"],
+        format!("digest-binding://{expected_field}")
+    );
+    let reason = v["violationReason"].as_str().unwrap();
+    assert!(
+        reason.contains(expected_field),
+        "reason {reason:?} should mention field {expected_field}"
+    );
+
+    let _ = EntryType::Violation; // sanity reference
+}


### PR DESCRIPTION
## Summary
- New \`aegis_identity::verify_digest_binding\`: pure compare of SVID-bound \`(model, manifest, config)\` triple against a live triple. Returns \`Ok(None)\` on match, \`Ok(Some(DigestMismatch))\` on first drift, \`Err\` on SVID parse failure.
- New \`aegis_policy::check_identity_binding\`: emits an \`EntryType::Violation\` entry on mismatch, then returns \`Error::IdentityRebind\` so the runtime can halt. Audit record exists before halt — that ordering is the entire point of the F1 invariant.

## Acceptance criteria mapping (issue #4)
- [x] Identity issuance computes and embeds the three digests — already done in #2 (the SVID custom extension).
- [x] On mismatch, produce a critical violation entry and halt the agent — \`check_identity_binding\` writes the entry, returns the halt error.
- [x] Conformance test: substituting any of the three artifacts after issuance triggers halt — six tests cover model / manifest / config swaps + two-at-once first-mismatch-wins + malformed cert path.
- [ ] **At every \`CheckPermission\`, the runtime verifies live digests** — *deferred*. The verifier function and emit-on-mismatch glue are the Phase 1a deliverables; the per-CheckPermission invocation lands when the gRPC server lands.

## Determinism note
Field-check order is fixed (model → manifest → config) so the violation message is replay-stable. If two artifacts drift simultaneously, the model field wins detection — documented in \`first_mismatch_wins_when_two_artifacts_change\`.

## Why malformed cert ≠ violation
A cert that won't parse can't be attributed to a specific artifact swap, so writing a violation entry for it would pollute the audit trail with an event that no remediation action can address. \`Error::Identity\` is returned and the ledger is untouched — the runtime should treat that as a fatal config error, not a security violation.

## Test plan
- [ ] CI green on Rust workflow.
- [ ] Six rebind tests: matching triple silent, three single-field swaps trigger halt with the right field name in the violation entry, two-at-once detects model first, malformed cert returns Identity error without writing.

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)