### PR TITLE
feat(approval-gate): localhost web UI approval channel (issue #35, F3)

### DIFF
--- a/crates/approval-gate/Cargo.toml
+++ b/crates/approval-gate/Cargo.toml
@@ -22,7 +22,13 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-pemfile = "2"
 rustls-pki-types = "1"
 x509-parser = "0.16"
+# F3 web UI approval channel (issue #35).
+tiny_http = "0.12"
+rand = "0.8"
+hex = "0.4"
+uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 tempfile = "3"
 aegis-identity = { path = "../identity" }
+ureq = { version = "2", default-features = false }

--- a/crates/approval-gate/src/lib.rs
+++ b/crates/approval-gate/src/lib.rs
@@ -22,10 +22,12 @@ use thiserror::Error;
 pub mod file;
 pub mod mtls;
 pub mod tty;
+pub mod web;
 
 pub use file::FileApprovalChannel;
 pub use mtls::MtlsApprovalChannel;
 pub use tty::TtyApprovalChannel;
+pub use web::WebApprovalChannel;
 
 /// One approval request the runtime hands to a channel.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/approval-gate/src/web.rs
+++ b/crates/approval-gate/src/web.rs
@@ -28,7 +28,6 @@
 //! Anything else returns 404. Any unauthenticated request returns 401.
 
 use std::collections::HashMap;
-use std::io::Read;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
@@ -337,5 +336,3 @@ fn generate_token() -> String {
     rand::rngs::OsRng.fill_bytes(&mut bytes);
     hex::encode(bytes)
 }
-
-use std::io::Read;

--- a/crates/approval-gate/src/web.rs
+++ b/crates/approval-gate/src/web.rs
@@ -111,8 +111,8 @@ impl WebApprovalChannel {
             )));
         }
 
-        let server = Server::http(parsed)
-            .map_err(|e| Error::Channel(format!("bind {parsed}: {e}")))?;
+        let server =
+            Server::http(parsed).map_err(|e| Error::Channel(format!("bind {parsed}: {e}")))?;
         let bound = match server.server_addr() {
             tiny_http::ListenAddr::IP(addr) => addr,
             _ => return Err(Error::Channel("non-IP listener".to_string())),
@@ -191,10 +191,9 @@ impl ApprovalChannel for WebApprovalChannel {
                             approver_identity: approver,
                             decided_at,
                         },
-                        RecordedDecision::Rejected {
-                            reason,
-                            decided_at,
-                        } => ApprovalOutcome::Rejected { reason, decided_at },
+                        RecordedDecision::Rejected { reason, decided_at } => {
+                            ApprovalOutcome::Rejected { reason, decided_at }
+                        }
                     });
                 }
             }

--- a/crates/approval-gate/src/web.rs
+++ b/crates/approval-gate/src/web.rs
@@ -51,6 +51,14 @@ pub struct WebApprovalChannel {
     server_thread: Option<thread::JoinHandle<()>>,
 }
 
+impl std::fmt::Debug for WebApprovalChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebApprovalChannel")
+            .field("bound", &self.bound)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Default)]
 struct State {
     pending: Mutex<HashMap<String, PendingRequest>>,

--- a/crates/approval-gate/src/web.rs
+++ b/crates/approval-gate/src/web.rs
@@ -1,0 +1,342 @@
+//! Localhost web UI approval channel (F3, issue #35).
+//!
+//! Spins up a tiny HTTP server bound to a loopback address only. A
+//! single one-shot bearer token authenticates every request — the
+//! agent prints the token + URL on startup and an operator pastes
+//! either into a browser or a shell client. The token is bound to the
+//! channel instance and discarded on `Drop`, so once the session ends
+//! it's useless.
+//!
+//! ## Why no TLS
+//! Loopback-only. TLS adds CA / cert provisioning friction with no
+//! benefit on the same machine. Cross-host approvals are the F3 mTLS
+//! channel's job (issue #36).
+//!
+//! ## Why bearer in a header (not a cookie)
+//! A drive-by browser tab on the same machine could mount a CSRF on a
+//! cookie-authenticated endpoint. Requiring the token in
+//! `Authorization: Bearer ...` defeats that — browsers don't send
+//! arbitrary headers cross-origin without a preflight, and our server
+//! doesn't honor preflights.
+//!
+//! ## Endpoints
+//!
+//! - `GET  /approvals`              — list outstanding approvals
+//! - `POST /approvals/<id>/grant`   — grant; optional JSON body `{"approver": "alice"}`
+//! - `POST /approvals/<id>/reject`  — reject; optional JSON body `{"reason": "..."}`
+//!
+//! Anything else returns 404. Any unauthenticated request returns 401.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::Instant;
+
+use chrono::{DateTime, Utc};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use tiny_http::{Header, Method, Request, Response, Server};
+use uuid::Uuid;
+
+use crate::{ApprovalChannel, ApprovalOutcome, ApprovalRequest, Error, Result};
+
+/// Web channel construction. Owns the HTTP server thread; on drop it
+/// signals shutdown and joins.
+pub struct WebApprovalChannel {
+    bound: SocketAddr,
+    token: String,
+    state: Arc<State>,
+    server: Arc<Server>,
+    server_thread: Option<thread::JoinHandle<()>>,
+}
+
+#[derive(Default)]
+struct State {
+    pending: Mutex<HashMap<String, PendingRequest>>,
+    cv: Condvar,
+}
+
+struct PendingRequest {
+    request: ApprovalRequest,
+    decision: Option<RecordedDecision>,
+}
+
+#[derive(Clone)]
+enum RecordedDecision {
+    Granted {
+        approver: String,
+        decided_at: DateTime<Utc>,
+    },
+    Rejected {
+        reason: String,
+        decided_at: DateTime<Utc>,
+    },
+}
+
+#[derive(Serialize)]
+struct ListEntry<'a> {
+    request_id: &'a str,
+    action_summary: &'a str,
+    resource_uri: &'a str,
+    access_type: &'a str,
+    session_id: &'a str,
+    reasoning_step_id: Option<&'a str>,
+}
+
+#[derive(Default, Deserialize)]
+struct GrantBody {
+    #[serde(default)]
+    approver: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct RejectBody {
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+impl WebApprovalChannel {
+    /// Bind to `bind_addr` (must resolve to a loopback IP) and spawn
+    /// the HTTP worker. Returns the channel + the bound address +
+    /// the printed bearer token.
+    pub fn new(bind_addr: &str) -> Result<Self> {
+        let parsed: SocketAddr = bind_addr
+            .parse()
+            .map_err(|e| Error::Channel(format!("parse bind_addr {bind_addr:?}: {e}")))?;
+        if !is_loopback(parsed.ip()) {
+            return Err(Error::Channel(format!(
+                "web channel refuses non-loopback bind {parsed}; use 127.0.0.1 or ::1"
+            )));
+        }
+
+        let server = Server::http(parsed)
+            .map_err(|e| Error::Channel(format!("bind {parsed}: {e}")))?;
+        let bound = match server.server_addr() {
+            tiny_http::ListenAddr::IP(addr) => addr,
+            _ => return Err(Error::Channel("non-IP listener".to_string())),
+        };
+        let server = Arc::new(server);
+        let state = Arc::new(State::default());
+        let token = generate_token();
+
+        let thread_state = Arc::clone(&state);
+        let thread_token = token.clone();
+        let thread_server = Arc::clone(&server);
+        let server_thread = thread::Builder::new()
+            .name("aegis-web-approval".to_string())
+            .spawn(move || serve(thread_server, thread_state, thread_token))
+            .map_err(Error::Io)?;
+
+        Ok(Self {
+            bound,
+            token,
+            state,
+            server,
+            server_thread: Some(server_thread),
+        })
+    }
+
+    /// Address the server is listening on. Useful for tests and for
+    /// printing the rendezvous URL.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.bound
+    }
+
+    /// Single-session bearer token. Print to the operator alongside
+    /// `local_addr()`; a fresh channel rotates it.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+}
+
+impl Drop for WebApprovalChannel {
+    fn drop(&mut self) {
+        // tiny_http::Server::unblock breaks the recv loop so the
+        // thread can exit; without it, the join would hang.
+        self.server.unblock();
+        if let Some(t) = self.server_thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+impl ApprovalChannel for WebApprovalChannel {
+    fn request_approval(&mut self, req: &ApprovalRequest) -> Result<ApprovalOutcome> {
+        let request_id = Uuid::now_v7().to_string();
+        let deadline = Instant::now() + req.timeout;
+        let mut guard = self
+            .state
+            .pending
+            .lock()
+            .map_err(|_| Error::Channel("pending mutex poisoned".to_string()))?;
+        guard.insert(
+            request_id.clone(),
+            PendingRequest {
+                request: req.clone(),
+                decision: None,
+            },
+        );
+
+        loop {
+            if let Some(entry) = guard.get(&request_id) {
+                if let Some(decision) = entry.decision.clone() {
+                    guard.remove(&request_id);
+                    return Ok(match decision {
+                        RecordedDecision::Granted {
+                            approver,
+                            decided_at,
+                        } => ApprovalOutcome::Granted {
+                            approver_identity: approver,
+                            decided_at,
+                        },
+                        RecordedDecision::Rejected {
+                            reason,
+                            decided_at,
+                        } => ApprovalOutcome::Rejected { reason, decided_at },
+                    });
+                }
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                guard.remove(&request_id);
+                return Ok(ApprovalOutcome::TimedOut {
+                    expired_at: Utc::now(),
+                });
+            }
+            let wait_for = deadline.saturating_duration_since(now);
+            let (next_guard, _) = self
+                .state
+                .cv
+                .wait_timeout(guard, wait_for)
+                .map_err(|_| Error::Channel("pending mutex poisoned".to_string()))?;
+            guard = next_guard;
+        }
+    }
+}
+
+fn serve(server: Arc<Server>, state: Arc<State>, token: String) {
+    for request in server.incoming_requests() {
+        handle(&state, &token, request);
+    }
+}
+
+fn handle(state: &State, token: &str, mut request: Request) {
+    if !authorized(&request, token) {
+        let _ = request.respond(plain(401, "missing or invalid bearer token"));
+        return;
+    }
+    let method = request.method().clone();
+    let url = request.url().to_string();
+    match method {
+        Method::Get if url == "/approvals" => respond_list(state, request),
+        Method::Post if url.starts_with("/approvals/") => {
+            let rest = &url["/approvals/".len()..];
+            if let Some(id) = rest.strip_suffix("/grant") {
+                resolve(state, id, true, &mut request);
+                let _ = request.respond(plain(200, "ok"));
+            } else if let Some(id) = rest.strip_suffix("/reject") {
+                resolve(state, id, false, &mut request);
+                let _ = request.respond(plain(200, "ok"));
+            } else {
+                let _ = request.respond(plain(404, "not found"));
+            }
+        }
+        _ => {
+            let _ = request.respond(plain(404, "not found"));
+        }
+    }
+}
+
+fn authorized(request: &Request, token: &str) -> bool {
+    let expected = format!("Bearer {token}");
+    request
+        .headers()
+        .iter()
+        .any(|h| h.field.equiv("Authorization") && h.value.as_str() == expected)
+}
+
+fn respond_list(state: &State, request: Request) {
+    let pending = match state.pending.lock() {
+        Ok(p) => p,
+        Err(_) => {
+            let _ = request.respond(plain(500, "state poisoned"));
+            return;
+        }
+    };
+    let entries: Vec<ListEntry<'_>> = pending
+        .iter()
+        .filter(|(_, p)| p.decision.is_none())
+        .map(|(id, p)| ListEntry {
+            request_id: id,
+            action_summary: &p.request.action_summary,
+            resource_uri: &p.request.resource_uri,
+            access_type: &p.request.access_type,
+            session_id: &p.request.session_id,
+            reasoning_step_id: p.request.reasoning_step_id.as_deref(),
+        })
+        .collect();
+    let body = match serde_json::to_string(&entries) {
+        Ok(b) => b,
+        Err(_) => {
+            let _ = request.respond(plain(500, "serialize"));
+            return;
+        }
+    };
+    let mut resp = Response::from_string(body).with_status_code(200);
+    if let Some(h) = json_header() {
+        resp = resp.with_header(h);
+    }
+    let _ = request.respond(resp);
+}
+
+fn resolve(state: &State, id: &str, grant: bool, request: &mut Request) {
+    let mut body = String::new();
+    let _ = request.as_reader().read_to_string(&mut body);
+
+    let decision = if grant {
+        let parsed: GrantBody = serde_json::from_str(&body).unwrap_or_default();
+        RecordedDecision::Granted {
+            approver: parsed.approver.unwrap_or_else(|| "web-channel".to_string()),
+            decided_at: Utc::now(),
+        }
+    } else {
+        let parsed: RejectBody = serde_json::from_str(&body).unwrap_or_default();
+        RecordedDecision::Rejected {
+            reason: parsed.reason.unwrap_or_else(|| "rejected".to_string()),
+            decided_at: Utc::now(),
+        }
+    };
+
+    let Ok(mut pending) = state.pending.lock() else {
+        return;
+    };
+    if let Some(entry) = pending.get_mut(id) {
+        entry.decision = Some(decision);
+    }
+    state.cv.notify_all();
+}
+
+fn plain(code: u16, msg: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    Response::from_string(msg.to_string()).with_status_code(code)
+}
+
+fn json_header() -> Option<Header> {
+    Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).ok()
+}
+
+fn is_loopback(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+fn generate_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+use std::io::Read;

--- a/crates/approval-gate/tests/web.rs
+++ b/crates/approval-gate/tests/web.rs
@@ -1,0 +1,146 @@
+//! End-to-end tests for the localhost web UI approval channel
+//! (issue #35, F3).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::time::Duration;
+
+use aegis_approval_gate::{ApprovalChannel, ApprovalOutcome, ApprovalRequest, WebApprovalChannel};
+
+fn req(timeout_ms: u64) -> ApprovalRequest {
+    ApprovalRequest {
+        action_summary: "delete /etc/secrets".to_string(),
+        resource_uri: "file:///etc/secrets".to_string(),
+        access_type: "delete".to_string(),
+        session_id: "session-web-test".to_string(),
+        reasoning_step_id: Some("rstep-007".to_string()),
+        timeout: Duration::from_millis(timeout_ms),
+    }
+}
+
+fn http_post(url: &str, token: &str, body: &str) -> u16 {
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(2))
+        .timeout_read(Duration::from_secs(2))
+        .build();
+    match agent
+        .post(url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .send_string(body)
+    {
+        Ok(r) => r.status(),
+        Err(ureq::Error::Status(code, _)) => code,
+        Err(e) => panic!("request {url}: {e}"),
+    }
+}
+
+fn http_get(url: &str, token: &str) -> (u16, String) {
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(2))
+        .timeout_read(Duration::from_secs(2))
+        .build();
+    match agent
+        .get(url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(r) => {
+            let code = r.status();
+            let body = r.into_string().unwrap();
+            (code, body)
+        }
+        Err(ureq::Error::Status(code, r)) => (code, r.into_string().unwrap_or_default()),
+        Err(e) => panic!("request {url}: {e}"),
+    }
+}
+
+#[test]
+fn refuses_non_loopback_bind() {
+    let err = WebApprovalChannel::new("0.0.0.0:0").unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("non-loopback"), "{msg}");
+}
+
+#[test]
+fn missing_token_returns_401() {
+    let mut channel = WebApprovalChannel::new("127.0.0.1:0").unwrap();
+    let url = format!("http://{}/approvals", channel.local_addr());
+    // Empty token still must not match the channel's real one.
+    let (status, _) = http_get(&url, "");
+    assert_eq!(status, 401);
+    drop(channel);
+}
+
+#[test]
+fn grant_via_http_resolves_with_approver_in_outcome() {
+    let mut channel = WebApprovalChannel::new("127.0.0.1:0").unwrap();
+    let addr = channel.local_addr();
+    let token = channel.token().to_string();
+
+    // Drive a grant from a separate thread once the request is pending.
+    std::thread::spawn(move || {
+        // small delay so the agent thread enqueues first
+        std::thread::sleep(Duration::from_millis(80));
+        let list_url = format!("http://{addr}/approvals");
+        let (status, body) = http_get(&list_url, &token);
+        assert_eq!(status, 200);
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&body).unwrap();
+        assert_eq!(entries.len(), 1, "list body: {body}");
+        let id = entries[0]["request_id"].as_str().unwrap().to_string();
+        let grant_url = format!("http://{addr}/approvals/{id}/grant");
+        let status = http_post(&grant_url, &token, r#"{"approver":"alice"}"#);
+        assert_eq!(status, 200);
+    });
+
+    let outcome = channel.request_approval(&req(5_000)).unwrap();
+    match outcome {
+        ApprovalOutcome::Granted {
+            approver_identity, ..
+        } => assert_eq!(approver_identity, "alice"),
+        other => panic!("expected Granted, got {other:?}"),
+    }
+}
+
+#[test]
+fn reject_via_http_resolves_with_reason() {
+    let mut channel = WebApprovalChannel::new("127.0.0.1:0").unwrap();
+    let addr = channel.local_addr();
+    let token = channel.token().to_string();
+
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(80));
+        let list_url = format!("http://{addr}/approvals");
+        let (_, body) = http_get(&list_url, &token);
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&body).unwrap();
+        let id = entries[0]["request_id"].as_str().unwrap().to_string();
+        let reject_url = format!("http://{addr}/approvals/{id}/reject");
+        let status = http_post(&reject_url, &token, r#"{"reason":"out of scope"}"#);
+        assert_eq!(status, 200);
+    });
+
+    let outcome = channel.request_approval(&req(5_000)).unwrap();
+    match outcome {
+        ApprovalOutcome::Rejected { reason, .. } => assert_eq!(reason, "out of scope"),
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+}
+
+#[test]
+fn timeout_when_no_decision_arrives() {
+    let mut channel = WebApprovalChannel::new("127.0.0.1:0").unwrap();
+    let started = std::time::Instant::now();
+    let outcome = channel.request_approval(&req(300)).unwrap();
+    let elapsed = started.elapsed();
+    assert!(
+        matches!(outcome, ApprovalOutcome::TimedOut { .. }),
+        "got {outcome:?}"
+    );
+    assert!(elapsed >= Duration::from_millis(250));
+}
+
+#[test]
+fn token_rotates_per_channel_instance() {
+    let a = WebApprovalChannel::new("127.0.0.1:0").unwrap();
+    let b = WebApprovalChannel::new("127.0.0.1:0").unwrap();
+    assert_ne!(a.token(), b.token());
+}

--- a/crates/approval-gate/tests/web.rs
+++ b/crates/approval-gate/tests/web.rs
@@ -63,7 +63,7 @@ fn refuses_non_loopback_bind() {
 
 #[test]
 fn missing_token_returns_401() {
-    let mut channel = WebApprovalChannel::new("127.0.0.1:0").unwrap();
+    let channel = WebApprovalChannel::new("127.0.0.1:0").unwrap();
     let url = format!("http://{}/approvals", channel.local_addr());
     // Empty token still must not match the channel's real one.
     let (status, _) = http_get(&url, "");


### PR DESCRIPTION
## Summary
- Second F3 approval channel (after TTY/file in #27 and alongside mTLS in #36) per ADR-005.
- tiny_http server bound to a loopback IP only — refuses any non-loopback bind at construction time.
- One-shot bearer token per channel instance, required on every request via \`Authorization: Bearer ...\`.

## Acceptance criteria (from issue #35)
- [x] Local HTTP server bound to \`127.0.0.1:<port>\`; refuses to start on \`0.0.0.0\`.
- [x] Session-token authentication via header (not cookies — CSRF defense).
- [x] \`GET /approvals\` lists pending; \`POST /approvals/<id>/grant\` and \`/reject\` resolve them.
- [x] Token rotates per channel instance; invalidated on Drop (server stops accepting).
- [x] Tests: non-loopback refused, bad token 401, grant proceeds with approver in outcome, reject with reason, timeout when no decision arrives, per-instance token rotation.
- [ ] Wiring into Session's runtime (a small follow-up — picks the channel from config).

## Out of scope
- TLS (loopback-only — TLS is mTLS-channel territory).
- User accounts (single token = auth model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)