### PR TITLE
feat(access-log, inference-engine): F5 reasoning-step emitter (issue #26)

### DIFF
--- a/crates/access-log/Cargo.toml
+++ b/crates/access-log/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 thiserror = "1"
+uuid = { version = "1", features = ["v7", "serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/access-log/src/error.rs
+++ b/crates/access-log/src/error.rs
@@ -12,4 +12,7 @@ pub enum Error {
 
     #[error("resource_uri must be non-empty")]
     EmptyResourceUri,
+
+    #[error("reasoning step input must be non-empty")]
+    EmptyReasoningInput,
 }

--- a/crates/access-log/src/lib.rs
+++ b/crates/access-log/src/lib.rs
@@ -17,6 +17,7 @@ use aegis_ledger_writer::{Entry, EntryRecord, EntryType, LedgerWriter};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use uuid::Uuid;
 
 pub mod error;
 pub use error::{Error, Result};
@@ -51,6 +52,90 @@ pub struct AccessEvent {
     /// `Utc::now()` is fine for the runtime, fixture timestamps are fine
     /// for tests/replay.
     pub timestamp: DateTime<Utc>,
+}
+
+/// One reasoning step emitted before a tool call (F5 per ADR-007). The
+/// step ID is what later access entries' `reasoning_step_id` field points
+/// at, giving auditors a reverse lookup from "what happened" to "why".
+///
+/// Phase 1a accepts pre-computed text — the LLM-driven runtime that
+/// generates `input` / `reasoning` / `tools_considered` / `tool_selected`
+/// arrives in Phase 2 (ADR-014's llama.cpp Backend). Until then, callers
+/// supply these fields directly (e.g., test fixtures, external graders).
+#[derive(Debug, Clone)]
+pub struct ReasoningStepEvent {
+    /// Step identifier embedded into downstream `EntryType::Access`
+    /// entries. Default-construct via [`ReasoningStepEvent::new_v7_id`]
+    /// for the typical caller.
+    pub step_id: Uuid,
+    /// What the agent received (user prompt, system input, prior tool
+    /// result that led to this reasoning).
+    pub input: String,
+    /// The agent's free-text rationale for choosing the next tool.
+    pub reasoning: String,
+    /// Tools the agent considered, in the order it considered them.
+    pub tools_considered: Vec<String>,
+    /// The tool the agent selected. None if the agent decided not to
+    /// invoke any tool (the reasoning is still recorded for audit).
+    pub tool_selected: Option<String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl ReasoningStepEvent {
+    /// Convenience: generate a UUIDv7 for `step_id`.
+    pub fn new_v7_id() -> Uuid {
+        Uuid::now_v7()
+    }
+}
+
+/// Append exactly one `EntryType::ReasoningStep` ledger entry. Returns
+/// the writer's record; callers thread `event.step_id` into the
+/// `reasoning_step_id` field of the next [`emit_access`] call so an
+/// auditor can correlate "agent did X" back to "agent reasoned Y".
+///
+/// Per the F5 contract (ADR-007): every Access entry SHOULD have a
+/// preceding ReasoningStep entry whose `reasoningStepId` matches.
+/// Enforcing the SHOULD is a runtime concern (the mediator's caller);
+/// this function is the typed event surface.
+pub fn emit_reasoning_step(
+    writer: &mut LedgerWriter,
+    agent_identity_hash: [u8; 32],
+    event: ReasoningStepEvent,
+) -> Result<EntryRecord> {
+    if event.input.is_empty() {
+        return Err(Error::EmptyReasoningInput);
+    }
+
+    let mut payload = Map::new();
+    payload.insert(
+        "reasoningStepId".to_string(),
+        Value::String(event.step_id.to_string()),
+    );
+    payload.insert("input".to_string(), Value::String(event.input));
+    payload.insert("reasoning".to_string(), Value::String(event.reasoning));
+    payload.insert(
+        "toolsConsidered".to_string(),
+        Value::Array(
+            event
+                .tools_considered
+                .into_iter()
+                .map(Value::String)
+                .collect(),
+        ),
+    );
+    if let Some(tool) = event.tool_selected {
+        payload.insert("toolSelected".to_string(), Value::String(tool));
+    }
+
+    let session_id = writer.session_id().to_string();
+    let record = writer.append(Entry {
+        session_id,
+        entry_type: EntryType::ReasoningStep,
+        agent_identity_hash,
+        timestamp: event.timestamp,
+        payload,
+    })?;
+    Ok(record)
 }
 
 /// Append exactly one `EntryType::Access` ledger entry for `event`.

--- a/crates/access-log/tests/integration.rs
+++ b/crates/access-log/tests/integration.rs
@@ -252,10 +252,7 @@ fn reasoning_step_carries_all_jsonld_terms() {
             step_id: fixed_step_id(),
             input: "user asked: summarize Q1 results".to_string(),
             reasoning: "I need to read the source CSV before summarizing.".to_string(),
-            tools_considered: vec![
-                "filesystem.read".to_string(),
-                "search_index".to_string(),
-            ],
+            tools_considered: vec!["filesystem.read".to_string(), "search_index".to_string()],
             tool_selected: Some("filesystem.read".to_string()),
             timestamp: ts(),
         },
@@ -272,7 +269,10 @@ fn reasoning_step_carries_all_jsonld_terms() {
     assert_eq!(v["entryType"], "reasoning_step");
     assert_eq!(v["reasoningStepId"], fixed_step_id().to_string());
     assert_eq!(v["input"], "user asked: summarize Q1 results");
-    assert_eq!(v["reasoning"], "I need to read the source CSV before summarizing.");
+    assert_eq!(
+        v["reasoning"],
+        "I need to read the source CSV before summarizing."
+    );
     assert_eq!(v["toolsConsidered"][0], "filesystem.read");
     assert_eq!(v["toolsConsidered"][1], "search_index");
     assert_eq!(v["toolSelected"], "filesystem.read");

--- a/crates/access-log/tests/integration.rs
+++ b/crates/access-log/tests/integration.rs
@@ -4,10 +4,13 @@
 
 use std::fs;
 
-use aegis_access_log::{emit_access, AccessEvent, AccessType, Error};
+use aegis_access_log::{
+    emit_access, emit_reasoning_step, AccessEvent, AccessType, Error, ReasoningStepEvent,
+};
 use aegis_ledger_writer::{EntryType, LedgerWriter};
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
+use uuid::Uuid;
 
 const SESSION: &str = "session-access-log";
 const AGENT_HASH: [u8; 32] = [0x11u8; 32];
@@ -227,4 +230,149 @@ fn each_access_type_serializes_via_payload() {
         assert_eq!(v["entryType"].as_str().unwrap(), "access");
     }
     let _ = EntryType::Access; // sanity reference
+}
+
+// ---------- F5 reasoning-step emitter tests (issue #26) ----------
+
+fn fixed_step_id() -> Uuid {
+    // Fixed UUIDv7 for golden-style assertions; the version + variant
+    // bits land in the right places so it parses identically on both
+    // engines.
+    Uuid::parse_str("01977a85-1234-7000-8000-aabbccddeeff").unwrap()
+}
+
+#[test]
+fn reasoning_step_carries_all_jsonld_terms() {
+    let (_dir, mut writer, path) = open_writer();
+
+    let record = emit_reasoning_step(
+        &mut writer,
+        AGENT_HASH,
+        ReasoningStepEvent {
+            step_id: fixed_step_id(),
+            input: "user asked: summarize Q1 results".to_string(),
+            reasoning: "I need to read the source CSV before summarizing.".to_string(),
+            tools_considered: vec![
+                "filesystem.read".to_string(),
+                "search_index".to_string(),
+            ],
+            tool_selected: Some("filesystem.read".to_string()),
+            timestamp: ts(),
+        },
+    )
+    .unwrap();
+    assert_eq!(record.sequence_number, 0);
+
+    writer.close().unwrap();
+    let content = fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines.len(), 1);
+
+    let v: Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(v["entryType"], "reasoning_step");
+    assert_eq!(v["reasoningStepId"], fixed_step_id().to_string());
+    assert_eq!(v["input"], "user asked: summarize Q1 results");
+    assert_eq!(v["reasoning"], "I need to read the source CSV before summarizing.");
+    assert_eq!(v["toolsConsidered"][0], "filesystem.read");
+    assert_eq!(v["toolsConsidered"][1], "search_index");
+    assert_eq!(v["toolSelected"], "filesystem.read");
+}
+
+#[test]
+fn reasoning_step_omits_tool_selected_when_none() {
+    let (_dir, mut writer, path) = open_writer();
+    emit_reasoning_step(
+        &mut writer,
+        AGENT_HASH,
+        ReasoningStepEvent {
+            step_id: fixed_step_id(),
+            input: "user prompt".to_string(),
+            reasoning: "no tool needed".to_string(),
+            tools_considered: vec![],
+            tool_selected: None,
+            timestamp: ts(),
+        },
+    )
+    .unwrap();
+    writer.close().unwrap();
+
+    let content = fs::read_to_string(&path).unwrap();
+    let v: Value = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert!(
+        v.get("toolSelected").is_none(),
+        "toolSelected must be absent when not provided"
+    );
+    assert_eq!(v["toolsConsidered"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn rejects_empty_reasoning_input() {
+    let (_dir, mut writer, _) = open_writer();
+    let err = emit_reasoning_step(
+        &mut writer,
+        AGENT_HASH,
+        ReasoningStepEvent {
+            step_id: fixed_step_id(),
+            input: String::new(),
+            reasoning: "rationale".to_string(),
+            tools_considered: vec![],
+            tool_selected: None,
+            timestamp: ts(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::EmptyReasoningInput));
+    assert_eq!(writer.entry_count(), 0);
+}
+
+#[test]
+fn reasoning_step_then_access_correlate_one_to_one() {
+    // The F5 audit invariant: every Access entry's reasoningStepId
+    // resolves to a preceding ReasoningStep entry whose stepId matches.
+    // Tested here at the emitter level (the runtime mediator wires the
+    // same flow per-tool-call in inference-engine tests).
+    let (_dir, mut writer, path) = open_writer();
+    let step_id = fixed_step_id();
+
+    emit_reasoning_step(
+        &mut writer,
+        AGENT_HASH,
+        ReasoningStepEvent {
+            step_id,
+            input: "user prompt".to_string(),
+            reasoning: "reading the report file".to_string(),
+            tools_considered: vec!["filesystem.read".to_string()],
+            tool_selected: Some("filesystem.read".to_string()),
+            timestamp: ts(),
+        },
+    )
+    .unwrap();
+    emit_access(
+        &mut writer,
+        AGENT_HASH,
+        AccessEvent {
+            resource_uri: "file:///data/report.md".to_string(),
+            access_type: AccessType::Read,
+            bytes_accessed: 4096,
+            reasoning_step_id: Some(step_id.to_string()),
+            timestamp: ts(),
+        },
+    )
+    .unwrap();
+    writer.close().unwrap();
+
+    let content = fs::read_to_string(&path).unwrap();
+    let entries: Vec<Value> = content
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0]["entryType"], "reasoning_step");
+    assert_eq!(entries[1]["entryType"], "access");
+    assert_eq!(
+        entries[0]["reasoningStepId"], entries[1]["reasoningStepId"],
+        "Access entry's reasoningStepId must match preceding ReasoningStep's stepId"
+    );
+
+    let _ = EntryType::ReasoningStep; // sanity reference
 }

--- a/crates/inference-engine/Cargo.toml
+++ b/crates/inference-engine/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 sha2 = "0.10"
 hex = "0.4"
 thiserror = "1"
+uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/inference-engine/src/mediator.rs
+++ b/crates/inference-engine/src/mediator.rs
@@ -25,14 +25,47 @@ use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Command, Output};
 
-use aegis_access_log::{emit_access, AccessEvent, AccessType};
+use aegis_access_log::{
+    emit_access, emit_reasoning_step, AccessEvent, AccessType, ReasoningStepEvent,
+};
 use aegis_policy::{check_identity_binding, Decision, NetworkProto};
 use chrono::Utc;
+use uuid::Uuid;
 
 use crate::error::{Error, Result};
 use crate::session::Session;
 
 impl Session {
+    /// Record a reasoning step (F5 per ADR-007) and return the step ID.
+    /// The caller threads the returned ID into the next
+    /// `mediate_*` call's `reasoning_step_id` parameter so an auditor
+    /// can correlate the resulting Access entry back to the agent's
+    /// stated rationale.
+    ///
+    /// Phase 1a accepts pre-computed reasoning text — the LLM-driven
+    /// runtime that generates input/reasoning/tools_considered/
+    /// tool_selected arrives in Phase 2 (ADR-014's llama.cpp Backend).
+    pub fn record_reasoning_step(
+        &mut self,
+        input: impl Into<String>,
+        reasoning: impl Into<String>,
+        tools_considered: Vec<String>,
+        tool_selected: Option<String>,
+    ) -> Result<Uuid> {
+        let event = ReasoningStepEvent {
+            step_id: ReasoningStepEvent::new_v7_id(),
+            input: input.into(),
+            reasoning: reasoning.into(),
+            tools_considered,
+            tool_selected,
+            timestamp: Utc::now(),
+        };
+        let step_id = event.step_id;
+        let agent_hash = self.agent_identity_hash();
+        emit_reasoning_step(self.ledger_writer_mut(), agent_hash, event)?;
+        Ok(step_id)
+    }
+
     /// Read a file with full mediation. Returns the file bytes.
     pub fn mediate_filesystem_read(
         &mut self,

--- a/crates/inference-engine/tests/mediator.rs
+++ b/crates/inference-engine/tests/mediator.rs
@@ -329,3 +329,57 @@ write_grants:
     let summary = verify_file(&ledger).unwrap();
     assert_eq!(summary.entry_count as usize, kinds.len());
 }
+
+#[test]
+fn record_reasoning_step_threads_id_into_subsequent_access() {
+    // F5 audit invariant: every Access entry's reasoningStepId resolves
+    // to a preceding ReasoningStep entry whose stepId matches.
+    // Demonstrates the canonical runtime call pattern: record reasoning
+    // → use the returned step_id in mediate_*.
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let target = dir.path().join("data.txt");
+    std::fs::write(&target, b"contents").unwrap();
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "m", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://mediator.local/agent/research/inst-1" }}
+tools:
+  filesystem:
+    read: ["{p}"]
+"#,
+        p = dir.path().to_str().unwrap()
+    );
+    let (mut s, ledger) = boot(dir.path(), ca_dir.path(), "session-f5", &yaml);
+
+    let step_id = s
+        .record_reasoning_step(
+            "user: please read data.txt",
+            "I need to invoke filesystem.read on the target.",
+            vec!["filesystem.read".to_string()],
+            Some("filesystem.read".to_string()),
+        )
+        .unwrap();
+    let step_id_str = step_id.to_string();
+
+    s.mediate_filesystem_read(&target, Some(&step_id_str)).unwrap();
+    s.shutdown().unwrap();
+
+    let entries = read_lines(&ledger);
+    // session_start, reasoning_step, access, session_end
+    assert_eq!(entries.len(), 4);
+    assert_eq!(entries[0]["entryType"], "session_start");
+    assert_eq!(entries[1]["entryType"], "reasoning_step");
+    assert_eq!(entries[2]["entryType"], "access");
+    assert_eq!(entries[3]["entryType"], "session_end");
+
+    // Correlation invariant.
+    assert_eq!(
+        entries[1]["reasoningStepId"], entries[2]["reasoningStepId"],
+        "Access reasoningStepId must match preceding ReasoningStep stepId"
+    );
+    assert_eq!(entries[1]["reasoningStepId"].as_str().unwrap(), step_id_str);
+    assert_eq!(entries[1]["toolSelected"], "filesystem.read");
+}

--- a/crates/inference-engine/tests/mediator.rs
+++ b/crates/inference-engine/tests/mediator.rs
@@ -364,7 +364,8 @@ tools:
         .unwrap();
     let step_id_str = step_id.to_string();
 
-    s.mediate_filesystem_read(&target, Some(&step_id_str)).unwrap();
+    s.mediate_filesystem_read(&target, Some(&step_id_str))
+        .unwrap();
     s.shutdown().unwrap();
 
     let entries = read_lines(&ledger);


### PR DESCRIPTION
## Summary
First v0.8.0 slice for the F5 audit story. Adds the typed event emitter that correlates every Access entry to a preceding ReasoningStep entry naming what the agent considered, what it selected, and why. Operationalizes vocabulary that the JSON-LD ledger has reserved since v0.1.0 (\`reasoningStepId\`, \`input\`, \`reasoning\`, \`toolsConsidered\`, \`toolSelected\` per ADR-007).

## Acceptance criteria mapping (issue #26)
- [x] \`emit_reasoning_step\` added to \`crates/access-log\`.
- [x] \`ReasoningStepEvent\` carries: step ID (UUIDv7), input, reasoning, tools_considered, tool_selected.
- [x] Mediator integration: \`Session::record_reasoning_step\` returns the step_id; caller threads it into \`mediate_*\`'s \`reasoning_step_id\` parameter.
- [x] Conformance test: a reasoning_step entry's \`reasoningStepId\` matches the next access entry's \`reasoningStepId\`.

## Phase 1a constraint
LLM-driven reasoning content arrives in Phase 2 (alongside ADR-014's llama.cpp Backend). This PR delivers the typed event surface; callers supply the prose. The mediator API stays stable — \`record_reasoning_step\` is a convenience, not a required step.

## Test plan
- [ ] CI green on Rust workflow.
- [ ] Four new tests:
  - \`reasoning_step_carries_all_jsonld_terms\` — payload contains all five v1 \`@context\` terms with correct values.
  - \`reasoning_step_omits_tool_selected_when_none\` — \`toolSelected\` absent when \`None\`; \`toolsConsidered\` empty array when \`vec![]\`.
  - \`rejects_empty_reasoning_input\` — closed-by-default refusal.
  - \`reasoning_step_then_access_correlate_one_to_one\` — emitter-level proof that the step_id threads.
  - \`record_reasoning_step_threads_id_into_subsequent_access\` (in inference-engine) — full runtime path with a Session.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)