### PR TITLE
docs(adr): adopt MCP as the agent-to-tool boundary (ADR-018)

### DIFF
--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -19,7 +19,7 @@
 | **v0.1.0** | Foundations: schemas frozen, IPC contract committed, monorepo + CI scaffolded | 2026-05-25 | ADR-002, ADR-004, ADR-011, ADR-015 / Phase 0 |
 | **v0.5.0** | Core Security Primitives: F1 identity, F2 manifest enforcement, F9 ledger writer + verify, F4 access log emitter | 2026-07-20 | ADR-003, ADR-004, ADR-006, ADR-011 / Phase 1a |
 | **v0.8.0** | Reasoning + Approval: F5 trajectory, F3 approval gate, F6 network deny, F7 read-only default | 2026-08-31 | ADR-005, ADR-007, ADR-008, ADR-009 / Phase 1b |
-| **v0.9.0** | Tooling + Replay: F10 validator, F8 replay viewer, OCI pull + Cosign, llama.cpp FFI | 2026-10-05 | ADR-010, ADR-012, ADR-013, ADR-014 / Phase 1c |
+| **v0.9.0** | Tooling + Replay: F10 validator, F8 replay viewer, OCI pull + Cosign, llama.cpp FFI, MCP client | 2026-10-05 | ADR-010, ADR-012, ADR-013, ADR-014, ADR-018 / Phase 1c |
 | **v1.0.0** | **Phase 1 GA — Security Review Milestone:** end-to-end conformance suite, auditor evidence package, design-partner review passed, Apache 2.0 community release | **2026-11-02** | ADR-001, ADR-016 / Phase 1 GA |
 | **v2.0.0** | Kubernetes Runtime: Operator + CRDs, SPIRE attestation, GPU backends (vLLM/TGI/KServe), persistent ledger | 2027-01-25 | ADR-002, ADR-015 / Phase 2 |
 | **v3.0.0** | OpenShift Enterprise Runtime: SCCs, disconnected install, GitOps, automated CMMC/FedRAMP exports | 2027-04-19 | ADR-015 / Phase 3 |
@@ -73,7 +73,7 @@ Phase 1b: F5 pre-execution trajectory recorder, F3 human approval gate (CLI + lo
 - **Status:** pushed (#4)
 - **Due:** 2026-10-05
 
-Phase 1c: F10 policy-as-code validator (aegis validate) with composition + linter, F8 deterministic offline single-file HTML replay viewer, OCI artifact pull + Cosign verification (aegis pull), llama.cpp Rust FFI binding integrated with Backend trait. Maps to ADRs 010, 012, 013, 014.
+Phase 1c: F10 policy-as-code validator (aegis validate) with composition + linter, F8 deterministic offline single-file HTML replay viewer, OCI artifact pull + Cosign verification (aegis pull), llama.cpp Rust FFI binding integrated with Backend trait, MCP client adoption per ADR-018 (manifest gains optional `tools.mcp[]`; F5 reasoning entries carry MCP tool names). Maps to ADRs 010, 012, 013, 014, 018.
 
 ### v1.0.0 — Phase 1 GA / Security Review Milestone
 <!-- milestone-id: v1-0-0-phase-1-ga-security-review-milestone -->

--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,7 @@ Priority key: **P0** = release blocker · **P1** = required for the phase exit m
 
 ## Phase 1c — Tooling and Replay (target: v0.9.0, 2026-10-05)
 
+- [ ] **P0** [ADR-018, F2/F5] Adopt MCP as the agent-to-tool protocol per ADR-018. Manifest gains optional `tools.mcp[]` (closed-by-default allowlist of `{server_name, server_uri, allowed_tools}`); mediator gains `mediate_mcp_tool_call` that routes side-effects through existing `mediate_*` methods; F5 reasoning entries' `toolsConsidered`/`toolSelected` carry MCP tool names; cross-language conformance battery extended.
 - [ ] **P0** [ADR-012, F10] Implement `aegis validate` schema validator + linter (start with ~10 high-value rules: overly broad paths, wildcard tools, missing approval gates on writes, unjustified network grants, etc.).
 - [x] **P0** [ADR-012, F10] Implement composition + inheritance: `extends:` links with parent-permission enforcement (child cannot exceed parent). — landed early under v0.5.0: PR #12 (issue #6) implements the resolver in `pkg/manifest/extends.go` with narrowing checks for fs paths, network policies, apis, write_grants, exec_grants, and approval classes.
 - [ ] **P0** [ADR-012, F10] Output formats: GitHub Actions annotations, JUnit XML, plain text, JSON. Generate human-readable policy summary report.

--- a/docs/adrs/018-adopt-mcp-protocol-for-agent-tool-boundary.md
+++ b/docs/adrs/018-adopt-mcp-protocol-for-agent-tool-boundary.md
@@ -1,0 +1,77 @@
+# 18. Adopt the Model Context Protocol (MCP) as the Agent-to-Tool Boundary
+
+**Status:** Accepted
+**Date:** 2026-04-29
+**Domain:** Tool Integration / Agent Runtime (extends F2 + F5)
+
+## Context
+
+[ADR-007](007-pre-execution-reasoning-trajectory.md) (F5 Pre-Execution Reasoning Trajectory) anticipates a reasoning capturer that "intercepts LLM tool-selection output" — but no protocol has ever been named for what produces that output. The JSON-LD ledger at `schemas/ledger/v1/context.jsonld` has reserved `toolsConsidered` and `toolSelected` terms since v0.1.0 yet they remain semantically empty. Meanwhile the manifest's `tools.apis[]` (`schemas/manifest/v1/manifest.schema.json`) is an HTTP-verb allowlist — useful for network-policy purposes but not a tool catalog. It carries no `description`, no `input_schema`, no machinery for tool discovery.
+
+Operators integrating Aegis-Node need a standard tool-invocation protocol so the runtime can mediate tool calls the same way it already mediates filesystem and network syscalls. Reinventing one would forfeit the broader Anthropic Model Context Protocol (MCP) ecosystem and burden every tool author with a bespoke Aegis-Node integration.
+
+The decision belongs in the v0.9.0 — Tooling and Replay milestone (due 2026-10-04), where it lands alongside the `llama.cpp` FFI binding (ADR-014) and the `aegis validate` CLI (ADR-012). A real model loader is also where MCP `tool_use` output naturally surfaces, so the protocol decision and its first concrete consumer ship together.
+
+## Decision
+
+Aegis-Node adopts the Model Context Protocol (MCP) as the canonical agent ↔ tool wire format.
+
+1. **MCP is the protocol.** From v0.9.0 onward, the agent ↔ tool boundary is MCP. F5 reasoning entries' `toolsConsidered` / `toolSelected` JSON-LD terms (already reserved in the v1 `@context`) carry MCP tool names.
+
+2. **Phase 1 ships an MCP _client_ only.** The runtime consumes external MCP servers' tool catalogs and invokes their tools. Aegis-Node does NOT expose its own surface (ledger, identity, policy) as an MCP server in Phase 1. A separate ADR may pursue an MCP-server surface later if the audit story demands it.
+
+3. **MCP slots _above_ the syscall mediator.** `crates/inference-engine/src/mediator.rs` already provides five `mediate_*` methods (filesystem_read/write/delete + network_connect + exec). MCP tool invocations that have filesystem, network, or exec side effects flow through these existing methods, so F2 enforcement and F4 access logging are inherited unchanged. The new entry point is `Session::mediate_mcp_tool_call(server, tool, args)`.
+
+4. **Manifest gains an optional `tools.mcp[]` array.** Per the [Compatibility Charter's "Allowed evolution" rule](../COMPATIBILITY_CHARTER.md) (adding new optional properties), this is a non-breaking schema extension — no `schemaVersion` bump. Each entry has the shape `{server_name, server_uri, allowed_tools: [string]}`. Closed-by-default: without a manifest entry, an MCP tool call is denied and emits a Violation per F2.
+
+5. **Implementation lands in v0.9.0** as four sub-issues under an umbrella tracking issue (filed alongside this ADR):
+   - **F2-MCP-A** — schema bump for `tools.mcp[]` (Go + Rust types + drift-test against the canonical schema).
+   - **F2-MCP-B** — mediator extension `mediate_mcp_tool_call` that resolves the server, invokes the tool, routes side-effects through existing `mediate_*` methods, and emits one `EntryType::Access` per call with the MCP tool name + reasoning_step_id.
+   - **F2-MCP-C** — cross-language conformance: Go `Manifest.Decide` and Rust `Policy::check_mcp_tool` agree on the allowlist battery; rows added to `tests/conformance/cases.json`.
+   - **F2-MCP-D** — at least one example MCP-using manifest under `schemas/manifest/v1/examples/`.
+
+## Consequences
+
+**Positive:**
+- F5's promise becomes operational. The `toolsConsidered` / `toolSelected` JSON-LD terms gain semantics tied to a real protocol; v0.9.0+ ledgers can be replayed against viewers that understand MCP tool names.
+- Native interop with the broader MCP ecosystem — Aegis-Node-protected agents can connect to any MCP-compliant tool server without bespoke integration code.
+- Closed-by-default tool allowlist preserves the zero-trust posture: only manifest-listed servers and tools may be invoked.
+- Existing F2 enforcement and F4 access logging apply for free: every MCP tool with filesystem/network/exec side effects flows through the existing mediator, so we get policy checks, access entries, and violation emit without new enforcement code.
+- Operators don't have to learn an Aegis-Node-specific tool format; if a tool exposes itself via MCP, Aegis-Node can use it.
+
+**Negative:**
+- MCP client implementation burden: JSON-RPC framing, transport (stdio / streamable HTTP), capability negotiation, error mapping. Phase 1 keeps this scoped via a small client crate.
+- Aegis-Node tracks upstream MCP wire evolution. A future Compatibility Charter entry must pin the MCP version supported in `schemaVersion: "1"` (likely MCP v0.x at adoption); a major MCP wire break could force a v2 manifest schema.
+- Tool authors who haven't adopted MCP need to wrap their tools in an MCP server before Aegis-Node can use them. Phase 1's `tools.apis[]` HTTP-verb allowlist remains for HTTP-only callers; MCP is additive, not a replacement.
+- MCP server attestation is unspecified in MCP itself. The manifest's `server_uri` carries the trust assertion (e.g., a SPIFFE ID for a co-located server, or a signed-binary path); enforcement of that assertion is closed-by-default but the attestation primitives must be defined per-tool in Phase 2.
+
+## Domain Considerations
+
+MCP is a young protocol but rapidly becoming the de facto standard for AI agent ↔ tool integration. Adopting it now lets Aegis-Node ride the ecosystem instead of competing with it. The risk surface is upstream wire churn; the mitigation is the Compatibility Charter's manifest-schema versioning, which lets us pin an MCP version per `schemaVersion`.
+
+The decision keeps Aegis-Node's enforcement story orthogonal to MCP's transport. MCP defines how tools are discovered and invoked; Aegis-Node decides whether each invocation is allowed and records what happened. The two protocols compose cleanly because MCP is agnostic to the policy layer above it.
+
+## Implementation Plan
+
+1. **Land this ADR** alongside a tracking issue ("MCP: implement Aegis-Node as an MCP client per ADR-018") under the v0.9.0 milestone (issue tracker, not in this PR's diff).
+2. **F2-MCP-A** — extend `schemas/manifest/v1/manifest.schema.json` with an optional `tools.mcp[]` definition, mirror in `pkg/manifest/types.go` and `crates/policy/src/manifest.rs`, refresh `pkg/manifest/schema_v1.json` drift-test.
+3. **F2-MCP-B** — add `mediate_mcp_tool_call` to `crates/inference-engine/src/mediator.rs`. Resolve the server from manifest, invoke via the new client, route side effects through existing `mediate_*` methods, emit one access entry per tool call.
+4. **F2-MCP-C** — extend `tests/conformance/cases.json` with MCP allowlist rows (allowed server + tool, allowed server + disallowed tool, disallowed server). Both engines must agree.
+5. **F2-MCP-D** — add `schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml` showing the canonical MCP-using shape.
+
+After all four sub-issues land, the umbrella closes and v0.9.0 has its first concrete tool-protocol deliverable.
+
+## Related PRD Sections
+
+- §4 F2 — Permission Manifest enforcement (this is what gates MCP tool calls).
+- §4 F5 — Reasoning Trajectory (this is what records the MCP tool selection).
+- §7 Architecture Principles (#2: Zero implicit trust) — the closed-by-default `tools.mcp[]` is the realization of this principle for tool dispatch.
+
+## Domain References
+
+- Anthropic Model Context Protocol specification — https://modelcontextprotocol.io
+- ADR-002 (Split-Language Architecture)
+- ADR-004 (Permission Manifest)
+- ADR-007 (Pre-Execution Reasoning Trajectory)
+- ADR-012 (Policy-as-Code Validation) — F10's `aegis validate` will validate the new `tools.mcp[]` shape once F2-MCP-A lands.
+- ADR-014 (CPU-First GGUF Inference via llama.cpp) — the model loader that surfaces MCP `tool_use` output.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -25,6 +25,7 @@ The decisions are anchored in the Architecture Principles (PRD §7) and the ten-
 | [015](015-three-phase-deployment-roadmap.md) | Three-Phase Deployment Roadmap | §5 |
 | [016](016-open-core-licensing-model.md) | Open-Core Licensing Model | §9.1 |
 | [017](017-local-development-environment-devcontainer-mise.md) | Local Development Environment: Devcontainer + mise | §7 (#3, #4), §6.1 |
+| [018](018-adopt-mcp-protocol-for-agent-tool-boundary.md) | Adopt the Model Context Protocol (MCP) as the Agent-to-Tool Boundary | §4 F2, §4 F5 |
 
 ## Decision Coverage Matrix
 


### PR DESCRIPTION
## Summary
New ADR-018 declares the Model Context Protocol (MCP) as Aegis-Node's canonical agent ↔ tool wire format. **Declare-only scope** — implementation lands in v0.9.0 alongside llama.cpp FFI as four sub-issues under a tracking umbrella.

## Why now
- ADR-007's F5 reasoning capturer plans to \"intercept LLM tool-selection output\" but never named the protocol that produces that output. ADR-018 names it.
- \`schemas/ledger/v1/context.jsonld\` reserves \`toolsConsidered\` / \`toolSelected\` JSON-LD terms since v0.1.0, semantically empty until now.
- Operators integrating Aegis-Node need a standard tool-invocation protocol. Reinventing one would forfeit the broad MCP ecosystem.

## Architecture
- Aegis-Node is an MCP **client** in Phase 1. Server surface stays out of scope (potential ADR-019).
- MCP slots **above** the existing syscall mediator. Side-effects flow through \`mediate_*\` methods so F2/F4 are inherited.
- Manifest gains an **optional** \`tools.mcp[]\` array — Compatibility Charter \"allowed evolution\" rule, no \`schemaVersion\` bump.

## Doc-only PR
No code changes — just the ADR + index + RELEASE_PLAN + TODO update. CI should be uneventful.

## Files
- \`docs/adrs/018-adopt-mcp-protocol-for-agent-tool-boundary.md\` — new ADR (Nygard format, generated via the \`adr-analysis\` MCP tool then edited to match existing convention).
- \`docs/adrs/README.md\` — index row for ADR-018.
- \`RELEASE_PLAN.md\` — v0.9.0 milestone description gains \"MCP client adoption per ADR-018\".
- \`TODO.md\` — new P0 bullet at top of Phase 1c.

## Test plan
- [ ] CI green on all four workflows (no code changes; expect uneventful).
- [ ] Render the ADR + README on GitHub — links resolve, table reads correctly.

## Follow-ups (filed after merge under v0.9.0 milestone)
- Umbrella: \"MCP: implement Aegis-Node as an MCP client per ADR-018\"
- F2-MCP-A: schema bump for \`tools.mcp[]\`
- F2-MCP-B: mediator extension \`mediate_mcp_tool_call\`
- F2-MCP-C: cross-language conformance for MCP allowlist
- F2-MCP-D: example MCP-using manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)