### PR TITLE
docs: update README + TODO to reflect v0.5.0 ship

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,43 @@
 
 Every enterprise wants AI agents. Every enterprise security team blocks them. Aegis-Node is the agent runtime built to survive the security review — so organizations can finally say yes.
 
-**Status:** Phase 0 — Foundations. Substrate scaffolded; schemas, IPC contract, and security primitives in flight. Not yet usable.
+**Status:** Phase 1a complete — [**v0.5.0** *Core Security Primitives*](https://github.com/tosin2013/aegis-node/releases/tag/v0.5.0) (pre-release, 2026-04-29). Working zero-trust runtime end-to-end: identity ([F1](https://github.com/tosin2013/aegis-node/issues?q=is%3Aclosed+label%3AF1)), manifest enforcement ([F2](https://github.com/tosin2013/aegis-node/issues?q=is%3Aclosed+label%3AF2)), access log ([F4](https://github.com/tosin2013/aegis-node/issues?q=is%3Aclosed+label%3AF4)), hash-chained ledger ([F9](https://github.com/tosin2013/aegis-node/issues?q=is%3Aclosed+label%3AF9)), plus an `aegis run` CLI that exercises them. Approval gate (F3) and reasoning trajectory (F5) ship in v0.8.0; replay viewer + policy validator + model-pull tooling in v0.9.0; v1.0.0 GA targets the [CMMC 2.0 deadline 2026-11-02](RELEASE_PLAN.md).
 
 ## What it is
 
 Aegis-Node is structured around the ten questions a zero-trust security team asks before approving an AI agent for production. Each question maps to a non-negotiable feature (F1–F10):
 
-| Security Review Question | Feature |
-|---|---|
-| What identity is the agent running as? | F1 Workload Identity |
-| What tools can it access? | F2 Permission Manifest |
-| Who approved the tool action? | F3 Human Approval Gate |
-| What data did it touch? | F4 Access Log |
-| Why did it act? | F5 Reasoning Trajectory |
-| Can it exfiltrate data? | F6 Network-Deny-by-Default |
-| Can it mutate production? | F7 Read-Only + Explicit Write Grants |
-| Can we replay what happened? | F8 Trajectory Replay |
-| Can logs be altered? | F9 Hash-Chained Ledger |
-| Can policies be reviewed before runtime? | F10 Policy-as-Code Validation |
+| Security Review Question | Feature | Shipping in |
+|---|---|---|
+| What identity is the agent running as? | F1 Workload Identity | ✅ v0.5.0 |
+| What tools can it access? | F2 Permission Manifest | ✅ v0.5.0 |
+| Who approved the tool action? | F3 Human Approval Gate | v0.8.0 |
+| What data did it touch? | F4 Access Log | ✅ v0.5.0 |
+| Why did it act? | F5 Reasoning Trajectory | v0.8.0 |
+| Can it exfiltrate data? | F6 Network-Deny-by-Default | ✅ v0.5.0 (network gate) |
+| Can it mutate production? | F7 Read-Only + Explicit Write Grants | ✅ v0.5.0 |
+| Can we replay what happened? | F8 Trajectory Replay | v0.9.0 |
+| Can logs be altered? | F9 Hash-Chained Ledger | ✅ v0.5.0 |
+| Can policies be reviewed before runtime? | F10 Policy-as-Code Validation | v0.9.0 |
+
+## What works today
+
+```bash
+# One-time CA setup
+aegis identity init --trust-domain aegis-node.local
+
+# Run a fixed tool-call script under enforcement (manifest gates every I/O)
+aegis run \
+  --manifest schemas/manifest/v1/examples/read-only-research.manifest.yaml \
+  --model /path/to/model.gguf \
+  --workload research --instance inst-001 \
+  --script my-script.json
+
+# Verify the produced ledger end-to-end (chain integrity + summary)
+aegis verify ledger-session-*.jsonl
+```
+
+Every tool call routes through: **identity rebind → policy decision → gate dispatch → access entry / violation entry**. Tampering the model file mid-session triggers an `IdentityRebind` violation and a halt. The Go validator (`pkg/manifest`) and Rust enforcer (`aegis_policy::Policy`) agree on every example manifest's allowed/denied operations — guarded by the [Conformance workflow](.github/workflows/conformance.yml) on every PR.
 
 ## Documentation
 
@@ -36,16 +55,30 @@ Aegis-Node is structured around the ten questions a zero-trust security team ask
 
 ```
 .
-├── proto/                  # aegis.proto (gRPC IPC contract — Phase 0 schema task)
+├── proto/                  # aegis.proto — gRPC IPC contract (frozen at aegis.v1)
 ├── schemas/
-│   ├── manifest/           # Permission Manifest JSON Schema
-│   └── ledger/             # Trajectory Ledger + Access Log JSON-LD @context
-├── crates/                 # Rust workspace (inference engine, network gate, ledger, identity)
-├── cmd/                    # Go binaries (aegis CLI, operator)
-├── pkg/                    # Go libraries
+│   ├── manifest/           # Permission Manifest JSON Schema (schemaVersion: "1")
+│   └── ledger/             # Trajectory Ledger + Access Log JSON-LD @context (v1)
+├── crates/                 # Rust workspace
+│   ├── identity/           # F1: SPIFFE local CA + X.509-SVID issuance + cdylib FFI
+│   ├── ledger-writer/      # F9: append-only hash-chained writer + verifier
+│   ├── access-log/         # F4: typed event emitter
+│   ├── policy/             # F2: closed-by-default decision engine + violation emit
+│   ├── network-gate/       # F6: AegisTcpStream::connect (policy-checked std::net wrapper)
+│   ├── filesystem-gate/    # F2: AegisFile-style policy-checked std::fs wrappers
+│   ├── inference-engine/   # F0: Session boot/shutdown + per-tool-call mediator
+│   └── cli/                # `aegis` binary: identity / verify / run subcommands
+├── pkg/
+│   ├── manifest/           # F2 Go validator + Decide engine (mirrors Rust semantics)
+│   ├── identity/ffi/       # cgo wrapper for crates/identity
+│   └── version/            # version stamping
+├── cmd/                    # Go binaries (aegis CLI alt-entry, operator scaffold)
+├── tests/
+│   ├── conformance/        # Cross-language Go ↔ Rust agreement battery (cases.json)
+│   └── runtime/            # End-to-end golden-ledger fixture (manifest + script + golden)
 ├── .devcontainer/          # Canonical dev environment (per ADR-017)
 ├── .github/workflows/      # CI: rust, go, schemas, conformance, devbox
-├── docs/adrs/              # Architectural Decision Records
+├── docs/adrs/              # 17 Architectural Decision Records
 ├── Cargo.toml              # Rust workspace
 ├── go.mod                  # Go module
 ├── mise.toml               # Native-install tool versions (devcontainer fallback)

--- a/TODO.md
+++ b/TODO.md
@@ -24,18 +24,26 @@ Priority key: **P0** = release blocker · **P1** = required for the phase exit m
 - [ ] **P2** [ADR-015] Document phase exit criteria publicly so the design-partner review milestone is unambiguous.
 - [ ] **P2** [ADR-016] Wire DCO sign-off check into CI (currently maintainer-verified at PR review).
 
-## Phase 1a — Core Security Primitives (target: v0.5.0, 2026-07-20)
+## Phase 1a — Core Security Primitives (✅ shipped: [v0.5.0](https://github.com/tosin2013/aegis-node/releases/tag/v0.5.0), 2026-04-29 — 12 weeks ahead of 2026-07-19 due date)
 
-- [ ] **P0** [ADR-003, F1] Implement built-in lightweight CA for local CLI (file-backed, single-tenant). SPIFFE ID format `spiffe://<trust-domain>/agent/<workload-name>/<instance>`.
-- [ ] **P0** [ADR-003, F1] Bind identity to `(model digest, manifest digest, configuration digest)` triple; halt execution on any digest change.
-- [ ] **P0** [ADR-004, F2] Implement strict YAML manifest parser with line/column errors; reject any tool call not covered by the manifest.
-- [ ] **P0** [ADR-004, F2] Wire enforcement at every Rust syscall boundary (file open, network connect, exec). Conformance test against Go-side validator.
-- [ ] **P0** [ADR-011, F9] Implement append-only ledger writer in Rust (no delete/update API surface); SHA-256 chain with genesis-zero start.
-- [ ] **P0** [ADR-011, F9] Implement `aegis verify <ledger-file>` walk-and-verify CLI with non-zero exit on integrity failure.
-- [ ] **P0** [ADR-006, F4] Emit structured access log entries at every I/O syscall: agent identity, resource URI, type, bytes, ns timestamp, session ID, F5 reasoning-step ID. Atomic writes only.
-- [ ] **P1** [ADR-004, F2] Ship official manifest templates: `read-only-research`, `single-write-target`, `network-egress-allowlist`, `air-gapped`.
-- [ ] **P1** [ADR-011, F9] Add RFC 3161 TSA notarization integration (optional, at session close).
-- [ ] **P2** [ADR-006] Ship reference Splunk + Elastic dashboards for ingestion.
+- [x] **P0** [ADR-003, F1] Implement built-in lightweight CA for local CLI (file-backed, single-tenant). SPIFFE ID format `spiffe://<trust-domain>/agent/<workload-name>/<instance>`. — PR #8 (issue #2)
+- [x] **P0** [ADR-003, F1] Bind identity to `(model digest, manifest digest, configuration digest)` triple; halt execution on any digest change. — PR #18 (issue #4)
+- [x] **P0** [ADR-004, F2] Implement strict YAML manifest parser with line/column errors; reject any tool call not covered by the manifest. — PR #12 (issue #6)
+- [x] **P0** [ADR-004, F2] Wire enforcement at every Rust syscall boundary (file open, network connect, exec). Conformance test against Go-side validator. — PRs #13 (decision engine + network gate), #19 (filesystem gate), #21 (exec_grants schema), #20 (cross-language conformance harness), #31 (runtime mediator) — issues #7, #14, #15, #16
+- [x] **P0** [ADR-011, F9] Implement append-only ledger writer in Rust (no delete/update API surface); SHA-256 chain with genesis-zero start. — PR #9 (issue #1) + golden-pinned root in PR #11
+- [x] **P0** [ADR-011, F9] Implement `aegis verify <ledger-file>` walk-and-verify CLI with non-zero exit on integrity failure. — PR #11 (issue #5)
+- [x] **P0** [ADR-006, F4] Emit structured access log entries at every I/O syscall: agent identity, resource URI, type, bytes, ns timestamp, session ID, F5 reasoning-step ID. Atomic writes only. — PR #10 (typed emitter, issue #3) + PR #31 (mediator wires the emitter at every tool call)
+- [ ] **P1** [ADR-004, F2] Ship official manifest templates: `read-only-research`, `single-write-target`, `network-egress-allowlist`, `air-gapped`. — *partial*: read-only-research, single-write-target, agent-with-exec landed in `schemas/manifest/v1/examples/`; allowlist + air-gapped variants pending.
+- [ ] **P1** [ADR-011, F9] Add RFC 3161 TSA notarization integration (optional, at session close). — deferred.
+- [ ] **P2** [ADR-006] Ship reference Splunk + Elastic dashboards for ingestion. — deferred.
+
+### Bonus shipped under v0.5.0 (not in original Phase 1a plan)
+
+- [x] **P0** F0 runtime — Session boot/shutdown lifecycle (PR #30, issue #24).
+- [x] **P0** F0 runtime — Per-tool-call mediator (PR #31, issue #25). Closes #3 + #7 by transitivity.
+- [x] **P0** F0 runtime — `aegis run` CLI subcommand (PR #32, issue #28).
+- [x] **P0** F0 runtime — End-to-end golden-ledger conformance (PR #33, issue #29).
+- [x] **P1** F1 — Go-callable FFI surface for in-process SVID issuance (PR #22, issue #17).
 
 ## Phase 1b — Reasoning + Approval (target: v0.8.0, 2026-08-31)
 
@@ -54,7 +62,7 @@ Priority key: **P0** = release blocker · **P1** = required for the phase exit m
 ## Phase 1c — Tooling and Replay (target: v0.9.0, 2026-10-05)
 
 - [ ] **P0** [ADR-012, F10] Implement `aegis validate` schema validator + linter (start with ~10 high-value rules: overly broad paths, wildcard tools, missing approval gates on writes, unjustified network grants, etc.).
-- [ ] **P0** [ADR-012, F10] Implement composition + inheritance: `extends:` links with parent-permission enforcement (child cannot exceed parent).
+- [x] **P0** [ADR-012, F10] Implement composition + inheritance: `extends:` links with parent-permission enforcement (child cannot exceed parent). — landed early under v0.5.0: PR #12 (issue #6) implements the resolver in `pkg/manifest/extends.go` with narrowing checks for fs paths, network policies, apis, write_grants, exec_grants, and approval classes.
 - [ ] **P0** [ADR-012, F10] Output formats: GitHub Actions annotations, JUnit XML, plain text, JSON. Generate human-readable policy summary report.
 - [ ] **P0** [ADR-010, F8] Build offline single-file HTML replay viewer (no `fetch()`/CDN/external calls). Synchronized timeline of F5 reasoning + F4 access + F3 approval events.
 - [ ] **P0** [ADR-010, F8] Add F9 chain verification on viewer load; broken chain → prominent integrity warning.


### PR DESCRIPTION
## Summary
The README still said \"Phase 0 — Foundations ... Not yet usable\" even though [v0.5.0](https://github.com/tosin2013/aegis-node/releases/tag/v0.5.0) shipped today. TODO.md had the Phase 1a P0 list entirely unchecked.

## What changed
- **README** status line: Phase 1a complete + release link + one-line summary of what works end-to-end. F1–F10 table gains a \"Shipping in\" column. New \"What works today\" section with copy-pasteable \`aegis identity init\` / \`aegis run\` / \`aegis verify\` invocations. Repo layout updated to match the actual crates and packages that ship.
- **TODO.md** Phase 1a flipped to \"✅ shipped\" with PR refs on every P0. New \"Bonus shipped under v0.5.0\" subsection covers the F0 runtime PRs that weren't in the original hand-authored plan. Phase 1c's extends/composition row marked done (landed early via the manifest parser).

## Test plan
- [ ] CI green (doc-only PR; no code touched).
- [ ] Render the README on GitHub — links resolve, table reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)