### PR TITLE
test(conformance): cross-language mTLS approval (Go -> Rust)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,3 +33,10 @@ jobs:
 
       - name: Rust conformance
         run: cargo test -p aegis-policy --test conformance -- --nocapture
+
+      - name: mTLS cross-language conformance
+        # Spawns the Go cmd/approver-bot from a Rust integration test
+        # and asserts the approver SPIFFE ID is recorded in the Granted
+        # outcome on the Rust side. See crates/approval-gate/tests/
+        # mtls_conformance.rs.
+        run: cargo test -p aegis-approval-gate --test mtls_conformance -- --nocapture

--- a/cmd/approver-bot/main.go
+++ b/cmd/approver-bot/main.go
@@ -1,0 +1,82 @@
+// Command approver-bot is a minimal mTLS approver client used by the
+// cross-language conformance harness for the Rust MtlsApprovalChannel
+// (issue #36). It is intentionally narrow:
+//
+//  1. Loads the supplied client cert + key.
+//  2. Dials the addr with TLS, presenting that cert and skipping
+//     server-cert validation (the test counterpart's design — server
+//     cert authentication is the mTLS channel's separate concern).
+//  3. Reads one line: the JSON-encoded approval request.
+//  4. Writes one line: the granted/rejected decision JSON.
+//
+// Exits 0 on success. Any I/O / TLS error → non-zero exit.
+package main
+
+import (
+	"bufio"
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+type decision struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+func main() {
+	addr := flag.String("addr", "", "host:port of the mTLS server")
+	certPath := flag.String("client-cert", "", "client cert PEM path")
+	keyPath := flag.String("client-key", "", "client key PEM path")
+	decisionStr := flag.String("decision", "granted", "granted | rejected")
+	reason := flag.String("reason", "out of policy", "reason when --decision=rejected")
+	flag.Parse()
+
+	if *addr == "" || *certPath == "" || *keyPath == "" {
+		log.Fatal("--addr, --client-cert, --client-key are required")
+	}
+
+	cert, err := tls.LoadX509KeyPair(*certPath, *keyPath)
+	if err != nil {
+		log.Fatalf("load client cert/key: %v", err)
+	}
+
+	// InsecureSkipVerify mirrors the Rust test's AcceptAnyServerCert —
+	// the channel under test authenticates the *client*; cross-host
+	// server-cert authentication is a separate concern that we do not
+	// exercise here.
+	cfg := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true, //nolint:gosec // documented above
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	conn, err := tls.Dial("tcp", *addr, cfg)
+	if err != nil {
+		log.Fatalf("tls dial %s: %v", *addr, err)
+	}
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	requestLine, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatalf("read request line: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "request: %s", requestLine)
+
+	d := decision{Decision: *decisionStr}
+	if *decisionStr == "rejected" {
+		d.Reason = *reason
+	}
+	body, err := json.Marshal(d)
+	if err != nil {
+		log.Fatalf("marshal decision: %v", err)
+	}
+	body = append(body, '\n')
+	if _, err := conn.Write(body); err != nil {
+		log.Fatalf("write decision: %v", err)
+	}
+}

--- a/crates/approval-gate/tests/mtls_conformance.rs
+++ b/crates/approval-gate/tests/mtls_conformance.rs
@@ -1,0 +1,124 @@
+//! Cross-language conformance for the F3 mTLS approval channel
+//! (issue #36). Spawns the Go-side `cmd/approver-bot` against the
+//! Rust `MtlsApprovalChannel` and asserts the approver SPIFFE ID
+//! threads through end-to-end.
+//!
+//! Skipped (with a stderr note) when `go` isn't on PATH so local
+//! `cargo test` runs cleanly without the Go toolchain installed. CI
+//! always has Go available in the conformance job.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use aegis_approval_gate::{ApprovalChannel, ApprovalOutcome, ApprovalRequest, MtlsApprovalChannel};
+use aegis_identity::{Digest, DigestTriple, LocalCa};
+
+const TRUST_DOMAIN: &str = "mtls-conformance.local";
+
+fn ephemeral_digests() -> DigestTriple {
+    DigestTriple {
+        model: Digest([1u8; 32]),
+        manifest: Digest([2u8; 32]),
+        config: Digest([3u8; 32]),
+    }
+}
+
+fn workspace_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn go_approver_bot_grants_via_mtls() {
+    if !go_available() {
+        eprintln!("skipping: `go` not in PATH (CI conformance job has it)");
+        return;
+    }
+
+    let work = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let ca = LocalCa::init(ca_dir.path(), TRUST_DOMAIN).unwrap();
+
+    let server_svid = ca
+        .issue_svid("research", "inst-1", ephemeral_digests())
+        .unwrap();
+    let approver_svid = ca
+        .issue_svid("approver-bot", "go-side", ephemeral_digests())
+        .unwrap();
+    let approver_uri = approver_svid.spiffe_id.uri();
+
+    let cert_path = work.path().join("client.crt");
+    let key_path = work.path().join("client.key");
+    std::fs::write(&cert_path, &approver_svid.cert_pem).unwrap();
+    std::fs::write(&key_path, &approver_svid.key_pem).unwrap();
+
+    let mut channel = MtlsApprovalChannel::new(
+        "127.0.0.1:0",
+        &server_svid.cert_pem,
+        &server_svid.key_pem,
+        &ca.root_cert_pem(),
+        vec![approver_uri.clone()],
+    )
+    .unwrap();
+    let addr = channel.local_addr();
+
+    let bot = Command::new("go")
+        .arg("run")
+        .arg("./cmd/approver-bot")
+        .arg("--addr")
+        .arg(addr.to_string())
+        .arg("--client-cert")
+        .arg(&cert_path)
+        .arg("--client-key")
+        .arg(&key_path)
+        .arg("--decision")
+        .arg("granted")
+        .current_dir(workspace_root())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn go approver-bot");
+
+    let outcome = channel
+        .request_approval(&ApprovalRequest {
+            action_summary: "delete /etc/secrets".to_string(),
+            resource_uri: "file:///etc/secrets".to_string(),
+            access_type: "delete".to_string(),
+            session_id: "session-mtls-conformance".to_string(),
+            reasoning_step_id: Some("rstep-007".to_string()),
+            timeout: Duration::from_secs(20),
+        })
+        .unwrap();
+
+    let bot_output = bot.wait_with_output().unwrap();
+    if !bot_output.status.success() {
+        panic!(
+            "approver-bot exited {}: stderr={}",
+            bot_output.status,
+            String::from_utf8_lossy(&bot_output.stderr)
+        );
+    }
+
+    match outcome {
+        ApprovalOutcome::Granted {
+            approver_identity, ..
+        } => assert_eq!(approver_identity, approver_uri),
+        other => panic!("expected Granted, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
Closes the deferred Go-side acceptance bullet from #36. Adds:
- \`cmd/approver-bot/main.go\` — minimal mTLS approver client (load SVID, dial, read request, write decision, exit).
- \`crates/approval-gate/tests/mtls_conformance.rs\` — Rust integration test that spawns the Go bot against a live MtlsApprovalChannel and asserts the Granted outcome carries the approver's SPIFFE URI.
- Conformance workflow gains an mTLS cross-language step that reuses the existing Go + Rust toolchain setup.

## Test plan
- [x] CI conformance job exercises Go -> Rust mTLS round-trip.
- [x] Local \`cargo test\` skips cleanly when \`go\` isn't on PATH (with a stderr note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)