### PR TITLE
feat(identity): C ABI + Go cgo bindings for in-process SVID issuance (issue #17)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,16 @@ jobs:
           go-version: '1.23'
           cache: true
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build aegis-identity cdylib
+        # pkg/identity/ffi cgo-links against libaegis_identity.so produced
+        # by the cdylib crate-type. Build it before any go test/vet so the
+        # link is satisfied.
+        run: cargo build -p aegis-identity --release
+
       - name: Tidy
         # Phase 1a doesn't commit go.sum yet — `go mod tidy` populates it
         # from the proxy on every run. Once the Go surface stabilizes, lock
@@ -26,12 +36,22 @@ jobs:
         run: go mod tidy
 
       - name: Vet
+        env:
+          CGO_LDFLAGS: -L${{ github.workspace }}/target/release
+          CGO_CFLAGS: -I${{ github.workspace }}/pkg/identity/ffi
         run: go vet ./...
 
       - name: Test
+        env:
+          CGO_LDFLAGS: -L${{ github.workspace }}/target/release
+          CGO_CFLAGS: -I${{ github.workspace }}/pkg/identity/ffi
+          LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
         run: go test -race -count=1 ./...
 
       - name: golangci-lint
+        env:
+          CGO_LDFLAGS: -L${{ github.workspace }}/target/release
+          CGO_CFLAGS: -I${{ github.workspace }}/pkg/identity/ffi
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.62.2

--- a/crates/identity/Cargo.toml
+++ b/crates/identity/Cargo.toml
@@ -10,6 +10,13 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[lib]
+# rlib for downstream Rust consumers (policy, cli, tests). cdylib +
+# staticlib for the Go FFI surface (issue #17). Building all three by
+# default keeps `cargo test` fast — pay for the cdylib only when
+# `cargo build` is invoked.
+crate-type = ["lib", "cdylib", "staticlib"]
+
 [dependencies]
 rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem", "ring", "x509-parser"] }
 x509-parser = "0.16"

--- a/crates/identity/src/ffi.rs
+++ b/crates/identity/src/ffi.rs
@@ -77,10 +77,10 @@ pub unsafe extern "C" fn aegis_identity_ca_init(
     dir: *const c_char,
     trust_domain: *const c_char,
 ) -> *mut LocalCa {
-    let Some(dir) = unsafe { c_str(dir, "dir") } else {
+    let Some(dir) = (unsafe { c_str(dir, "dir") }) else {
         return ptr::null_mut();
     };
-    let Some(td) = unsafe { c_str(trust_domain, "trust_domain") } else {
+    let Some(td) = (unsafe { c_str(trust_domain, "trust_domain") }) else {
         return ptr::null_mut();
     };
     match LocalCa::init(Path::new(dir), td) {
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn aegis_identity_ca_init(
 /// `dir` must be a NUL-terminated UTF-8 string.
 #[no_mangle]
 pub unsafe extern "C" fn aegis_identity_ca_load(dir: *const c_char) -> *mut LocalCa {
-    let Some(dir) = unsafe { c_str(dir, "dir") } else {
+    let Some(dir) = (unsafe { c_str(dir, "dir") }) else {
         return ptr::null_mut();
     };
     match LocalCa::load(Path::new(dir)) {

--- a/crates/identity/src/ffi.rs
+++ b/crates/identity/src/ffi.rs
@@ -1,0 +1,279 @@
+//! C ABI for `aegis-identity` — used by the Go control plane to issue
+//! workload identity SVIDs in-process (issue #17).
+//!
+//! The header at `pkg/identity/ffi/aegis_identity.h` is the canonical
+//! C-side declaration; this module's `#[no_mangle] extern "C"` functions
+//! must match it. A drift between the two surfaces as a Go cgo build
+//! error.
+//!
+//! ## Memory ownership rules
+//!
+//! - `aegis_identity_ca_init` / `aegis_identity_ca_load` return an opaque
+//!   pointer the caller MUST eventually free with
+//!   `aegis_identity_ca_free`.
+//! - `aegis_identity_issue_svid` populates the caller-provided `out_svid`
+//!   with three heap-allocated `char*` strings. The caller MUST call
+//!   `aegis_identity_svid_clear` to release them.
+//! - `aegis_identity_last_error` returns a pointer into thread-local
+//!   storage. The caller MUST NOT free it; the lifetime ends at the
+//!   next FFI call from the same thread.
+//!
+//! ## Thread safety
+//!
+//! `LocalCa::issue_svid` takes `&self`, so concurrent issuance against
+//! the same CA pointer is sound. `LAST_ERROR` is per-thread, so error
+//! reads are race-free as long as each caller reads on the same thread
+//! that issued the failing call.
+
+use std::cell::RefCell;
+use std::ffi::{c_char, c_int, CStr, CString};
+use std::path::Path;
+use std::ptr;
+
+use crate::svid::{Digest, DigestTriple};
+use crate::LocalCa;
+
+pub const AEGIS_OK: c_int = 0;
+pub const AEGIS_ERR_NULL: c_int = -1;
+pub const AEGIS_ERR_INVALID_UTF8: c_int = -2;
+pub const AEGIS_ERR_LOAD: c_int = -3;
+pub const AEGIS_ERR_ISSUE: c_int = -4;
+pub const AEGIS_ERR_INTERNAL: c_int = -5;
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
+}
+
+fn set_last_error(msg: impl Into<String>) {
+    let s = msg.into();
+    let cs = CString::new(s).unwrap_or_else(|_| {
+        // The only way CString::new fails is interior NULs — replace with
+        // a generic message so the caller still gets *something*.
+        CString::new("aegis_identity: error message contained NULs").unwrap_or_default()
+    });
+    LAST_ERROR.with(|e| *e.borrow_mut() = Some(cs));
+}
+
+/// Returns the last error from the calling thread, or NULL if none.
+/// The pointer is owned by Rust thread-local storage; do NOT free it.
+#[no_mangle]
+pub extern "C" fn aegis_identity_last_error() -> *const c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow()
+            .as_ref()
+            .map(|cs| cs.as_ptr())
+            .unwrap_or(ptr::null())
+    })
+}
+
+/// Initialize a new CA at `dir` for `trust_domain`. Refuses to overwrite
+/// an existing CA (per `LocalCa::init`).
+///
+/// # Safety
+///
+/// `dir` and `trust_domain` must be NUL-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn aegis_identity_ca_init(
+    dir: *const c_char,
+    trust_domain: *const c_char,
+) -> *mut LocalCa {
+    let Some(dir) = unsafe { c_str(dir, "dir") } else {
+        return ptr::null_mut();
+    };
+    let Some(td) = unsafe { c_str(trust_domain, "trust_domain") } else {
+        return ptr::null_mut();
+    };
+    match LocalCa::init(Path::new(dir), td) {
+        Ok(ca) => Box::into_raw(Box::new(ca)),
+        Err(e) => {
+            set_last_error(format!("init CA: {e}"));
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Load an existing CA from `dir`.
+///
+/// # Safety
+///
+/// `dir` must be a NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn aegis_identity_ca_load(dir: *const c_char) -> *mut LocalCa {
+    let Some(dir) = unsafe { c_str(dir, "dir") } else {
+        return ptr::null_mut();
+    };
+    match LocalCa::load(Path::new(dir)) {
+        Ok(ca) => Box::into_raw(Box::new(ca)),
+        Err(e) => {
+            set_last_error(format!("load CA: {e}"));
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Free a CA handle returned by `ca_init` or `ca_load`. Safe to call
+/// with NULL (no-op).
+///
+/// # Safety
+///
+/// `ca` must have come from `aegis_identity_ca_init` or
+/// `aegis_identity_ca_load` and must not have been previously freed.
+#[no_mangle]
+pub unsafe extern "C" fn aegis_identity_ca_free(ca: *mut LocalCa) {
+    if !ca.is_null() {
+        drop(unsafe { Box::from_raw(ca) });
+    }
+}
+
+/// Output struct for `issue_svid`. All three pointers are heap-allocated
+/// NUL-terminated UTF-8 strings, freed via `aegis_identity_svid_clear`.
+#[repr(C)]
+pub struct AegisSvid {
+    pub cert_pem: *mut c_char,
+    pub key_pem: *mut c_char,
+    pub spiffe_id: *mut c_char,
+}
+
+/// Issue an X.509-SVID. Digest pointers must each point to 32 bytes.
+///
+/// Returns `AEGIS_OK` on success and populates `*out_svid`. On failure
+/// returns a negative code; the caller can retrieve a human-readable
+/// message via `aegis_identity_last_error`.
+///
+/// # Safety
+///
+/// All pointers must be valid for the duration of the call.
+/// `model_digest`, `manifest_digest`, `config_digest` must each point
+/// to 32 readable bytes. `workload` and `instance` must be
+/// NUL-terminated UTF-8. `out_svid` must point to a writable
+/// `AegisSvid`.
+#[no_mangle]
+pub unsafe extern "C" fn aegis_identity_issue_svid(
+    ca: *const LocalCa,
+    workload: *const c_char,
+    instance: *const c_char,
+    model_digest: *const u8,
+    manifest_digest: *const u8,
+    config_digest: *const u8,
+    out_svid: *mut AegisSvid,
+) -> c_int {
+    if ca.is_null()
+        || workload.is_null()
+        || instance.is_null()
+        || model_digest.is_null()
+        || manifest_digest.is_null()
+        || config_digest.is_null()
+        || out_svid.is_null()
+    {
+        set_last_error("null argument");
+        return AEGIS_ERR_NULL;
+    }
+
+    let Some(workload) = (unsafe { c_str(workload, "workload") }) else {
+        return AEGIS_ERR_INVALID_UTF8;
+    };
+    let Some(instance) = (unsafe { c_str(instance, "instance") }) else {
+        return AEGIS_ERR_INVALID_UTF8;
+    };
+
+    let triple = unsafe {
+        DigestTriple {
+            model: read_digest(model_digest),
+            manifest: read_digest(manifest_digest),
+            config: read_digest(config_digest),
+        }
+    };
+
+    let svid = match unsafe { &*ca }.issue_svid(workload, instance, triple) {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(format!("issue: {e}"));
+            return AEGIS_ERR_ISSUE;
+        }
+    };
+
+    let cert = match CString::new(svid.cert_pem) {
+        Ok(c) => c.into_raw(),
+        Err(e) => {
+            set_last_error(format!("cert PEM contained NULs: {e}"));
+            return AEGIS_ERR_INTERNAL;
+        }
+    };
+    let key = match CString::new(svid.key_pem) {
+        Ok(c) => c.into_raw(),
+        Err(e) => {
+            unsafe { drop(CString::from_raw(cert)) };
+            set_last_error(format!("key PEM contained NULs: {e}"));
+            return AEGIS_ERR_INTERNAL;
+        }
+    };
+    let sid = match CString::new(svid.spiffe_id.uri()) {
+        Ok(c) => c.into_raw(),
+        Err(e) => {
+            unsafe {
+                drop(CString::from_raw(cert));
+                drop(CString::from_raw(key));
+            }
+            set_last_error(format!("spiffe id contained NULs: {e}"));
+            return AEGIS_ERR_INTERNAL;
+        }
+    };
+
+    unsafe {
+        *out_svid = AegisSvid {
+            cert_pem: cert,
+            key_pem: key,
+            spiffe_id: sid,
+        };
+    }
+    AEGIS_OK
+}
+
+/// Free the strings inside an `AegisSvid`. Sets each pointer back to
+/// NULL so a second call is a no-op. The caller still owns the
+/// `AegisSvid` struct itself.
+///
+/// # Safety
+///
+/// `svid` must point to a valid `AegisSvid` previously populated by
+/// `aegis_identity_issue_svid`. Must not be called twice on the same
+/// pointers without an intervening successful issue.
+#[no_mangle]
+pub unsafe extern "C" fn aegis_identity_svid_clear(svid: *mut AegisSvid) {
+    if svid.is_null() {
+        return;
+    }
+    let s = unsafe { &mut *svid };
+    if !s.cert_pem.is_null() {
+        unsafe { drop(CString::from_raw(s.cert_pem)) };
+        s.cert_pem = ptr::null_mut();
+    }
+    if !s.key_pem.is_null() {
+        unsafe { drop(CString::from_raw(s.key_pem)) };
+        s.key_pem = ptr::null_mut();
+    }
+    if !s.spiffe_id.is_null() {
+        unsafe { drop(CString::from_raw(s.spiffe_id)) };
+        s.spiffe_id = ptr::null_mut();
+    }
+}
+
+unsafe fn c_str<'a>(p: *const c_char, label: &'static str) -> Option<&'a str> {
+    if p.is_null() {
+        set_last_error(format!("{label} is NULL"));
+        return None;
+    }
+    match unsafe { CStr::from_ptr(p) }.to_str() {
+        Ok(s) => Some(s),
+        Err(e) => {
+            set_last_error(format!("{label} not valid UTF-8: {e}"));
+            None
+        }
+    }
+}
+
+unsafe fn read_digest(p: *const u8) -> Digest {
+    let mut buf = [0u8; 32];
+    unsafe { std::ptr::copy_nonoverlapping(p, buf.as_mut_ptr(), 32) };
+    Digest(buf)
+}

--- a/crates/identity/src/lib.rs
+++ b/crates/identity/src/lib.rs
@@ -16,6 +16,7 @@
 mod binding;
 mod ca;
 pub mod error;
+pub mod ffi;
 mod spiffe;
 mod svid;
 

--- a/pkg/identity/ffi/aegis_identity.go
+++ b/pkg/identity/ffi/aegis_identity.go
@@ -1,0 +1,138 @@
+// Package ffi exposes the Rust `aegis-identity` crate's C ABI to Go via
+// cgo. Used by the control plane to issue X.509-SVIDs in-process,
+// avoiding the latency of shelling out to `aegis identity issue`.
+//
+// The Rust side is at crates/identity/src/ffi.rs; the C declarations
+// the cgo preamble #includes live at pkg/identity/ffi/aegis_identity.h.
+//
+// Linking:
+//
+//	cgo searches for libaegis_identity at link time. Set CGO_LDFLAGS or
+//	rely on the workspace's `target/release` (or debug) directory. The
+//	conformance/Go workflows do `cargo build -p aegis-identity --release`
+//	first, then run go test with LD_LIBRARY_PATH pointing at target/release.
+package ffi
+
+/*
+#cgo CFLAGS: -I${SRCDIR}
+#cgo LDFLAGS: -laegis_identity
+#include <stdlib.h>
+#include "aegis_identity.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// CA wraps an opaque pointer to a loaded `LocalCa`. Always call Close
+// to release the underlying Rust allocation; SetFinalizer handles the
+// case where the caller forgets, but explicit Close is preferred.
+type CA struct {
+	handle *C.AegisLocalCa
+}
+
+// Init creates a new CA at `dir` for `trustDomain`. Refuses to overwrite
+// an existing CA (matches Rust's LocalCa::init).
+func Init(dir, trustDomain string) (*CA, error) {
+	cdir := C.CString(dir)
+	defer C.free(unsafe.Pointer(cdir))
+	ctd := C.CString(trustDomain)
+	defer C.free(unsafe.Pointer(ctd))
+
+	handle := C.aegis_identity_ca_init(cdir, ctd)
+	if handle == nil {
+		return nil, lastError()
+	}
+	return wrapCA(handle), nil
+}
+
+// Load reconstitutes an existing CA from disk.
+func Load(dir string) (*CA, error) {
+	cdir := C.CString(dir)
+	defer C.free(unsafe.Pointer(cdir))
+
+	handle := C.aegis_identity_ca_load(cdir)
+	if handle == nil {
+		return nil, lastError()
+	}
+	return wrapCA(handle), nil
+}
+
+// Close releases the Rust-side CA allocation. Idempotent.
+func (c *CA) Close() {
+	if c == nil || c.handle == nil {
+		return
+	}
+	C.aegis_identity_ca_free(c.handle)
+	c.handle = nil
+	runtime.SetFinalizer(c, nil)
+}
+
+func wrapCA(handle *C.AegisLocalCa) *CA {
+	c := &CA{handle: handle}
+	runtime.SetFinalizer(c, func(c *CA) { c.Close() })
+	return c
+}
+
+// Digests carries the (model, manifest, config) SHA-256 triple bound
+// into every issued SVID per ADR-003 (F1).
+type Digests struct {
+	Model    [32]byte
+	Manifest [32]byte
+	Config   [32]byte
+}
+
+// SVID is the typed result of a successful Issue. Strings are owned by
+// Go; the Rust-side allocations have already been freed by the time
+// Issue returns.
+type SVID struct {
+	CertPEM  string
+	KeyPEM   string
+	SpiffeID string
+}
+
+// Issue stamps a fresh SVID for the given workload + instance, binding
+// the digest triple into the cert's custom extension. Safe to call
+// concurrently against the same CA (Rust side takes &self).
+func (c *CA) Issue(workload, instance string, digests Digests) (*SVID, error) {
+	if c == nil || c.handle == nil {
+		return nil, errors.New("aegis_identity: Issue called on closed CA")
+	}
+	cw := C.CString(workload)
+	defer C.free(unsafe.Pointer(cw))
+	ci := C.CString(instance)
+	defer C.free(unsafe.Pointer(ci))
+
+	var out C.AegisSvid
+	rc := C.aegis_identity_issue_svid(
+		c.handle,
+		cw,
+		ci,
+		(*C.uint8_t)(unsafe.Pointer(&digests.Model[0])),
+		(*C.uint8_t)(unsafe.Pointer(&digests.Manifest[0])),
+		(*C.uint8_t)(unsafe.Pointer(&digests.Config[0])),
+		&out,
+	)
+	if rc != C.AEGIS_OK {
+		return nil, lastError()
+	}
+	defer C.aegis_identity_svid_clear(&out)
+
+	return &SVID{
+		CertPEM:  C.GoString(out.cert_pem),
+		KeyPEM:   C.GoString(out.key_pem),
+		SpiffeID: C.GoString(out.spiffe_id),
+	}, nil
+}
+
+func lastError() error {
+	cs := C.aegis_identity_last_error()
+	if cs == nil {
+		return errors.New("aegis_identity: unknown FFI error")
+	}
+	return fmt.Errorf("aegis_identity: %s", C.GoString(cs))
+}

--- a/pkg/identity/ffi/aegis_identity.h
+++ b/pkg/identity/ffi/aegis_identity.h
@@ -1,0 +1,72 @@
+/*
+ * aegis_identity.h — C ABI for the Rust `aegis-identity` crate.
+ *
+ * Match this header to crates/identity/src/ffi.rs. A drift between the
+ * two surfaces as a Go cgo build error.
+ *
+ * Memory ownership rules:
+ *
+ *   - aegis_identity_ca_init / aegis_identity_ca_load return an opaque
+ *     pointer the caller MUST eventually pass to aegis_identity_ca_free.
+ *   - aegis_identity_issue_svid populates the caller-provided AegisSvid
+ *     with three heap-allocated NUL-terminated strings. Caller MUST
+ *     call aegis_identity_svid_clear to release them.
+ *   - aegis_identity_last_error returns a pointer into thread-local
+ *     storage. Caller MUST NOT free; lifetime ends at the next FFI
+ *     call from the same thread.
+ *
+ * Thread safety:
+ *
+ *   LocalCa::issue_svid takes &self in Rust, so concurrent issuance
+ *   against the same CA pointer is sound. last_error is per-thread.
+ */
+
+#ifndef AEGIS_IDENTITY_H
+#define AEGIS_IDENTITY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle for a loaded local CA. */
+typedef struct AegisLocalCa AegisLocalCa;
+
+typedef struct {
+    char* cert_pem;   /* free via aegis_identity_svid_clear */
+    char* key_pem;    /* free via aegis_identity_svid_clear */
+    char* spiffe_id;  /* free via aegis_identity_svid_clear */
+} AegisSvid;
+
+#define AEGIS_OK              0
+#define AEGIS_ERR_NULL        (-1)
+#define AEGIS_ERR_INVALID_UTF8 (-2)
+#define AEGIS_ERR_LOAD        (-3)
+#define AEGIS_ERR_ISSUE       (-4)
+#define AEGIS_ERR_INTERNAL    (-5)
+
+const char* aegis_identity_last_error(void);
+
+AegisLocalCa* aegis_identity_ca_init(const char* dir, const char* trust_domain);
+AegisLocalCa* aegis_identity_ca_load(const char* dir);
+void          aegis_identity_ca_free(AegisLocalCa* ca);
+
+int aegis_identity_issue_svid(
+    const AegisLocalCa* ca,
+    const char* workload,
+    const char* instance,
+    const uint8_t* model_digest,    /* 32 bytes */
+    const uint8_t* manifest_digest, /* 32 bytes */
+    const uint8_t* config_digest,   /* 32 bytes */
+    AegisSvid* out_svid
+);
+
+void aegis_identity_svid_clear(AegisSvid* svid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AEGIS_IDENTITY_H */

--- a/pkg/identity/ffi/aegis_identity_test.go
+++ b/pkg/identity/ffi/aegis_identity_test.go
@@ -1,0 +1,159 @@
+package ffi
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"net/url"
+	"os"
+	"testing"
+)
+
+// digestBindingOID — placeholder OID matching crates/identity/src/svid.rs
+// (slated for replacement when we register a real OID; the format is
+// what the Compatibility Charter freezes, not the OID itself).
+var digestBindingOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 1}
+
+func TestFFI_RoundTrip(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aegis-ffi-")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	ca, err := Init(dir, "ffi-test.local")
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer ca.Close()
+
+	want := Digests{}
+	for i := range want.Model {
+		want.Model[i] = 0xAA
+		want.Manifest[i] = 0xBB
+		want.Config[i] = 0xCC
+	}
+
+	svid, err := ca.Issue("research", "inst-001", want)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Cert PEM must parse and carry the SPIFFE URI in a SAN entry.
+	block, _ := pem.Decode([]byte(svid.CertPEM))
+	if block == nil {
+		t.Fatal("cert PEM did not decode")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	wantURI := "spiffe://ffi-test.local/agent/research/inst-001"
+	if svid.SpiffeID != wantURI {
+		t.Errorf("returned SpiffeID: got %q want %q", svid.SpiffeID, wantURI)
+	}
+	if !certHasURISAN(cert, wantURI) {
+		t.Errorf("URI SAN %q not found in cert", wantURI)
+	}
+
+	// Digest extension: 96 raw bytes, model||manifest||config.
+	gotDigest := findExtension(cert, digestBindingOID)
+	if gotDigest == nil {
+		t.Fatalf("digest binding extension OID %v not found", digestBindingOID)
+	}
+	if len(gotDigest) != 96 {
+		t.Fatalf("digest binding length: got %d want 96", len(gotDigest))
+	}
+	if !bytes.Equal(gotDigest[:32], want.Model[:]) {
+		t.Errorf("model digest mismatch")
+	}
+	if !bytes.Equal(gotDigest[32:64], want.Manifest[:]) {
+		t.Errorf("manifest digest mismatch")
+	}
+	if !bytes.Equal(gotDigest[64:96], want.Config[:]) {
+		t.Errorf("config digest mismatch")
+	}
+
+	// Key PEM should also decode; we don't need the key value, just the format.
+	if blk, _ := pem.Decode([]byte(svid.KeyPEM)); blk == nil {
+		t.Error("key PEM did not decode")
+	}
+}
+
+func TestFFI_LoadAfterInit(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aegis-ffi-load-")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	caInit, err := Init(dir, "ffi-test.local")
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	caInit.Close()
+
+	caLoad, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer caLoad.Close()
+
+	digests := Digests{}
+	for i := range digests.Model {
+		digests.Model[i] = 0x42
+	}
+	if _, err := caLoad.Issue("research", "inst-load", digests); err != nil {
+		t.Fatalf("Issue after Load: %v", err)
+	}
+}
+
+func TestFFI_LoadMissingDir(t *testing.T) {
+	if _, err := Load("/nonexistent/aegis-ffi-load-test"); err == nil {
+		t.Fatal("expected error loading from missing dir")
+	}
+}
+
+func TestFFI_DoubleInitFails(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aegis-ffi-double-")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	first, err := Init(dir, "ffi-test.local")
+	if err != nil {
+		t.Fatalf("first Init: %v", err)
+	}
+	first.Close()
+
+	if _, err := Init(dir, "ffi-test.local"); err == nil {
+		t.Fatal("expected second Init to fail")
+	}
+}
+
+func certHasURISAN(cert *x509.Certificate, want string) bool {
+	wantURL, err := url.Parse(want)
+	if err != nil {
+		return false
+	}
+	for _, u := range cert.URIs {
+		if u.String() == wantURL.String() {
+			return true
+		}
+	}
+	return false
+}
+
+// findExtension returns the raw extension bytes (the inner content) for
+// the given OID, or nil if the cert doesn't carry it.
+func findExtension(cert *x509.Certificate, oid asn1.ObjectIdentifier) []byte {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oid) {
+			return ext.Value
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- \`crates/identity\` now builds as cdylib + staticlib alongside rlib. New \`ffi.rs\` module exposes a stable C ABI for CA init/load/free + SVID issue/clear + thread-local last-error.
- \`pkg/identity/ffi\` carries a hand-written header and an idiomatic Go cgo wrapper (\`CA\`, \`Issue\`, \`Digests\`, \`SVID\`).
- Go CI builds the Rust cdylib first, then runs \`go vet\` / \`go test\` / \`golangci-lint\` with CGO_LDFLAGS + CGO_CFLAGS + LD_LIBRARY_PATH set.

## Acceptance criteria mapping (issue #17)
- [x] cdylib build target with stable C ABI for load + issue.
- [x] Hand-written header committed at \`pkg/identity/ffi/aegis_identity.h\` (cbindgen automation deferred — signature drift surfaces as a Go cgo compile error, which is the meaningful guard).
- [x] cgo bindings under \`pkg/identity/ffi\` with idiomatic Go (\`Issue(workload, instance, digests) (*SVID, error)\`).
- [x] Memory ownership documented at the top of both Rust ffi.rs and the C header.
- [x] Round-trip test: Go calls Rust → parses returned PEM → SAN URI + digest-binding extension match input.

## Memory ownership rules (mirrored across Rust + C + Go)
| Surface | Allocated by | Freed by |
|---|---|---|
| \`AegisLocalCa*\` | \`ca_init\` / \`ca_load\` (Rust) | \`ca_free\` (caller) |
| \`AegisSvid.cert_pem\` etc | \`issue_svid\` (Rust) | \`svid_clear\` (caller) |
| \`last_error\` returned ptr | thread-local in Rust | NEVER freed by caller |

## Concurrency
\`LocalCa::issue_svid\` takes \`&self\`, so concurrent issuance against the same CA pointer is sound. Go side documents this in \`Issue\` doc comment.

## Why hand-written header (deferred cbindgen)
- The surface is small (5 functions + 1 struct) and stable.
- Cbindgen as a build step adds complexity and a runtime tool dep.
- Drift detection is automatic: if Rust changes a signature, the Go cgo compile fails the next CI run. That's the same guarantee cbindgen + a check-in-CI pattern would give us.
- We can switch later if the surface grows past ~10 functions.

## Test plan
- [ ] Rust workflow: cdylib + rlib + staticlib all build.
- [ ] Go workflow: \`cargo build -p aegis-identity --release\` succeeds, then \`go test ./pkg/identity/...\` runs the cgo round-trip and asserts the SPIFFE URI + digest extension.
- [ ] golangci-lint clean against the cgo file.
- [ ] Conformance workflow (Go validator ↔ Rust enforcer) unaffected — it only touches \`pkg/manifest/...\`.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)