### PR TITLE
feat(inference-engine): Session boot/shutdown lifecycle (issue #24, F0-A)

### DIFF
--- a/crates/inference-engine/Cargo.toml
+++ b/crates/inference-engine/Cargo.toml
@@ -11,3 +11,14 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+aegis-identity = { path = "../identity" }
+aegis-ledger-writer = { path = "../ledger-writer" }
+aegis-policy = { path = "../policy" }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
+serde_json = "1"
+sha2 = "0.10"
+hex = "0.4"
+thiserror = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/inference-engine/src/error.rs
+++ b/crates/inference-engine/src/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("identity: {0}")]
+    Identity(#[from] aegis_identity::Error),
+
+    #[error("policy: {0}")]
+    Policy(#[from] aegis_policy::Error),
+
+    #[error("ledger: {0}")]
+    Ledger(#[from] aegis_ledger_writer::Error),
+
+    #[error("serialization: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    #[error(
+        "issued SVID does not bind the digests we passed to it (digest_field={field:?}); \
+         likely an aegis-identity bug"
+    )]
+    SvidSelfCheck { field: String },
+}

--- a/crates/inference-engine/src/lib.rs
+++ b/crates/inference-engine/src/lib.rs
@@ -1,3 +1,17 @@
 //! Aegis-Node inference engine.
 //!
-//! Rust binding to `llama.cpp` per ADR-002 and ADR-014. Phase 0 scaffold.
+//! Phase 1a deliberately does NOT bind to llama.cpp yet — that lands in
+//! v0.9.0 per ADR-014. What this crate ships now is the *runtime
+//! mediation harness*: a [`Session`] type that wires [`aegis_identity`],
+//! [`aegis_policy`], and [`aegis_ledger_writer`] into a single
+//! boot → mediate → shutdown lifecycle.
+//!
+//! The per-tool-call mediator (rebind → policy → gate → access entry)
+//! lands in F0-B (issue #25); this crate gains a `Mediator` type at
+//! that point.
+
+pub mod error;
+mod session;
+
+pub use error::{Error, Result};
+pub use session::{BootConfig, Session};

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -53,6 +53,18 @@ pub struct Session {
     session_id: String,
 }
 
+impl std::fmt::Debug for Session {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // LedgerWriter holds a BufWriter<File> that isn't Debug; surface
+        // only the operator-meaningful fields.
+        f.debug_struct("Session")
+            .field("session_id", &self.session_id)
+            .field("spiffe_id", &self.spiffe_id)
+            .field("bound_digests", &self.bound_digests)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Session {
     /// Run the boot sequence end-to-end. On any failure the partial
     /// ledger is dropped (LedgerWriter cleans up via close-on-drop).

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -1,0 +1,212 @@
+//! Aegis-Node session lifecycle (F0-A — issue #24).
+//!
+//! `Session` is the runtime's top-level integration object. `boot` reads
+//! a manifest + model + config, computes their SHA-256 digests, gets an
+//! SVID with those digests bound in, opens the Trajectory Ledger, and
+//! emits the `EntryType::SessionStart` entry. `shutdown` writes
+//! `SessionEnd` and returns the chain root hash.
+//!
+//! The mediator (F0-B, #25) sits on top of `Session` and owns the
+//! per-tool-call sequence: rebind → policy → gate → access entry. This
+//! module deliberately does not implement that — boot is its own slice.
+
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+
+use aegis_identity::{
+    verify_digest_binding, Digest, DigestField, DigestTriple, LocalCa, SpiffeId,
+};
+use aegis_ledger_writer::{Entry, EntryType, LedgerWriter};
+use aegis_policy::Policy;
+use chrono::Utc;
+use serde_json::{Map, Value};
+use sha2::{Digest as _, Sha256};
+
+use crate::error::{Error, Result};
+
+/// Inputs to [`Session::boot`].
+#[derive(Debug, Clone)]
+pub struct BootConfig {
+    /// Caller-supplied session identifier (UUIDv7 in production; tests
+    /// pin it for golden output).
+    pub session_id: String,
+    pub manifest_path: PathBuf,
+    pub model_path: PathBuf,
+    /// Optional runtime config; absent → empty-bytes digest.
+    pub config_path: Option<PathBuf>,
+    pub identity_dir: PathBuf,
+    pub workload_name: String,
+    pub instance: String,
+    pub ledger_path: PathBuf,
+}
+
+/// Live agent session: compiled policy, open ledger, issued SVID, the
+/// digest triple bound at boot, and the agent identity hash that flows
+/// into every ledger entry.
+pub struct Session {
+    policy: Policy,
+    ledger: LedgerWriter,
+    svid_cert_pem: String,
+    svid_key_pem: String,
+    bound_digests: DigestTriple,
+    spiffe_id: SpiffeId,
+    agent_identity_hash: [u8; 32],
+    session_id: String,
+}
+
+impl Session {
+    /// Run the boot sequence end-to-end. On any failure the partial
+    /// ledger is dropped (LedgerWriter cleans up via close-on-drop).
+    pub fn boot(cfg: BootConfig) -> Result<Self> {
+        let policy = Policy::from_yaml_file(&cfg.manifest_path)?;
+
+        let model_digest = sha256_file(&cfg.model_path)?;
+        let manifest_digest = sha256_file(&cfg.manifest_path)?;
+        let config_digest = match &cfg.config_path {
+            Some(p) => sha256_file(p)?,
+            None => sha256_bytes(&[]),
+        };
+        let bound_digests = DigestTriple {
+            model: Digest(model_digest),
+            manifest: Digest(manifest_digest),
+            config: Digest(config_digest),
+        };
+
+        let ca = LocalCa::load(&cfg.identity_dir)?;
+        let svid = ca.issue_svid(&cfg.workload_name, &cfg.instance, bound_digests)?;
+
+        // Self-check: the cert we just got back MUST encode the digests
+        // we passed in. If not, aegis-identity has a bug — fail loud.
+        if let Some(mismatch) = verify_digest_binding(&svid.cert_pem, &bound_digests)? {
+            return Err(Error::SvidSelfCheck {
+                field: digest_field_name(mismatch.field).to_string(),
+            });
+        }
+
+        let agent_identity_hash = sha256_bytes(svid.spiffe_id.uri().as_bytes());
+
+        let mut ledger = LedgerWriter::create(&cfg.ledger_path, cfg.session_id.clone())?;
+
+        let mut payload = Map::new();
+        payload.insert(
+            "spiffeId".to_string(),
+            Value::String(svid.spiffe_id.uri()),
+        );
+        payload.insert(
+            "modelDigestHex".to_string(),
+            Value::String(hex::encode(bound_digests.model.0)),
+        );
+        payload.insert(
+            "manifestDigestHex".to_string(),
+            Value::String(hex::encode(bound_digests.manifest.0)),
+        );
+        payload.insert(
+            "configDigestHex".to_string(),
+            Value::String(hex::encode(bound_digests.config.0)),
+        );
+        ledger.append(Entry {
+            session_id: cfg.session_id.clone(),
+            entry_type: EntryType::SessionStart,
+            agent_identity_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+
+        Ok(Self {
+            policy,
+            ledger,
+            svid_cert_pem: svid.cert_pem,
+            svid_key_pem: svid.key_pem,
+            bound_digests,
+            spiffe_id: svid.spiffe_id,
+            agent_identity_hash,
+            session_id: cfg.session_id,
+        })
+    }
+
+    /// Emit `SessionEnd`, close the ledger, and return the chain root
+    /// hash. The root is what an auditor pins to detect tampering.
+    pub fn shutdown(mut self) -> Result<[u8; 32]> {
+        let mut payload = Map::new();
+        payload.insert(
+            "spiffeId".to_string(),
+            Value::String(self.spiffe_id.uri()),
+        );
+        self.ledger.append(Entry {
+            session_id: self.session_id.clone(),
+            entry_type: EntryType::SessionEnd,
+            agent_identity_hash: self.agent_identity_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(self.ledger.close()?)
+    }
+
+    pub fn policy(&self) -> &Policy {
+        &self.policy
+    }
+
+    pub fn spiffe_id(&self) -> &SpiffeId {
+        &self.spiffe_id
+    }
+
+    pub fn agent_identity_hash(&self) -> [u8; 32] {
+        self.agent_identity_hash
+    }
+
+    pub fn bound_digests(&self) -> &DigestTriple {
+        &self.bound_digests
+    }
+
+    pub fn cert_pem(&self) -> &str {
+        &self.svid_cert_pem
+    }
+
+    pub fn key_pem(&self) -> &str {
+        &self.svid_key_pem
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Mutable access for the F0-B mediator and downstream emitters that
+    /// need to append entries.
+    pub fn ledger_writer_mut(&mut self) -> &mut LedgerWriter {
+        &mut self.ledger
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<[u8; 32]> {
+    let f = File::open(path)?;
+    let mut reader = BufReader::new(f);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&hasher.finalize());
+    Ok(out)
+}
+
+fn sha256_bytes(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&hasher.finalize());
+    out
+}
+
+fn digest_field_name(f: DigestField) -> &'static str {
+    match f {
+        DigestField::Model => "model",
+        DigestField::Manifest => "manifest",
+        DigestField::Config => "config",
+    }
+}

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -14,9 +14,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
-use aegis_identity::{
-    verify_digest_binding, Digest, DigestField, DigestTriple, LocalCa, SpiffeId,
-};
+use aegis_identity::{verify_digest_binding, Digest, DigestField, DigestTriple, LocalCa, SpiffeId};
 use aegis_ledger_writer::{Entry, EntryType, LedgerWriter};
 use aegis_policy::Policy;
 use chrono::Utc;
@@ -89,10 +87,7 @@ impl Session {
         let mut ledger = LedgerWriter::create(&cfg.ledger_path, cfg.session_id.clone())?;
 
         let mut payload = Map::new();
-        payload.insert(
-            "spiffeId".to_string(),
-            Value::String(svid.spiffe_id.uri()),
-        );
+        payload.insert("spiffeId".to_string(), Value::String(svid.spiffe_id.uri()));
         payload.insert(
             "modelDigestHex".to_string(),
             Value::String(hex::encode(bound_digests.model.0)),
@@ -129,10 +124,7 @@ impl Session {
     /// hash. The root is what an auditor pins to detect tampering.
     pub fn shutdown(mut self) -> Result<[u8; 32]> {
         let mut payload = Map::new();
-        payload.insert(
-            "spiffeId".to_string(),
-            Value::String(self.spiffe_id.uri()),
-        );
+        payload.insert("spiffeId".to_string(), Value::String(self.spiffe_id.uri()));
         self.ledger.append(Entry {
             session_id: self.session_id.clone(),
             entry_type: EntryType::SessionEnd,

--- a/crates/inference-engine/tests/integration.rs
+++ b/crates/inference-engine/tests/integration.rs
@@ -1,0 +1,176 @@
+//! End-to-end tests for [`Session`] boot/shutdown (issue #24, F0-A).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+
+use aegis_identity::LocalCa;
+use aegis_inference_engine::{BootConfig, Error, Session};
+use aegis_ledger_writer::{verify_file, GENESIS_PREV_HASH};
+use serde_json::Value;
+
+const TRUST_DOMAIN: &str = "session-boot.local";
+
+fn write_minimal_manifest(path: &Path) {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "session-boot", version: "1.0.0" }
+identity: { spiffeId: "spiffe://session-boot.local/agent/research/inst-001" }
+tools:
+  filesystem:
+    read: ["/data"]
+"#;
+    std::fs::write(path, yaml).unwrap();
+}
+
+fn init_ca(dir: &Path) {
+    LocalCa::init(dir, TRUST_DOMAIN).unwrap();
+}
+
+fn boot_cfg(dir: &Path, ca_dir: &Path, session_id: &str) -> BootConfig {
+    let manifest_path = dir.join("manifest.yaml");
+    let model_path = dir.join("model.gguf");
+    let ledger_path = dir.join("ledger.jsonl");
+    write_minimal_manifest(&manifest_path);
+    std::fs::write(&model_path, b"fake-model-bytes-for-test").unwrap();
+
+    BootConfig {
+        session_id: session_id.to_string(),
+        manifest_path,
+        model_path,
+        config_path: None,
+        identity_dir: ca_dir.to_path_buf(),
+        workload_name: "research".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path,
+    }
+}
+
+#[test]
+fn boot_writes_session_start_then_shutdown_writes_session_end() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let cfg = boot_cfg(dir.path(), ca_dir.path(), "session-happy");
+    let ledger_path = cfg.ledger_path.clone();
+
+    let session = Session::boot(cfg).unwrap();
+    let spiffe = session.spiffe_id().uri();
+    assert_eq!(spiffe, "spiffe://session-boot.local/agent/research/inst-001");
+
+    let root = session.shutdown().unwrap();
+    assert_ne!(root, GENESIS_PREV_HASH);
+
+    let summary = verify_file(&ledger_path).unwrap();
+    assert_eq!(summary.entry_count, 2);
+    assert_eq!(summary.session_id.as_deref(), Some("session-happy"));
+    assert_eq!(summary.root_hash_hex, hex::encode(root));
+
+    let content = std::fs::read_to_string(&ledger_path).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    let v0: Value = serde_json::from_str(lines[0]).unwrap();
+    let v1: Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(v0["entryType"], "session_start");
+    assert_eq!(v1["entryType"], "session_end");
+    assert_eq!(v0["spiffeId"].as_str().unwrap(), spiffe);
+    assert_eq!(
+        v0["modelDigestHex"].as_str().unwrap().len(),
+        64,
+        "model digest must be 32-byte hex"
+    );
+    assert_eq!(v0["manifestDigestHex"].as_str().unwrap().len(), 64);
+    assert_eq!(v0["configDigestHex"].as_str().unwrap().len(), 64);
+}
+
+#[test]
+fn missing_model_file_errors_before_ledger_open() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let mut cfg = boot_cfg(dir.path(), ca_dir.path(), "session-no-model");
+    let _ = std::fs::remove_file(&cfg.model_path);
+    cfg.model_path = dir.path().join("does-not-exist.gguf");
+
+    let err = Session::boot(cfg).unwrap_err();
+    assert!(matches!(err, Error::Io(_)), "got {err:?}");
+    // Ledger file must NOT have been created (no partial-state on the
+    // disk for an audit run that never started).
+    assert!(!dir.path().join("ledger.jsonl").exists());
+}
+
+#[test]
+fn ca_not_initialized_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    // Note: ca_dir is empty — no init.
+
+    let cfg = boot_cfg(dir.path(), ca_dir.path(), "session-no-ca");
+    let err = Session::boot(cfg).unwrap_err();
+    assert!(matches!(err, Error::Identity(_)), "got {err:?}");
+}
+
+#[test]
+fn manifest_with_extends_is_rejected_in_phase_1a() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let manifest_path = dir.path().join("manifest.yaml");
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://session-boot.local/agent/x/1" }
+extends: ["base.yaml"]
+tools: {}
+"#;
+    std::fs::write(&manifest_path, yaml).unwrap();
+    std::fs::write(dir.path().join("model.gguf"), b"x").unwrap();
+
+    let cfg = BootConfig {
+        session_id: "session-extends".to_string(),
+        manifest_path,
+        model_path: dir.path().join("model.gguf"),
+        config_path: None,
+        identity_dir: ca_dir.path().to_path_buf(),
+        workload_name: "research".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path: dir.path().join("ledger.jsonl"),
+    };
+    let err = Session::boot(cfg).unwrap_err();
+    assert!(matches!(err, Error::Policy(_)), "got {err:?}");
+}
+
+#[test]
+fn config_path_changes_config_digest() {
+    let dir_a = tempfile::tempdir().unwrap();
+    let ca_dir_a = tempfile::tempdir().unwrap();
+    init_ca(ca_dir_a.path());
+
+    let mut cfg_a = boot_cfg(dir_a.path(), ca_dir_a.path(), "session-a");
+    let cfg_path_a = dir_a.path().join("config.toml");
+    std::fs::write(&cfg_path_a, b"[runtime]\nx = 1\n").unwrap();
+    cfg_a.config_path = Some(cfg_path_a);
+
+    let session_a = Session::boot(cfg_a).unwrap();
+    let digest_a = *session_a.bound_digests();
+    session_a.shutdown().unwrap();
+
+    let dir_b = tempfile::tempdir().unwrap();
+    let ca_dir_b = tempfile::tempdir().unwrap();
+    init_ca(ca_dir_b.path());
+
+    let mut cfg_b = boot_cfg(dir_b.path(), ca_dir_b.path(), "session-b");
+    let cfg_path_b = dir_b.path().join("config.toml");
+    std::fs::write(&cfg_path_b, b"[runtime]\nx = 2\n").unwrap();
+    cfg_b.config_path = Some(cfg_path_b);
+
+    let session_b = Session::boot(cfg_b).unwrap();
+    let digest_b = *session_b.bound_digests();
+    session_b.shutdown().unwrap();
+
+    assert_eq!(digest_a.model, digest_b.model, "model bytes are identical");
+    assert_ne!(
+        digest_a.config, digest_b.config,
+        "different config files must produce different config_digest"
+    );
+}

--- a/crates/inference-engine/tests/integration.rs
+++ b/crates/inference-engine/tests/integration.rs
@@ -56,7 +56,10 @@ fn boot_writes_session_start_then_shutdown_writes_session_end() {
 
     let session = Session::boot(cfg).unwrap();
     let spiffe = session.spiffe_id().uri();
-    assert_eq!(spiffe, "spiffe://session-boot.local/agent/research/inst-001");
+    assert_eq!(
+        spiffe,
+        "spiffe://session-boot.local/agent/research/inst-001"
+    );
 
     let root = session.shutdown().unwrap();
     assert_ne!(root, GENESIS_PREV_HASH);


### PR DESCRIPTION
## Summary
First slice of the F0 runtime umbrella (#23). \`Session::boot\` reads manifest + model + (optional) config, computes SHA-256 of each, gets an SVID with the digest triple bound in, opens the Trajectory Ledger, and emits the \`SessionStart\` entry. \`Session::shutdown\` writes \`SessionEnd\` and returns the chain root hash.

## Acceptance criteria mapping (issue #24)
- [x] New \`Session\` struct in \`crates/inference-engine\` carrying loaded policy, open ledger writer, SVID PEMs, bound digest triple, agent identity hash, session id.
- [x] \`Session::boot(BootConfig) -> Result<Session>\` runs the seven-step orchestration (parse → digest → load CA → issue → verify-self → open ledger → session_start).
- [x] \`Session::shutdown(self) -> Result<[u8; 32]>\` emits SessionEnd, closes the writer, returns root hash.
- [x] Tests: happy-path session_start/session_end shape; missing-model errors before ledger open; CA-not-initialized errors cleanly; manifest with extends rejected (Phase 1a constraint).
- [x] Bonus: \`config_path_changes_config_digest\` proves the digest triple actually depends on config bytes.

## Why crates/inference-engine, not a new crates/runtime
\`Session\` is the runtime's top-level type and that's where llama.cpp lives in v0.9.0 (ADR-014). Adding another crate just to host \`Session\` would split the runtime story across two crates that always compile together. Easier to keep them co-located.

## What's NOT in this PR
- The per-mediation rebind check (boot-time self-check is here; the per-call hook lands with F0-B / #25).
- Any actual model loading. Phase 1a treats the model as opaque bytes; only its SHA-256 matters for binding. Real llama.cpp integration is v0.9.0.
- The mediation loop itself (rebind → policy → gate → access entry). That's #25's job; this PR ships the carrier it'll plug into.

## Test plan
- [ ] CI green on Rust workflow.
- [ ] All 5 integration tests pass.
- [ ] Conformance harness unaffected (this PR doesn't touch \`pkg/manifest\` or the policy decision battery).

Refs #24. Closes after merge; F0-B (#25) is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)