### PR TITLE
feat(manifest): exec_grants — closed-by-default exec gating (issue #15)

### DIFF
--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -22,8 +22,8 @@ pub use decision::{Decision, NetworkProto};
 pub use error::{Error, Result};
 pub use identity_binding::{check_identity_binding, check_identity_binding_now};
 pub use manifest::{
-    Agent, ApiGrant, ApprovalClass, Filesystem, Identity, Manifest, Network, NetworkAllowEntry,
-    NetworkMode, NetworkPolicy, NetworkProtocol, Tools, WriteAction, WriteGrant,
+    Agent, ApiGrant, ApprovalClass, ExecGrant, Filesystem, Identity, Manifest, Network,
+    NetworkAllowEntry, NetworkMode, NetworkPolicy, NetworkProtocol, Tools, WriteAction, WriteGrant,
 };
 pub use policy::Policy;
 pub use violation::{emit_violation, ViolationEvent};

--- a/crates/policy/src/manifest.rs
+++ b/crates/policy/src/manifest.rs
@@ -26,6 +26,8 @@ pub struct Manifest {
     pub write_grants: Vec<WriteGrant>,
     #[serde(default, rename = "approval_required_for")]
     pub approval_required_for: Vec<ApprovalClass>,
+    #[serde(default, rename = "exec_grants")]
+    pub exec_grants: Vec<ExecGrant>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,6 +135,17 @@ pub enum WriteAction {
     Delete,
     Update,
     Create,
+}
+
+/// One entry in `exec_grants`. `program` is either an absolute path or
+/// a bare basename. `args_match` is parsed in Phase 1 and enforced when
+/// the runtime can pass argv to the gate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecGrant {
+    pub program: String,
+    #[serde(default, rename = "args_match")]
+    pub args_match: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/policy/src/policy.rs
+++ b/crates/policy/src/policy.rs
@@ -135,14 +135,27 @@ impl Policy {
         network_decision(policy, host, port, protocol, "inbound")
     }
 
-    /// Exec: v1 schema has no exec-grant primitive. Always denied. A future
-    /// schema version will introduce explicit exec grants — this method
-    /// will gain a corresponding manifest lookup at that point.
+    /// Exec: closed-by-default. A grant matches if its `program` field
+    /// equals the query path (when the field has a slash) or the query's
+    /// basename (when the field is a bare name). `any_exec` upgrades a
+    /// hit to RequireApproval. `args_match` is stored but not enforced
+    /// until the runtime can pass argv through.
     pub fn check_exec(&self, program: &Path) -> Decision {
-        let _ = program;
-        Decision::deny(
-            "exec is not grantable in manifest schema v1; future schema will add exec_grants"
-                .to_string(),
+        let matched = self
+            .manifest
+            .exec_grants
+            .iter()
+            .any(|g| program_matches(&g.program, program));
+        if !matched {
+            return Decision::deny(format!(
+                "exec of {} not granted by manifest",
+                program.display()
+            ));
+        }
+        self.upgrade_for_approval(
+            Decision::Allow,
+            ApprovalClass::AnyExec,
+            "any_exec requires approval",
         )
     }
 
@@ -177,6 +190,19 @@ impl Policy {
             other => other,
         }
     }
+}
+
+/// True if a manifest's exec_grant `program` field matches the query.
+/// Slash-bearing strings are treated as absolute paths; bare strings are
+/// treated as basenames.
+fn program_matches(grant_program: &str, query: &Path) -> bool {
+    if grant_program.contains('/') {
+        return Path::new(grant_program) == query;
+    }
+    query
+        .file_name()
+        .map(|f| f == grant_program)
+        .unwrap_or(false)
 }
 
 /// Returns true if `path` is at-or-under any of `parents`. "/data" covers

--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -149,10 +149,56 @@ tools:
 }
 
 #[test]
-fn exec_is_always_denied_in_v1() {
+fn exec_denied_when_manifest_has_no_grants() {
+    // read-only-research has no exec_grants → closed-by-default.
     let p = read_only_research();
     let dec = p.check_exec(Path::new("/usr/bin/ffmpeg"));
     assert!(dec.is_deny(), "got {dec:?}");
+}
+
+#[test]
+fn exec_grant_absolute_path_matches_exact() {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools: {}
+exec_grants:
+  - program: "/usr/bin/git"
+"#;
+    let p = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap();
+    assert!(p.check_exec(Path::new("/usr/bin/git")).is_allow());
+    assert!(p.check_exec(Path::new("/usr/local/bin/git")).is_deny());
+}
+
+#[test]
+fn exec_grant_basename_matches_anywhere() {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools: {}
+exec_grants:
+  - program: "ffmpeg"
+"#;
+    let p = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap();
+    assert!(p.check_exec(Path::new("/usr/bin/ffmpeg")).is_allow());
+    assert!(p.check_exec(Path::new("/snap/bin/ffmpeg")).is_allow());
+    assert!(p.check_exec(Path::new("/usr/bin/curl")).is_deny());
+}
+
+#[test]
+fn exec_any_exec_upgrades_match_to_approval() {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools: {}
+exec_grants:
+  - program: "/usr/bin/git"
+approval_required_for: ["any_exec"]
+"#;
+    let p = Policy::from_yaml_bytes(yaml.as_bytes()).unwrap();
+    assert!(p.check_exec(Path::new("/usr/bin/git")).is_approval());
+    // any_exec must NOT promote a deny into approval.
+    assert!(p.check_exec(Path::new("/usr/bin/curl")).is_deny());
 }
 
 #[test]

--- a/pkg/manifest/decide.go
+++ b/pkg/manifest/decide.go
@@ -1,6 +1,10 @@
 package manifest
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
 
 // DecisionKind mirrors aegis_policy::Decision in Rust. The cross-language
 // conformance harness (issue #16) asserts both engines produce the same
@@ -66,7 +70,7 @@ func (m *Manifest) Decide(q Query) Decision {
 	case QueryNetworkInbound:
 		return m.decideNetwork(false, q.Host, q.Port, q.Protocol)
 	case QueryExec:
-		return denyDecision("exec is not grantable in manifest schema v1; future schema will add exec_grants")
+		return m.decideExec(q.ResourceURI)
 	default:
 		return denyDecision(fmt.Sprintf("unknown query kind %q", q.Kind))
 	}
@@ -103,6 +107,31 @@ func (m *Manifest) decideFsDelete(uri string) Decision {
 		return m.writeGrantDecision(uri, g, ActionDelete)
 	}
 	return denyDecision(fmt.Sprintf("filesystem delete of %s not granted by any write_grant", uri))
+}
+
+func (m *Manifest) decideExec(program string) Decision {
+	matched := false
+	for _, g := range m.ExecGrants {
+		if programMatches(g.Program, program) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return denyDecision(fmt.Sprintf("exec of %s not granted by manifest", program))
+	}
+	return upgradeForApproval(allowDecision(), m.ApprovalRequiredFor, ApprovalAnyExec,
+		"any_exec requires approval")
+}
+
+// programMatches: slash-bearing grants are absolute paths matched
+// exactly; bare basenames match the query's path.Base. MUST stay in
+// lockstep with Rust's program_matches.
+func programMatches(grant, query string) bool {
+	if strings.Contains(grant, "/") {
+		return grant == query
+	}
+	return filepath.Base(query) == grant
 }
 
 func (m *Manifest) decideNetwork(outbound bool, host string, port int, protocol string) Decision {

--- a/pkg/manifest/extends.go
+++ b/pkg/manifest/extends.go
@@ -134,6 +134,24 @@ func narrowsParent(child, parent *Manifest, childPath, parentPath string) error 
 		}
 	}
 
+	// exec_grants narrowing: every child program must exist in parent.
+	// args_match: if parent has no args_match, child can have any (parent
+	// is wider). If parent has args_match, child must have exactly the
+	// same string (regex inclusion is undecidable in general; exact
+	// match is the defensible v1 rule). Documented in the PR for #15.
+	for _, ce := range child.ExecGrants {
+		pe := findExecGrant(parent.ExecGrants, ce.Program)
+		if pe == nil {
+			return mk(fmt.Sprintf("exec_grants[%s]", ce.Program),
+				fmt.Sprintf("program %q is not granted by parent", ce.Program))
+		}
+		if pe.ArgsMatch != "" && pe.ArgsMatch != ce.ArgsMatch {
+			return mk(fmt.Sprintf("exec_grants[%s].args_match", ce.Program),
+				fmt.Sprintf("parent restricts args_match to %q; child must match exactly (got %q)",
+					pe.ArgsMatch, ce.ArgsMatch))
+		}
+	}
+
 	// approval_required_for runs the *opposite* direction: child cannot
 	// drop a class the parent insists on. Narrowing here means "at least
 	// as strict", so child ⊇ parent.
@@ -144,6 +162,15 @@ func narrowsParent(child, parent *Manifest, childPath, parentPath string) error 
 		}
 	}
 
+	return nil
+}
+
+func findExecGrant(grants []ExecGrant, program string) *ExecGrant {
+	for i := range grants {
+		if grants[i].Program == program {
+			return &grants[i]
+		}
+	}
 	return nil
 }
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -280,6 +280,38 @@ tools: {}
 	}
 }
 
+func TestExecGrantsNarrowingRejected(t *testing.T) {
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "parent.yaml")
+	child := filepath.Join(dir, "child.yaml")
+	mustWrite(t, parent, `schemaVersion: "1"
+agent: { name: "p", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/p/1" }
+tools: {}
+exec_grants:
+  - program: "/usr/bin/git"
+`)
+	mustWrite(t, child, `schemaVersion: "1"
+agent: { name: "c", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/c/1" }
+extends: ["parent.yaml"]
+tools: {}
+exec_grants:
+  - program: "/usr/bin/curl"
+`)
+	_, err := LoadResolved(child)
+	if err == nil {
+		t.Fatal("expected NarrowingError for new exec program")
+	}
+	var ne *NarrowingError
+	if !errors.As(err, &ne) {
+		t.Fatalf("error type: %T", err)
+	}
+	if !strings.HasPrefix(ne.Field, "exec_grants[") {
+		t.Errorf("field: %q", ne.Field)
+	}
+}
+
 func mustWrite(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {

--- a/pkg/manifest/schema_v1.json
+++ b/pkg/manifest/schema_v1.json
@@ -91,6 +91,12 @@
         ]
       },
       "uniqueItems": true
+    },
+    "exec_grants": {
+      "type": "array",
+      "description": "Programs the agent may exec (F2 in PRD §4). Closed-by-default — without an entry, exec is denied. Per-issue #15.",
+      "items": { "$ref": "#/definitions/execGrant" },
+      "uniqueItems": true
     }
   },
   "definitions": {
@@ -151,6 +157,23 @@
             "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
           },
           "uniqueItems": true
+        }
+      }
+    },
+    "execGrant": {
+      "type": "object",
+      "required": ["program"],
+      "additionalProperties": false,
+      "properties": {
+        "program": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path (e.g. /usr/bin/git) or bare basename (e.g. ffmpeg). Bare basename matches any path whose basename is equal."
+        },
+        "args_match": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional regex applied to the joined argv (space-separated). Engine support is staged: parsed in Phase 1, enforced when the runtime ships."
         }
       }
     },

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -20,6 +20,7 @@ type Manifest struct {
 	Tools               Tools           `yaml:"tools" json:"tools"`
 	WriteGrants         []WriteGrant    `yaml:"write_grants,omitempty" json:"write_grants,omitempty"`
 	ApprovalRequiredFor []ApprovalClass `yaml:"approval_required_for,omitempty" json:"approval_required_for,omitempty"`
+	ExecGrants          []ExecGrant     `yaml:"exec_grants,omitempty" json:"exec_grants,omitempty"`
 }
 
 type Agent struct {
@@ -81,6 +82,15 @@ type WriteGrant struct {
 	Duration         string   `yaml:"duration,omitempty" json:"duration,omitempty"`
 	ExpiresAt        string   `yaml:"expires_at,omitempty" json:"expires_at,omitempty"`
 	ApprovalRequired bool     `yaml:"approval_required,omitempty" json:"approval_required,omitempty"`
+}
+
+// ExecGrant is one entry in `exec_grants`. `Program` may be an absolute
+// path (matched exactly) or a bare basename (matches any path with that
+// file name). `ArgsMatch` is parsed in Phase 1 and enforced once the
+// runtime can pass argv to the gate.
+type ExecGrant struct {
+	Program   string `yaml:"program" json:"program"`
+	ArgsMatch string `yaml:"args_match,omitempty" json:"args_match,omitempty"`
 }
 
 // ApprovalClass enumerates the valid string values of `approval_required_for`.

--- a/schemas/manifest/v1/examples/agent-with-exec.manifest.yaml
+++ b/schemas/manifest/v1/examples/agent-with-exec.manifest.yaml
@@ -1,0 +1,25 @@
+# Example Permission Manifest — agent allowed to exec a single program.
+# Per ADR-004 (F2). Demonstrates exec_grants per issue #15.
+
+schemaVersion: "1"
+agent:
+  name: "media-transcoder"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/transcoder/inst-001"
+tools:
+  filesystem:
+    read:
+      - "/data/media/in"
+    write:
+      - "/data/media/out"
+  network:
+    outbound: deny
+    inbound: deny
+write_grants: []
+exec_grants:
+  # Absolute path — only this binary, anywhere on $PATH won't substitute.
+  - program: "/usr/bin/ffmpeg"
+    args_match: "^-i .+ -c:v "
+approval_required_for:
+  - "any_exec"

--- a/schemas/manifest/v1/manifest.schema.json
+++ b/schemas/manifest/v1/manifest.schema.json
@@ -91,6 +91,12 @@
         ]
       },
       "uniqueItems": true
+    },
+    "exec_grants": {
+      "type": "array",
+      "description": "Programs the agent may exec (F2 in PRD §4). Closed-by-default — without an entry, exec is denied. Per-issue #15.",
+      "items": { "$ref": "#/definitions/execGrant" },
+      "uniqueItems": true
     }
   },
   "definitions": {
@@ -151,6 +157,23 @@
             "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
           },
           "uniqueItems": true
+        }
+      }
+    },
+    "execGrant": {
+      "type": "object",
+      "required": ["program"],
+      "additionalProperties": false,
+      "properties": {
+        "program": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path (e.g. /usr/bin/git) or bare basename (e.g. ffmpeg). Bare basename matches any path whose basename is equal."
+        },
+        "args_match": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional regex applied to the joined argv (space-separated). Engine support is staged: parsed in Phase 1, enforced when the runtime ships."
         }
       }
     },

--- a/tests/conformance/cases.json
+++ b/tests/conformance/cases.json
@@ -105,9 +105,51 @@
       "expected": "deny"
     },
     {
-      "name": "exec_is_always_denied_in_v1",
+      "name": "exec_denied_when_no_grants",
       "manifest": "../../schemas/manifest/v1/examples/read-only-research.manifest.yaml",
       "query": { "kind": "exec", "resource_uri": "/usr/bin/ffmpeg" },
+      "expected": "deny"
+    },
+    {
+      "name": "exec_basename_grant_matches_any_path",
+      "manifest": "manifests/exec-grant.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/usr/bin/ffmpeg" },
+      "expected": "allow"
+    },
+    {
+      "name": "exec_basename_grant_matches_alt_path",
+      "manifest": "manifests/exec-grant.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/snap/bin/ffmpeg" },
+      "expected": "allow"
+    },
+    {
+      "name": "exec_basename_grant_denies_other_program",
+      "manifest": "manifests/exec-grant.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/usr/bin/curl" },
+      "expected": "deny"
+    },
+    {
+      "name": "exec_grant_with_any_exec_upgrades_to_approval",
+      "manifest": "manifests/exec-with-approval.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/usr/bin/git" },
+      "expected": "require_approval"
+    },
+    {
+      "name": "exec_any_exec_does_not_promote_a_deny",
+      "manifest": "manifests/exec-with-approval.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/usr/bin/curl" },
+      "expected": "deny"
+    },
+    {
+      "name": "exec_absolute_path_grant_matches_exact",
+      "manifest": "../../schemas/manifest/v1/examples/agent-with-exec.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/usr/bin/ffmpeg" },
+      "expected": "require_approval"
+    },
+    {
+      "name": "exec_absolute_path_grant_rejects_alt_location",
+      "manifest": "../../schemas/manifest/v1/examples/agent-with-exec.manifest.yaml",
+      "query": { "kind": "exec", "resource_uri": "/usr/local/bin/ffmpeg" },
       "expected": "deny"
     }
   ]

--- a/tests/conformance/manifests/exec-grant.manifest.yaml
+++ b/tests/conformance/manifests/exec-grant.manifest.yaml
@@ -1,0 +1,12 @@
+# Conformance fixture: a basename exec_grant. Used to exercise
+# basename-vs-absolute matching and the closed-by-default deny path.
+
+schemaVersion: "1"
+agent:
+  name: "exec-grant-test"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/exec-test/inst-001"
+tools: {}
+exec_grants:
+  - program: "ffmpeg"

--- a/tests/conformance/manifests/exec-with-approval.manifest.yaml
+++ b/tests/conformance/manifests/exec-with-approval.manifest.yaml
@@ -1,0 +1,13 @@
+# Conformance fixture: matched exec_grant + any_exec approval upgrade.
+
+schemaVersion: "1"
+agent:
+  name: "exec-approval-test"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/exec-approval/inst-001"
+tools: {}
+exec_grants:
+  - program: "/usr/bin/git"
+approval_required_for:
+  - "any_exec"


### PR DESCRIPTION
## Summary
- Adds optional \`exec_grants\` to the v1 manifest schema, with \`execGrant\` carrying \`program\` (path or basename) + optional \`args_match\` regex.
- Both engines (Go \`pkg/manifest.Decide\` and Rust \`aegis_policy::Policy::check_exec\`) replace their placeholder unconditional-deny with a closed-by-default lookup.
- Conformance harness gains 8 new rows; both sides must agree.

## Compatibility Charter decision
Stays on \`schemaVersion: "1"\`. The Charter explicitly allows \"adding new optional properties\" within a frozen surface (\`docs/COMPATIBILITY_CHARTER.md\` §\"Allowed evolution\"). No version bump needed; old manifests still load unchanged, new manifests opt in by adding the field.

## Acceptance criteria mapping (issue #15)
- [x] Schema bump → in-place v1 extension per Charter; no \`schemaVersion: "1.1"\` cut.
- [x] \`program\` + optional \`args_match\` regex on each grant.
- [x] \`pkg/manifest\` parses + validates the new field (drift-test against canonical schema stays green).
- [x] \`Policy::check_exec\` looks up the grant; absolute path → exact match, basename → \`file_name\` match.
- [x] \`approval_required_for: [any_exec]\` upgrades Allow → RequireApproval.
- [x] Tests cover matched (Allow + Approval), unmatched (Deny), basename-anywhere matching, and the negative that approval doesn't promote a deny.
- [x] \`schemas/manifest/v1/examples/agent-with-exec.manifest.yaml\` lands as the canonical exec example.

## Why exact-string args_match for narrowing
Regex inclusion is undecidable in general, and even tractable subsets of PCRE need a per-engine implementation. The narrowing rule \"parent.args_match must equal child.args_match (or be empty)\" is conservative and obviously correct: a child can't widen what the parent restricts. A future schema bump could introduce a more expressive structural rule.

## args_match enforcement is staged
Phase 1 (this PR): schema accepts and parsers retain \`args_match\`. The decision engines do NOT yet evaluate the regex against argv — there's no runtime to feed it argv. Phase 2 lands when the runtime exists.

## Test plan
- [ ] Schemas workflow compiles the updated JSON Schema.
- [ ] Go workflow: \`TestExecGrantsNarrowingRejected\` plus the embedded-schema drift test stay green.
- [ ] Rust workflow: four new exec tests in \`crates/policy/tests/integration.rs\`.
- [ ] Conformance workflow: 8 new rows pass on both Go and Rust.

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)