### PR TITLE
feat(policy): explicit-takes-precedence (ADR-019, issue #40)

### DIFF
--- a/crates/policy/src/policy.rs
+++ b/crates/policy/src/policy.rs
@@ -75,33 +75,46 @@ impl Policy {
     /// time fields are treated as eternal (current behavior pre-#38).
     /// NTP skew during a session can cause early/late expiry — short
     /// sessions are the documented mitigation.
+    ///
+    /// **Explicit-takes-precedence (ADR-019, issue #40)**: if any
+    /// `write_grant` names the resource for the requested action, that
+    /// grant's time window is decisive — broader `tools.filesystem.write`
+    /// coverage does NOT paper over an expired explicit grant. A
+    /// time-expired explicit grant returns `Deny` (so the runtime emits
+    /// an F9 violation per ADR-009) instead of falling through.
     pub fn check_filesystem_write(
         &self,
         path: &Path,
         now: DateTime<Utc>,
         session_start: DateTime<Utc>,
     ) -> Decision {
-        if let Some(g) = self.find_write_grant(path, WriteAction::Write, now, session_start) {
-            return self.write_decision(path, g, WriteAction::Write);
+        match self.classify_write_grant(path, WriteAction::Write, now, session_start) {
+            ExplicitGrant::Valid(g) => self.write_decision(path, g, WriteAction::Write),
+            ExplicitGrant::Expired => Decision::deny(format!(
+                "filesystem write of {} blocked by expired write_grant",
+                path.display()
+            )),
+            ExplicitGrant::None => {
+                let covered = self
+                    .manifest
+                    .tools
+                    .filesystem
+                    .as_ref()
+                    .map(|f| paths_cover(path, &f.write))
+                    .unwrap_or(false);
+                if covered {
+                    return self.upgrade_for_approval(
+                        Decision::Allow,
+                        ApprovalClass::AnyWrite,
+                        "any_write requires approval",
+                    );
+                }
+                Decision::deny(format!(
+                    "filesystem write of {} not granted by manifest",
+                    path.display()
+                ))
+            }
         }
-        let covered = self
-            .manifest
-            .tools
-            .filesystem
-            .as_ref()
-            .map(|f| paths_cover(path, &f.write))
-            .unwrap_or(false);
-        if covered {
-            return self.upgrade_for_approval(
-                Decision::Allow,
-                ApprovalClass::AnyWrite,
-                "any_write requires approval",
-            );
-        }
-        Decision::deny(format!(
-            "filesystem write of {} not granted by manifest",
-            path.display()
-        ))
     }
 
     /// Filesystem delete: only allowed via a write grant whose `actions`
@@ -113,13 +126,17 @@ impl Policy {
         now: DateTime<Utc>,
         session_start: DateTime<Utc>,
     ) -> Decision {
-        if let Some(g) = self.find_write_grant(path, WriteAction::Delete, now, session_start) {
-            return self.write_decision(path, g, WriteAction::Delete);
+        match self.classify_write_grant(path, WriteAction::Delete, now, session_start) {
+            ExplicitGrant::Valid(g) => self.write_decision(path, g, WriteAction::Delete),
+            ExplicitGrant::Expired => Decision::deny(format!(
+                "filesystem delete of {} blocked by expired write_grant",
+                path.display()
+            )),
+            ExplicitGrant::None => Decision::deny(format!(
+                "filesystem delete of {} not granted by any write_grant",
+                path.display()
+            )),
         }
-        Decision::deny(format!(
-            "filesystem delete of {} not granted by any write_grant",
-            path.display()
-        ))
     }
 
     /// Network outbound: closed-by-default. Per ADR-008 the absence of a
@@ -179,17 +196,36 @@ impl Policy {
         )
     }
 
-    fn find_write_grant(
+    /// Classify whether the manifest has an explicit `write_grant` for
+    /// `(path, action)` — and if so, whether any matching grant is
+    /// currently in its time window. Used by `check_filesystem_write`
+    /// and `check_filesystem_delete` to enforce the explicit-takes-
+    /// precedence rule (ADR-019).
+    fn classify_write_grant(
         &self,
         path: &Path,
         want: WriteAction,
         now: DateTime<Utc>,
         session_start: DateTime<Utc>,
-    ) -> Option<&WriteGrant> {
+    ) -> ExplicitGrant<'_> {
         let p = path.to_string_lossy();
-        self.manifest.write_grants.iter().find(|g| {
-            g.resource == p && g.actions.contains(&want) && grant_time_valid(g, now, session_start)
-        })
+        let matching: Vec<&WriteGrant> = self
+            .manifest
+            .write_grants
+            .iter()
+            .filter(|g| g.resource == p && g.actions.contains(&want))
+            .collect();
+        if matching.is_empty() {
+            return ExplicitGrant::None;
+        }
+        if let Some(g) = matching
+            .iter()
+            .copied()
+            .find(|g| grant_time_valid(g, now, session_start))
+        {
+            return ExplicitGrant::Valid(g);
+        }
+        ExplicitGrant::Expired
     }
 
     fn write_decision(&self, path: &Path, g: &WriteGrant, action: WriteAction) -> Decision {
@@ -215,6 +251,17 @@ impl Policy {
             other => other,
         }
     }
+}
+
+/// Outcome of inspecting `manifest.write_grants` for a resource/action.
+/// Drives the explicit-takes-precedence rule (ADR-019).
+enum ExplicitGrant<'a> {
+    /// No grant in the manifest names this resource for this action.
+    None,
+    /// At least one matching grant is currently in its time window.
+    Valid(&'a WriteGrant),
+    /// At least one matching grant exists but ALL of them are expired.
+    Expired,
 }
 
 /// True if a manifest's exec_grant `program` field matches the query.

--- a/docs/adrs/019-explicit-write-grant-takes-precedence.md
+++ b/docs/adrs/019-explicit-write-grant-takes-precedence.md
@@ -1,0 +1,111 @@
+# 19. Explicit Write Grant Takes Precedence Over Broad Path Coverage
+
+**Status:** Accepted
+**Date:** 2026-04-29
+**Domain:** Permission Manifest / F7 Time-Bounded Write Grants (extends ADR-009)
+
+## Context
+
+[ADR-009](009-read-only-default-with-explicit-write-grants.md) (F7) introduced
+time-bounded `write_grants` so an operator can express "agent X may write
+`/tmp/secret.txt` only between 10:00 and 11:00". After [issue #38](https://github.com/tosin2013/aegis-node/issues/38)
+landed both engines (Rust `aegis-policy`, Go `pkg/manifest`) agreed on the
+single-axis case: an expired grant filters out and the path falls back to
+closed-by-default Deny. The `time-bounded-write.manifest.yaml` conformance
+fixture deliberately avoided one second-order interaction by setting `tools: {}`,
+and the comment in that file reserved the question for a follow-up — this ADR.
+
+The interaction is:
+
+```yaml
+tools:
+  filesystem:
+    write: ["/tmp"]
+write_grants:
+  - resource: "/tmp/secret.txt"
+    actions: ["write"]
+    expires_at: "2026-04-29T10:30:00Z"
+```
+
+After `10:30:00Z`, the previous behavior was:
+
+1. `find_write_grant("/tmp/secret.txt", write, now)` returns `None` because
+   the only matching grant is time-expired and gets filtered out.
+2. Code falls through to `tools.filesystem.write` and finds `/tmp` covers
+   the path.
+3. **Decision: Allow.**
+
+That fall-through quietly weakens the time bound. A reader looking at the
+manifest would reasonably read it as "this is the boundary on what I'll
+allow for `/tmp/secret.txt`". They would not expect the broader `/tmp` rule
+to reactivate the path after the explicit grant expired.
+
+## Decision
+
+**Explicit-takes-precedence.** If any `write_grant` names a resource for the
+requested action, that grant's time window is decisive — broader
+`tools.filesystem.write` coverage does NOT paper over an expired explicit
+grant.
+
+The classification has three outcomes:
+
+| State | Trigger | Effect |
+|---|---|---|
+| **Valid** | At least one matching grant is in its time window | Allow / RequireApproval per the grant's `approval_required` flag and `approval_required_for: [any_write]` |
+| **Expired** | At least one matching grant exists, but ALL are out of window | **Deny** + F9 Violation (per ADR-009's "expired grants emit violations" line) |
+| **None** | No matching grant at all | Fall through to `tools.filesystem.write` (existing behavior) |
+
+`Valid` wins over `Expired` — if two grants name the same resource and one
+is in window, the in-window grant decides. This handles legitimate
+overlap (e.g., a renewal grant added before the previous one expired).
+
+The same rule applies to `check_filesystem_delete` for symmetry, even though
+that path has no broader-rule fall-through to undermine. Sharing the
+classifier keeps the two paths consistent and makes future actions
+(`update`, `create`) inherit the rule for free.
+
+## Consequences
+
+**Positive**
+
+- Time bounds become unforgeable from the manifest reader's perspective:
+  if you write a time-bounded grant for a resource, that's the lifetime of
+  access regardless of what else the manifest says.
+- Aligns with ADR-009's stated intent that "expired grants emit violations".
+- No schema change — `schemaVersion: "1"` stays frozen. Per the
+  [Compatibility Charter](../COMPATIBILITY_CHARTER.md), this is a runtime
+  semantics tightening that doesn't add or remove fields.
+
+**Negative**
+
+- A pre-#39 manifest that intentionally relied on fall-through (broad rule
+  resumes after specific grant expires) will see different behavior under
+  the new rule. We believe this pattern is rare in practice (the grants
+  shipped in v0.5.0 / v0.8.0 fixtures don't use it), and a manifest author
+  who genuinely wants "specific until X, then broad" can still express it
+  by leaving the broad rule in place and removing the `expires_at` from the
+  explicit grant.
+- The classifier must scan all grants (rather than the previous early-return
+  on first valid hit). The cost is bounded by the number of `write_grants`
+  in the manifest — typically single digits — so the impact is negligible.
+
+## Implementation
+
+- **Rust** (`crates/policy/src/policy.rs`): new private `ExplicitGrant` enum
+  (`Valid(&WriteGrant) | Expired | None`) and `Policy::classify_write_grant`
+  helper. Both `check_filesystem_write` and `check_filesystem_delete`
+  branch on the classifier instead of calling `find_write_grant` and falling
+  through on `None`.
+- **Go** (`pkg/manifest/decide.go`): mirror with `grantState` + `Manifest.classifyWriteGrant`.
+- **Conformance**: a new fixture `tests/conformance/manifests/explicit-overrides-broad.manifest.yaml`
+  pairs a broad `tools.filesystem.write: ["/tmp"]` rule with an explicit
+  `write_grant` for `/tmp/secret.txt`. Cross-language cases added to
+  `tests/conformance/cases.json`.
+
+## Refs
+
+- ADR-009 (F7 read-only default)
+- Issue #38 / PR #39 — first half of F7 (parser + single-axis enforcement)
+- Issue #40 — this ADR
+- `time-bounded-write.manifest.yaml` — fixture comment that anticipated
+  this question

--- a/pkg/manifest/decide.go
+++ b/pkg/manifest/decide.go
@@ -220,34 +220,6 @@ const (
 // interop without changing types.go signatures.
 type WriteAction string
 
-func (m *Manifest) findWriteGrantFor(
-	uri string,
-	action WriteAction,
-	now, sessionStart time.Time,
-) *WriteGrant {
-	for i := range m.WriteGrants {
-		g := &m.WriteGrants[i]
-		if g.Resource != uri {
-			continue
-		}
-		hasAction := false
-		for _, a := range g.Actions {
-			if a == string(action) {
-				hasAction = true
-				break
-			}
-		}
-		if !hasAction {
-			continue
-		}
-		if !grantTimeValid(g, now, sessionStart) {
-			continue
-		}
-		return g
-	}
-	return nil
-}
-
 // grantState distinguishes the three relevant outcomes when looking
 // up an explicit write_grant for a resource: no grant at all (fall
 // through to broader rules), a time-valid grant (decisive), or one

--- a/pkg/manifest/decide.go
+++ b/pkg/manifest/decide.go
@@ -98,8 +98,15 @@ func (m *Manifest) decideFsRead(uri string) Decision {
 }
 
 func (m *Manifest) decideFsWrite(uri string, now, sessionStart time.Time) Decision {
-	if g := m.findWriteGrantFor(uri, ActionWrite, now, sessionStart); g != nil {
+	// Explicit-takes-precedence (ADR-019, issue #40): if any write_grant
+	// names this resource for this action, that grant's time window is
+	// decisive — broader tools.filesystem.write does NOT paper over an
+	// expired explicit grant.
+	switch state, g := m.classifyWriteGrant(uri, ActionWrite, now, sessionStart); state {
+	case grantValid:
 		return m.writeGrantDecision(uri, g, ActionWrite)
+	case grantExpired:
+		return denyDecision(fmt.Sprintf("filesystem write of %s blocked by expired write_grant", uri))
 	}
 	var paths []string
 	if m.Tools.Filesystem != nil {
@@ -113,8 +120,11 @@ func (m *Manifest) decideFsWrite(uri string, now, sessionStart time.Time) Decisi
 }
 
 func (m *Manifest) decideFsDelete(uri string, now, sessionStart time.Time) Decision {
-	if g := m.findWriteGrantFor(uri, ActionDelete, now, sessionStart); g != nil {
+	switch state, g := m.classifyWriteGrant(uri, ActionDelete, now, sessionStart); state {
+	case grantValid:
 		return m.writeGrantDecision(uri, g, ActionDelete)
+	case grantExpired:
+		return denyDecision(fmt.Sprintf("filesystem delete of %s blocked by expired write_grant", uri))
 	}
 	return denyDecision(fmt.Sprintf("filesystem delete of %s not granted by any write_grant", uri))
 }
@@ -236,6 +246,51 @@ func (m *Manifest) findWriteGrantFor(
 		return g
 	}
 	return nil
+}
+
+// grantState distinguishes the three relevant outcomes when looking
+// up an explicit write_grant for a resource: no grant at all (fall
+// through to broader rules), a time-valid grant (decisive), or one
+// that exists but has expired (decisive Deny per ADR-019).
+type grantState int
+
+const (
+	grantNone grantState = iota
+	grantValid
+	grantExpired
+)
+
+// classifyWriteGrant mirrors Rust's `Policy::classify_write_grant`. It
+// scans `m.WriteGrants` for any entry naming `uri` for `action` and
+// returns the strongest outcome — Valid wins over Expired wins over
+// None. Drives the explicit-takes-precedence rule.
+func (m *Manifest) classifyWriteGrant(
+	uri string,
+	action WriteAction,
+	now, sessionStart time.Time,
+) (grantState, *WriteGrant) {
+	state := grantNone
+	for i := range m.WriteGrants {
+		g := &m.WriteGrants[i]
+		if g.Resource != uri {
+			continue
+		}
+		hasAction := false
+		for _, a := range g.Actions {
+			if a == string(action) {
+				hasAction = true
+				break
+			}
+		}
+		if !hasAction {
+			continue
+		}
+		if grantTimeValid(g, now, sessionStart) {
+			return grantValid, g
+		}
+		state = grantExpired
+	}
+	return state, nil
 }
 
 // grantTimeValid mirrors aegis_policy::policy::grant_time_valid in Rust:

--- a/tests/conformance/cases.json
+++ b/tests/conformance/cases.json
@@ -206,6 +206,42 @@
         "session_start": "2026-04-29T10:00:00Z"
       },
       "expected": "allow"
+    },
+    {
+      "_doc": "ADR-019: explicit-takes-precedence. Inside the grant window, the explicit write_grant for /tmp/secret.txt allows the write — same as broad /tmp coverage would, so the rule is observably equivalent here.",
+      "name": "explicit_grant_in_window_allows",
+      "manifest": "manifests/explicit-overrides-broad.manifest.yaml",
+      "query": {
+        "kind": "filesystem_write",
+        "resource_uri": "/tmp/secret.txt",
+        "now": "2026-04-29T10:15:00Z",
+        "session_start": "2026-04-29T10:00:00Z"
+      },
+      "expected": "allow"
+    },
+    {
+      "_doc": "ADR-019: explicit-takes-precedence. AFTER the explicit grant's cutoff, the broader tools.filesystem.write: ['/tmp'] rule does NOT paper over the expired explicit grant — Deny.",
+      "name": "explicit_grant_expired_denies_despite_broad_coverage",
+      "manifest": "manifests/explicit-overrides-broad.manifest.yaml",
+      "query": {
+        "kind": "filesystem_write",
+        "resource_uri": "/tmp/secret.txt",
+        "now": "2026-04-29T11:00:00Z",
+        "session_start": "2026-04-29T10:00:00Z"
+      },
+      "expected": "deny"
+    },
+    {
+      "_doc": "ADR-019: any path NOT named by an explicit grant still falls through to the broad rule. /tmp/other.txt has no explicit grant, so /tmp coverage applies and the write is allowed regardless of clock.",
+      "name": "non_explicit_path_falls_through_to_broad_coverage",
+      "manifest": "manifests/explicit-overrides-broad.manifest.yaml",
+      "query": {
+        "kind": "filesystem_write",
+        "resource_uri": "/tmp/other.txt",
+        "now": "2026-04-29T11:00:00Z",
+        "session_start": "2026-04-29T10:00:00Z"
+      },
+      "expected": "allow"
     }
   ]
 }

--- a/tests/conformance/manifests/explicit-overrides-broad.manifest.yaml
+++ b/tests/conformance/manifests/explicit-overrides-broad.manifest.yaml
@@ -1,0 +1,23 @@
+# Conformance fixture for ADR-019 (issue #40):
+# explicit-takes-precedence over broader tools.filesystem.write coverage.
+#
+# An explicit write_grant for /tmp/secret.txt is the boundary for that
+# resource regardless of expiry. The broad /tmp coverage exists for
+# everything else under /tmp, but does NOT paper over the explicit
+# grant when it expires.
+
+schemaVersion: "1"
+agent:
+  name: "explicit-overrides-broad-test"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/overlap-test/inst-001"
+tools:
+  filesystem:
+    write: ["/tmp"]
+write_grants:
+  # Time-bounded explicit grant on a single resource. Per ADR-019 this
+  # is decisive for /tmp/secret.txt — both before AND after expiry.
+  - resource: "/tmp/secret.txt"
+    actions: ["write"]
+    expires_at: "2026-04-29T10:30:00Z"

--- a/tests/conformance/manifests/time-bounded-write.manifest.yaml
+++ b/tests/conformance/manifests/time-bounded-write.manifest.yaml
@@ -2,13 +2,11 @@
 # `duration` (relative to session_start) and `expires_at` (absolute).
 # Per F7 / issue #38.
 #
-# NOTE: deliberately no `tools.filesystem.write` blanket coverage —
-# the only path-write coverage comes from the write_grants below, so
-# an expired grant correctly falls through to the closed-by-default
-# Deny rather than being undermined by a broader rule. The interaction
-# of expired write_grants with broader path coverage is a separate
-# semantic question (closed-by-default vs fallback) that deserves its
-# own issue once #38 lands.
+# NOTE: deliberately no `tools.filesystem.write` blanket coverage so
+# this fixture exercises the single-axis time-bound case in isolation.
+# The interaction of expired write_grants with broader coverage is
+# settled in ADR-019 and exercised by the
+# `explicit-overrides-broad.manifest.yaml` fixture.
 
 schemaVersion: "1"
 agent:


### PR DESCRIPTION
## Summary
Settles the F7 second-order semantic question from #40: an explicit \`write_grant\` for a resource is the boundary for that resource regardless of expiry. Broader \`tools.filesystem.write\` coverage does NOT paper over an expired explicit grant.

## Decision (ADR-019, accepted)
- **Valid** explicit grant ⇒ Allow / RequireApproval (existing behavior)
- **Expired** explicit grant ⇒ **Deny** (emits F9 violation per ADR-009)
- **No** explicit grant for the path ⇒ fall through to broader rule (existing behavior)

## Implementation
- Rust: new private \`ExplicitGrant\` enum + \`Policy::classify_write_grant\` helper. \`check_filesystem_write\` / \`check_filesystem_delete\` branch on it.
- Go: mirror with \`grantState\` + \`classifyWriteGrant\`.
- Conformance: new \`explicit-overrides-broad.manifest.yaml\` fixture with broad \`/tmp\` coverage + a time-bounded explicit grant on \`/tmp/secret.txt\`; three cross-language rows exercise the in-window, post-expiry, and non-explicit-path paths.

## Acceptance criteria from #40
- [x] Decision documented in an ADR (ADR-019).
- [x] Both engines implement the chosen rule.
- [x] Conformance harness gains rows for the overlapping case.
- [x] Existing fixtures still pass — \`time-bounded-write.manifest.yaml\` doesn't pair with a broad rule, so all its rows are unaffected. The stale fixture comment that anticipated this issue is updated to point at the new fixture + ADR.

No schema change — \`schemaVersion: "1"\` stays frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)