### PR TITLE
test(conformance): cross-language Go ↔ Rust agreement harness (issue #16)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,8 +13,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Conformance harness (placeholder)
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Go conformance
+        # Both engines load the same fixture (tests/conformance/cases.json).
+        # If either disagrees with the fixture, that side fails — and since
+        # they share the fixture, agreeing with it transitively means the
+        # two engines agree with each other.
         run: |
-          echo "Cross-language conformance suite per ADR-002 and ADR-012."
-          echo "Validator (Go) and enforcer (Rust) must agree on every manifest semantic."
-          echo "Implementation pending Phase 1a (manifest schema + validator + enforcer all live)."
+          go mod tidy
+          go test -v -run TestConformance ./pkg/manifest/...
+
+      - name: Rust conformance
+        run: cargo test -p aegis-policy --test conformance -- --nocapture

--- a/crates/policy/tests/conformance.rs
+++ b/crates/policy/tests/conformance.rs
@@ -1,0 +1,140 @@
+//! Cross-language conformance harness (issue #16) — Rust side.
+//!
+//! Loads tests/conformance/cases.json and asserts the Rust enforcer
+//! agrees with every expected decision. The Go side runs the same
+//! fixture in `pkg/manifest`. If either disagrees, that side's CI
+//! fails — and since both pass against the same fixture, transitively
+//! both engines agree.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+
+use aegis_policy::{Decision, NetworkProto, Policy};
+use serde::Deserialize;
+
+const CASES_PATH: &str = "../../tests/conformance/cases.json";
+
+#[derive(Debug, Deserialize)]
+struct ConformanceFile {
+    version: String,
+    cases: Vec<ConformanceCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConformanceCase {
+    name: String,
+    manifest: String,
+    query: Query,
+    expected: ExpectedKind,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Query {
+    FilesystemRead { resource_uri: String },
+    FilesystemWrite { resource_uri: String },
+    FilesystemDelete { resource_uri: String },
+    NetworkOutbound {
+        host: String,
+        port: u16,
+        protocol: ProtocolStr,
+    },
+    NetworkInbound {
+        host: String,
+        port: u16,
+        protocol: ProtocolStr,
+    },
+    Exec {
+        #[serde(default)]
+        resource_uri: String,
+    },
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum ProtocolStr {
+    Http,
+    Https,
+    Tcp,
+    Udp,
+}
+
+impl From<ProtocolStr> for NetworkProto {
+    fn from(p: ProtocolStr) -> Self {
+        match p {
+            ProtocolStr::Http => NetworkProto::Http,
+            ProtocolStr::Https => NetworkProto::Https,
+            ProtocolStr::Tcp => NetworkProto::Tcp,
+            ProtocolStr::Udp => NetworkProto::Udp,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ExpectedKind {
+    Allow,
+    Deny,
+    RequireApproval,
+}
+
+fn decision_kind(d: &Decision) -> ExpectedKind {
+    match d {
+        Decision::Allow => ExpectedKind::Allow,
+        Decision::Deny { .. } => ExpectedKind::Deny,
+        Decision::RequireApproval { .. } => ExpectedKind::RequireApproval,
+    }
+}
+
+#[test]
+fn conformance_rust_side() {
+    let cases_path = Path::new(CASES_PATH);
+    let cases_dir = cases_path.parent().unwrap();
+    let raw = std::fs::read_to_string(cases_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", cases_path.display()));
+    let file: ConformanceFile = serde_json::from_str(&raw).expect("parse cases.json");
+    assert_eq!(file.version, "1", "unexpected fixture version");
+    assert!(!file.cases.is_empty(), "no cases in fixture");
+
+    let mut failed: Vec<String> = Vec::new();
+    for case in &file.cases {
+        let manifest_path: PathBuf = cases_dir.join(&case.manifest);
+        let policy = Policy::from_yaml_file(&manifest_path)
+            .unwrap_or_else(|e| panic!("load {}: {e}", manifest_path.display()));
+
+        let decision = match &case.query {
+            Query::FilesystemRead { resource_uri } => {
+                policy.check_filesystem_read(Path::new(resource_uri))
+            }
+            Query::FilesystemWrite { resource_uri } => {
+                policy.check_filesystem_write(Path::new(resource_uri))
+            }
+            Query::FilesystemDelete { resource_uri } => {
+                policy.check_filesystem_delete(Path::new(resource_uri))
+            }
+            Query::NetworkOutbound { host, port, protocol } => {
+                policy.check_network_outbound(host, *port, (*protocol).into())
+            }
+            Query::NetworkInbound { host, port, protocol } => {
+                policy.check_network_inbound(host, *port, (*protocol).into())
+            }
+            Query::Exec { resource_uri } => policy.check_exec(Path::new(resource_uri)),
+        };
+
+        let actual = decision_kind(&decision);
+        if actual != case.expected {
+            failed.push(format!(
+                "case {} drift: want {:?} got {:?} (reason: {:?})",
+                case.name, case.expected, actual, decision
+            ));
+        }
+    }
+
+    assert!(
+        failed.is_empty(),
+        "{} conformance case(s) failed:\n  {}",
+        failed.len(),
+        failed.join("\n  ")
+    );
+}

--- a/crates/policy/tests/conformance.rs
+++ b/crates/policy/tests/conformance.rs
@@ -32,9 +32,15 @@ struct ConformanceCase {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum Query {
-    FilesystemRead { resource_uri: String },
-    FilesystemWrite { resource_uri: String },
-    FilesystemDelete { resource_uri: String },
+    FilesystemRead {
+        resource_uri: String,
+    },
+    FilesystemWrite {
+        resource_uri: String,
+    },
+    FilesystemDelete {
+        resource_uri: String,
+    },
     NetworkOutbound {
         host: String,
         port: u16,
@@ -113,12 +119,16 @@ fn conformance_rust_side() {
             Query::FilesystemDelete { resource_uri } => {
                 policy.check_filesystem_delete(Path::new(resource_uri))
             }
-            Query::NetworkOutbound { host, port, protocol } => {
-                policy.check_network_outbound(host, *port, (*protocol).into())
-            }
-            Query::NetworkInbound { host, port, protocol } => {
-                policy.check_network_inbound(host, *port, (*protocol).into())
-            }
+            Query::NetworkOutbound {
+                host,
+                port,
+                protocol,
+            } => policy.check_network_outbound(host, *port, (*protocol).into()),
+            Query::NetworkInbound {
+                host,
+                port,
+                protocol,
+            } => policy.check_network_inbound(host, *port, (*protocol).into()),
             Query::Exec { resource_uri } => policy.check_exec(Path::new(resource_uri)),
         };
 

--- a/pkg/manifest/conformance_test.go
+++ b/pkg/manifest/conformance_test.go
@@ -1,0 +1,55 @@
+package manifest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const conformancePath = "../../tests/conformance/cases.json"
+
+type conformanceFile struct {
+	Version string            `json:"version"`
+	Cases   []conformanceCase `json:"cases"`
+}
+
+type conformanceCase struct {
+	Name     string       `json:"name"`
+	Manifest string       `json:"manifest"`
+	Query    Query        `json:"query"`
+	Expected DecisionKind `json:"expected"`
+}
+
+func TestConformance_GoSide(t *testing.T) {
+	data, err := os.ReadFile(conformancePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", conformancePath, err)
+	}
+	var cf conformanceFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		t.Fatalf("parse cases.json: %v", err)
+	}
+	if cf.Version != "1" {
+		t.Fatalf("unexpected fixture version %q", cf.Version)
+	}
+	if len(cf.Cases) == 0 {
+		t.Fatal("no cases in fixture")
+	}
+
+	casesDir := filepath.Dir(conformancePath)
+	for _, c := range cf.Cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			manifestPath := filepath.Join(casesDir, c.Manifest)
+			m, err := Load(manifestPath)
+			if err != nil {
+				t.Fatalf("load %s: %v", manifestPath, err)
+			}
+			got := m.Decide(c.Query)
+			if got.Kind != c.Expected {
+				t.Errorf("decision drift: want %q got %q (reason=%q)", c.Expected, got.Kind, got.Reason)
+			}
+		})
+	}
+}

--- a/pkg/manifest/decide.go
+++ b/pkg/manifest/decide.go
@@ -1,0 +1,235 @@
+package manifest
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DecisionKind mirrors aegis_policy::Decision in Rust. The cross-language
+// conformance harness (issue #16) asserts both engines produce the same
+// kind for every query in tests/conformance/cases.json.
+type DecisionKind string
+
+const (
+	DecisionAllow           DecisionKind = "allow"
+	DecisionDeny            DecisionKind = "deny"
+	DecisionRequireApproval DecisionKind = "require_approval"
+)
+
+// Decision is the answer to a single permission check.
+type Decision struct {
+	Kind   DecisionKind
+	Reason string
+}
+
+func allowDecision() Decision        { return Decision{Kind: DecisionAllow} }
+func denyDecision(r string) Decision { return Decision{Kind: DecisionDeny, Reason: r} }
+func approvalDecision(r string) Decision {
+	return Decision{Kind: DecisionRequireApproval, Reason: r}
+}
+
+// QueryKind enumerates the operation kinds the conformance harness
+// exercises. Mirrors Rust's check_filesystem_* / check_network_* / check_exec.
+type QueryKind string
+
+const (
+	QueryFilesystemRead   QueryKind = "filesystem_read"
+	QueryFilesystemWrite  QueryKind = "filesystem_write"
+	QueryFilesystemDelete QueryKind = "filesystem_delete"
+	QueryNetworkOutbound  QueryKind = "network_outbound"
+	QueryNetworkInbound   QueryKind = "network_inbound"
+	QueryExec             QueryKind = "exec"
+)
+
+// Query is one I/O attempt described abstractly so both Go and Rust
+// engines can evaluate it without invoking the underlying syscall.
+type Query struct {
+	Kind        QueryKind `json:"kind"`
+	ResourceURI string    `json:"resource_uri,omitempty"`
+	Host        string    `json:"host,omitempty"`
+	Port        int       `json:"port,omitempty"`
+	Protocol    string    `json:"protocol,omitempty"`
+}
+
+// Decide answers a Query against `m`. Closed-by-default: silence is
+// denial. approval_required_for upgrades Allow → RequireApproval.
+//
+// Semantics MUST match aegis_policy::Policy::check_* in Rust. The
+// conformance harness asserts agreement on every example manifest.
+func (m *Manifest) Decide(q Query) Decision {
+	switch q.Kind {
+	case QueryFilesystemRead:
+		return m.decideFsRead(q.ResourceURI)
+	case QueryFilesystemWrite:
+		return m.decideFsWrite(q.ResourceURI)
+	case QueryFilesystemDelete:
+		return m.decideFsDelete(q.ResourceURI)
+	case QueryNetworkOutbound:
+		return m.decideNetwork(true, q.Host, q.Port, q.Protocol)
+	case QueryNetworkInbound:
+		return m.decideNetwork(false, q.Host, q.Port, q.Protocol)
+	case QueryExec:
+		return denyDecision("exec is not grantable in manifest schema v1; future schema will add exec_grants")
+	default:
+		return denyDecision(fmt.Sprintf("unknown query kind %q", q.Kind))
+	}
+}
+
+func (m *Manifest) decideFsRead(uri string) Decision {
+	var paths []string
+	if m.Tools.Filesystem != nil {
+		paths = m.Tools.Filesystem.Read
+	}
+	if !pathCovered(uri, paths) {
+		return denyDecision(fmt.Sprintf("filesystem read of %s not granted by manifest", uri))
+	}
+	return allowDecision()
+}
+
+func (m *Manifest) decideFsWrite(uri string) Decision {
+	if g := m.findWriteGrantFor(uri, ActionWrite); g != nil {
+		return m.writeGrantDecision(uri, g, ActionWrite)
+	}
+	var paths []string
+	if m.Tools.Filesystem != nil {
+		paths = m.Tools.Filesystem.Write
+	}
+	if pathCovered(uri, paths) {
+		return upgradeForApproval(allowDecision(), m.ApprovalRequiredFor, ApprovalAnyWrite,
+			"any_write requires approval")
+	}
+	return denyDecision(fmt.Sprintf("filesystem write of %s not granted by manifest", uri))
+}
+
+func (m *Manifest) decideFsDelete(uri string) Decision {
+	if g := m.findWriteGrantFor(uri, ActionDelete); g != nil {
+		return m.writeGrantDecision(uri, g, ActionDelete)
+	}
+	return denyDecision(fmt.Sprintf("filesystem delete of %s not granted by any write_grant", uri))
+}
+
+func (m *Manifest) decideNetwork(outbound bool, host string, port int, protocol string) Decision {
+	var policy *NetworkPolicy
+	if m.Tools.Network != nil {
+		if outbound {
+			policy = m.Tools.Network.Outbound
+		} else {
+			policy = m.Tools.Network.Inbound
+		}
+	}
+	dir := "outbound"
+	if !outbound {
+		dir = "inbound"
+	}
+	base := evalNetwork(policy, host, port, protocol, dir)
+	if !outbound {
+		return base
+	}
+	return upgradeForApproval(base, m.ApprovalRequiredFor, ApprovalAnyNetworkOutbound,
+		"any_network_outbound requires approval")
+}
+
+func evalNetwork(p *NetworkPolicy, host string, port int, protocol, direction string) Decision {
+	if p == nil {
+		return denyDecision(fmt.Sprintf("network %s denied: manifest has no policy", direction))
+	}
+	if p.Mode == NetworkAllow {
+		return allowDecision()
+	}
+	if p.Mode == NetworkDeny || p.Mode == "" {
+		return denyDecision(fmt.Sprintf("network %s denied: manifest sets deny", direction))
+	}
+	for _, e := range p.Allowlist {
+		if matchesAllowEntry(e, host, port, protocol) {
+			return allowDecision()
+		}
+	}
+	return denyDecision(fmt.Sprintf("network %s %s:%d not in manifest allowlist", direction, host, port))
+}
+
+func matchesAllowEntry(e NetworkAllowEntry, host string, port int, protocol string) bool {
+	if e.Host != host {
+		return false
+	}
+	if e.Port != 0 && e.Port != port {
+		return false
+	}
+	if e.Protocol != "" && e.Protocol != protocol {
+		return false
+	}
+	return true
+}
+
+// pathCovered: child path is at-or-under any parent. "/data" covers
+// "/data" and "/data/x" but not "/data2". MUST match Rust's
+// `paths_cover` exactly.
+func pathCovered(child string, parents []string) bool {
+	for _, p := range parents {
+		if p == child {
+			return true
+		}
+		if p == "/" {
+			return true
+		}
+		if strings.HasPrefix(child, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// Action-name shortcuts so callers don't import the WriteAction enum
+// just to look up a grant.
+const (
+	ActionWrite  = WriteAction("write")
+	ActionDelete = WriteAction("delete")
+	ActionUpdate = WriteAction("update")
+	ActionCreate = WriteAction("create")
+)
+
+// WriteAction string is what the YAML emits ("write" / "delete" / …).
+// Defined here as a typed string so existing Manifest.WriteGrant.Actions
+// interop without changing types.go signatures.
+type WriteAction string
+
+func (m *Manifest) findWriteGrantFor(uri string, action WriteAction) *WriteGrant {
+	for i := range m.WriteGrants {
+		g := &m.WriteGrants[i]
+		if g.Resource != uri {
+			continue
+		}
+		for _, a := range g.Actions {
+			if a == string(action) {
+				return g
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Manifest) writeGrantDecision(uri string, g *WriteGrant, action WriteAction) Decision {
+	cls := ApprovalAnyWrite
+	if action == ActionDelete {
+		cls = ApprovalAnyDelete
+	}
+	if g.ApprovalRequired || hasApprovalClass(m.ApprovalRequiredFor, cls) {
+		return approvalDecision(fmt.Sprintf("%s on %s requires approval per write_grant", action, uri))
+	}
+	return allowDecision()
+}
+
+func upgradeForApproval(base Decision, classes []ApprovalClass, want ApprovalClass, reason string) Decision {
+	if base.Kind == DecisionAllow && hasApprovalClass(classes, want) {
+		return approvalDecision(reason)
+	}
+	return base
+}
+
+func hasApprovalClass(classes []ApprovalClass, want ApprovalClass) bool {
+	for _, c := range classes {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/manifest/decide.go
+++ b/pkg/manifest/decide.go
@@ -1,9 +1,6 @@
 package manifest
 
-import (
-	"fmt"
-	"strings"
-)
+import "fmt"
 
 // DecisionKind mirrors aegis_policy::Decision in Rust. The cross-language
 // conformance harness (issue #16) asserts both engines produce the same
@@ -158,24 +155,6 @@ func matchesAllowEntry(e NetworkAllowEntry, host string, port int, protocol stri
 		return false
 	}
 	return true
-}
-
-// pathCovered: child path is at-or-under any parent. "/data" covers
-// "/data" and "/data/x" but not "/data2". MUST match Rust's
-// `paths_cover` exactly.
-func pathCovered(child string, parents []string) bool {
-	for _, p := range parents {
-		if p == child {
-			return true
-		}
-		if p == "/" {
-			return true
-		}
-		if strings.HasPrefix(child, p+"/") {
-			return true
-		}
-	}
-	return false
 }
 
 // Action-name shortcuts so callers don't import the WriteAction enum

--- a/tests/conformance/cases.json
+++ b/tests/conformance/cases.json
@@ -1,0 +1,114 @@
+{
+  "_doc": "Cross-language conformance fixture (issue #16). Both pkg/manifest (Go) and aegis_policy::Policy (Rust) MUST agree with every expected decision below. Manifest paths are relative to this file's directory. Updating a case requires both runners to pass; if they disagree the engines drifted.",
+  "version": "1",
+  "cases": [
+    {
+      "name": "read_only_research_grants_listed_path",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "filesystem_read", "resource_uri": "/data/reports/q1.md" },
+      "expected": "allow"
+    },
+    {
+      "name": "read_only_research_grants_other_listed_path",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "filesystem_read", "resource_uri": "/data/papers/abstract.txt" },
+      "expected": "allow"
+    },
+    {
+      "name": "read_only_research_denies_unlisted_read",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "filesystem_read", "resource_uri": "/etc/passwd" },
+      "expected": "deny"
+    },
+    {
+      "name": "read_only_research_boundary_denies_data2",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "filesystem_read", "resource_uri": "/data2/secret" },
+      "expected": "deny"
+    },
+    {
+      "name": "read_only_research_denies_all_writes",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "filesystem_write", "resource_uri": "/data/reports/x" },
+      "expected": "deny"
+    },
+    {
+      "name": "read_only_research_denies_all_deletes",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "filesystem_delete", "resource_uri": "/data/reports/x" },
+      "expected": "deny"
+    },
+    {
+      "name": "read_only_research_denies_outbound",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "api.example.com", "port": 443, "protocol": "https" },
+      "expected": "deny"
+    },
+    {
+      "name": "single_write_target_allows_listed_read",
+      "manifest": "../../schemas/manifest/v1/examples/single-write-target.manifest.yaml",
+      "query": { "kind": "filesystem_read", "resource_uri": "/data/sources/in.csv" },
+      "expected": "allow"
+    },
+    {
+      "name": "single_write_target_grant_requires_approval",
+      "manifest": "../../schemas/manifest/v1/examples/single-write-target.manifest.yaml",
+      "query": { "kind": "filesystem_write", "resource_uri": "/data/output/daily-report.md" },
+      "expected": "require_approval"
+    },
+    {
+      "name": "single_write_target_denies_other_writes",
+      "manifest": "../../schemas/manifest/v1/examples/single-write-target.manifest.yaml",
+      "query": { "kind": "filesystem_write", "resource_uri": "/data/output/other.md" },
+      "expected": "deny"
+    },
+    {
+      "name": "allowlist_match_host_port_protocol",
+      "manifest": "manifests/network-allowlist.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "api.example.com", "port": 443, "protocol": "https" },
+      "expected": "allow"
+    },
+    {
+      "name": "allowlist_miss_port",
+      "manifest": "manifests/network-allowlist.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "api.example.com", "port": 80, "protocol": "https" },
+      "expected": "deny"
+    },
+    {
+      "name": "allowlist_miss_host",
+      "manifest": "manifests/network-allowlist.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "evil.example.com", "port": 443, "protocol": "https" },
+      "expected": "deny"
+    },
+    {
+      "name": "allowlist_miss_protocol",
+      "manifest": "manifests/network-allowlist.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "api.example.com", "port": 443, "protocol": "tcp" },
+      "expected": "deny"
+    },
+    {
+      "name": "allow_all_outbound_anywhere",
+      "manifest": "manifests/network-allow-all.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "anywhere.example.org", "port": 80, "protocol": "http" },
+      "expected": "allow"
+    },
+    {
+      "name": "approval_class_upgrades_allowlist_hit",
+      "manifest": "manifests/approval-class.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "api.example.com", "port": 443, "protocol": "https" },
+      "expected": "require_approval"
+    },
+    {
+      "name": "approval_class_does_not_promote_a_deny",
+      "manifest": "manifests/approval-class.manifest.yaml",
+      "query": { "kind": "network_outbound", "host": "evil.example.com", "port": 443, "protocol": "https" },
+      "expected": "deny"
+    },
+    {
+      "name": "exec_is_always_denied_in_v1",
+      "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/usr/bin/ffmpeg" },
+      "expected": "deny"
+    }
+  ]
+}

--- a/tests/conformance/manifests/approval-class.manifest.yaml
+++ b/tests/conformance/manifests/approval-class.manifest.yaml
@@ -1,0 +1,19 @@
+# Conformance fixture: allowlist + any_network_outbound approval class.
+# An allowed entry is upgraded to require_approval rather than allowed
+# silently.
+
+schemaVersion: "1"
+agent:
+  name: "approval-class-test"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/approval/inst-001"
+tools:
+  network:
+    outbound:
+      allowlist:
+        - host: "api.example.com"
+          port: 443
+          protocol: "https"
+approval_required_for:
+  - "any_network_outbound"

--- a/tests/conformance/manifests/network-allow-all.manifest.yaml
+++ b/tests/conformance/manifests/network-allow-all.manifest.yaml
@@ -1,0 +1,13 @@
+# Conformance fixture: outbound = allow (escape hatch). Should match
+# anything; used to verify the deny < allowlist < allow ladder.
+
+schemaVersion: "1"
+agent:
+  name: "allow-all-test"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/allow-all/inst-001"
+tools:
+  network:
+    outbound: allow
+    inbound: deny

--- a/tests/conformance/manifests/network-allowlist.manifest.yaml
+++ b/tests/conformance/manifests/network-allowlist.manifest.yaml
@@ -1,0 +1,17 @@
+# Conformance fixture: outbound network allowlist with one entry.
+# Used to exercise allowlist match / port-miss / host-miss / proto-miss.
+
+schemaVersion: "1"
+agent:
+  name: "allowlist-test"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/allowlist/inst-001"
+tools:
+  network:
+    outbound:
+      allowlist:
+        - host: "api.example.com"
+          port: 443
+          protocol: "https"
+    inbound: deny


### PR DESCRIPTION
## Summary
- Real fixture-driven Conformance workflow: both \`pkg/manifest\` (Go) and \`aegis_policy::Policy\` (Rust) load the same \`tests/conformance/cases.json\` and assert per-case.
- New \`Manifest.Decide(Query) Decision\` in Go — the Go side was previously schema-only; this PR makes it a decision engine that mirrors the Rust check_* surface.
- 18 cases cover every issue #16 acceptance bullet plus a few negatives the criteria implied (allowlist port/host/protocol misses, approval-class promotion / non-promotion of denies).

## Acceptance criteria mapping (issue #16)
- [x] Test harness on both sides loads each manifest in \`schemas/manifest/v1/examples/\` plus three new fixtures under \`tests/conformance/manifests/\`.
- [x] Both sides answer the same battery; disagreement = CI failure on the disagreeing side.
- [x] Battery covers fs-read at-or-under grant, fs-write under \`write_grants\`, network deny / allow / allowlist match / allowlist miss, approval-class upgrade.
- [x] CI workflow \`Conformance / Go validator ↔ Rust enforcer\` runs the harness — placeholder gone.
- [x] Fixtures live at \`tests/conformance/\` and are referenced from both languages.

## Why fixture-as-source-of-truth
Subprocess diff would test the binaries; that adds value but risks "oh, just a serialization quirk" debates. Fixture-as-truth is sharper: each engine asserts independently against the same expected decisions, so a drift surfaces on exactly one side. Updating a case requires both runners to pass, which forces the change to be considered together.

## Negative-case coverage that the criteria implied
- Boundary check: \`/data2/secret\` does NOT match a \`/data\` grant.
- Allowlist port miss: same host but wrong port → deny.
- Allowlist host miss: wrong host → deny.
- Allowlist protocol miss: \`tcp\` query against \`https\`-only entry → deny.
- Approval class does NOT promote a deny: an outside-allowlist call with \`any_network_outbound\` set still denies (approval is an upgrade, never a downgrade).
- Exec is denied in v1 (placeholder until #15 lands \`exec_grants\`).

## Test plan
- [ ] CI green: Go workflow, Rust workflow, AND the new Conformance workflow all pass on first run.
- [ ] If either engine drifts, the PR adding the drift will fail in exactly one of the two halves — exposing which side broke.

Closes #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)