### PR TITLE
feat(manifest): tools.mcp[] schema bump (ADR-018, F2-MCP-A)

### DIFF
--- a/crates/policy/src/manifest.rs
+++ b/crates/policy/src/manifest.rs
@@ -58,6 +58,8 @@ pub struct Tools {
     pub network: Option<Network>,
     #[serde(default)]
     pub apis: Vec<ApiGrant>,
+    #[serde(default)]
+    pub mcp: Vec<McpServerGrant>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -118,6 +120,17 @@ pub struct ApiGrant {
     pub name: String,
     #[serde(default)]
     pub methods: Vec<String>,
+}
+
+/// One entry in `tools.mcp` (per ADR-018). The agent may connect to
+/// `server_uri` and invoke any tool name in `allowed_tools`. Closed by
+/// default — an MCP tool call against a server not listed here is denied.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpServerGrant {
+    pub server_name: String,
+    pub server_uri: String,
+    pub allowed_tools: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -246,3 +246,49 @@ fn emit_violation_appends_violation_entry() {
 
     let _ = EntryType::Violation; // sanity
 }
+
+/// Per ADR-018 / issue #43. Parses a valid `tools.mcp[]` example.
+#[test]
+fn mcp_server_grant_parses() {
+    let yaml = br#"
+schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools:
+  mcp:
+    - server_name: "fs-helper"
+      server_uri: "stdio:/usr/local/bin/mcp-fs"
+      allowed_tools: ["read_file", "list_dir"]
+    - server_name: "web-search"
+      server_uri: "https://mcp.example.com:8443"
+      allowed_tools: []
+"#;
+    let p = Policy::from_yaml_bytes(yaml).unwrap();
+    let mcp = &p.manifest().tools.mcp;
+    assert_eq!(mcp.len(), 2);
+    assert_eq!(mcp[0].server_name, "fs-helper");
+    assert_eq!(mcp[0].server_uri, "stdio:/usr/local/bin/mcp-fs");
+    assert_eq!(mcp[0].allowed_tools, vec!["read_file", "list_dir"]);
+    assert_eq!(mcp[1].server_name, "web-search");
+    assert!(mcp[1].allowed_tools.is_empty());
+}
+
+/// Per ADR-018 / issue #43. Malformed entry (missing `server_uri`) is rejected.
+#[test]
+fn mcp_server_grant_rejects_missing_uri() {
+    let yaml = br#"
+schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools:
+  mcp:
+    - server_name: "fs-helper"
+      allowed_tools: ["read_file"]
+"#;
+    let err = Policy::from_yaml_bytes(yaml).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("server_uri") || msg.contains("missing"),
+        "error should mention the missing field: {msg}",
+    );
+}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -150,6 +150,62 @@ tools:
 	}
 }
 
+// Per ADR-018 / issue #43. Parses a valid `tools.mcp[]` example.
+func TestMCPServerGrantParses(t *testing.T) {
+	yaml := `schemaVersion: "1"
+agent:
+  name: "x"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://td/agent/x/1"
+tools:
+  mcp:
+    - server_name: "fs-helper"
+      server_uri: "stdio:/usr/local/bin/mcp-fs"
+      allowed_tools: ["read_file", "list_dir"]
+    - server_name: "web-search"
+      server_uri: "https://mcp.example.com:8443"
+      allowed_tools: []
+`
+	m, err := Parse("m.yaml", []byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Tools.MCP) != 2 {
+		t.Fatalf("mcp: got %d entries, want 2", len(m.Tools.MCP))
+	}
+	if m.Tools.MCP[0].ServerName != "fs-helper" ||
+		m.Tools.MCP[0].ServerURI != "stdio:/usr/local/bin/mcp-fs" ||
+		len(m.Tools.MCP[0].AllowedTools) != 2 ||
+		m.Tools.MCP[0].AllowedTools[0] != "read_file" {
+		t.Errorf("mcp[0]: %+v", m.Tools.MCP[0])
+	}
+	if m.Tools.MCP[1].ServerName != "web-search" ||
+		len(m.Tools.MCP[1].AllowedTools) != 0 {
+		t.Errorf("mcp[1]: %+v", m.Tools.MCP[1])
+	}
+}
+
+// Per ADR-018 / issue #43. A malformed entry (missing required server_uri)
+// must be rejected by the schema.
+func TestMCPServerGrantRejectsMissingURI(t *testing.T) {
+	yaml := `schemaVersion: "1"
+agent:
+  name: "x"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://td/agent/x/1"
+tools:
+  mcp:
+    - server_name: "fs-helper"
+      allowed_tools: ["read_file"]
+`
+	_, err := Parse("m.yaml", []byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for missing server_uri")
+	}
+}
+
 func TestExtendsNarrowingAccepted(t *testing.T) {
 	dir := t.TempDir()
 	parent := filepath.Join(dir, "parent.yaml")

--- a/pkg/manifest/schema_v1.json
+++ b/pkg/manifest/schema_v1.json
@@ -69,6 +69,12 @@
           "type": "array",
           "items": { "$ref": "#/definitions/apiGrant" },
           "uniqueItems": true
+        },
+        "mcp": {
+          "type": "array",
+          "description": "MCP servers the agent may connect to (per ADR-018). Closed-by-default — without an entry, MCP tool calls are denied.",
+          "items": { "$ref": "#/definitions/mcpServerGrant" },
+          "uniqueItems": true
         }
       }
     },
@@ -165,6 +171,25 @@
             "type": "string",
             "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
           },
+          "uniqueItems": true
+        }
+      }
+    },
+    "mcpServerGrant": {
+      "type": "object",
+      "required": ["server_name", "server_uri", "allowed_tools"],
+      "additionalProperties": false,
+      "properties": {
+        "server_name": { "type": "string", "minLength": 1 },
+        "server_uri": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where the MCP server lives. Examples: stdio:/path/to/binary, https://host:port, spiffe://td/agent/..."
+        },
+        "allowed_tools": {
+          "type": "array",
+          "description": "Names of MCP tools from this server the agent may invoke. Closed-by-default; empty array means none.",
+          "items": { "type": "string", "minLength": 1 },
           "uniqueItems": true
         }
       }

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -37,9 +37,10 @@ type Identity struct {
 }
 
 type Tools struct {
-	Filesystem *Filesystem `yaml:"filesystem,omitempty" json:"filesystem,omitempty"`
-	Network    *Network    `yaml:"network,omitempty" json:"network,omitempty"`
-	APIs       []APIGrant  `yaml:"apis,omitempty" json:"apis,omitempty"`
+	Filesystem *Filesystem      `yaml:"filesystem,omitempty" json:"filesystem,omitempty"`
+	Network    *Network         `yaml:"network,omitempty" json:"network,omitempty"`
+	APIs       []APIGrant       `yaml:"apis,omitempty" json:"apis,omitempty"`
+	MCP        []MCPServerGrant `yaml:"mcp,omitempty" json:"mcp,omitempty"`
 }
 
 type Filesystem struct {
@@ -78,6 +79,16 @@ type NetworkAllowEntry struct {
 type APIGrant struct {
 	Name    string   `yaml:"name" json:"name"`
 	Methods []string `yaml:"methods,omitempty" json:"methods,omitempty"`
+}
+
+// MCPServerGrant is one entry in `tools.mcp` (per ADR-018). The agent may
+// connect to `ServerURI` and invoke any tool name listed in `AllowedTools`.
+// Closed-by-default: an MCP tool call against a server not listed here is
+// denied + emits a Violation per F2.
+type MCPServerGrant struct {
+	ServerName   string   `yaml:"server_name" json:"server_name"`
+	ServerURI    string   `yaml:"server_uri" json:"server_uri"`
+	AllowedTools []string `yaml:"allowed_tools" json:"allowed_tools"`
 }
 
 type WriteGrant struct {

--- a/schemas/manifest/v1/manifest.schema.json
+++ b/schemas/manifest/v1/manifest.schema.json
@@ -69,6 +69,12 @@
           "type": "array",
           "items": { "$ref": "#/definitions/apiGrant" },
           "uniqueItems": true
+        },
+        "mcp": {
+          "type": "array",
+          "description": "MCP servers the agent may connect to (per ADR-018). Closed-by-default — without an entry, MCP tool calls are denied.",
+          "items": { "$ref": "#/definitions/mcpServerGrant" },
+          "uniqueItems": true
         }
       }
     },
@@ -165,6 +171,25 @@
             "type": "string",
             "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
           },
+          "uniqueItems": true
+        }
+      }
+    },
+    "mcpServerGrant": {
+      "type": "object",
+      "required": ["server_name", "server_uri", "allowed_tools"],
+      "additionalProperties": false,
+      "properties": {
+        "server_name": { "type": "string", "minLength": 1 },
+        "server_uri": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where the MCP server lives. Examples: stdio:/path/to/binary, https://host:port, spiffe://td/agent/..."
+        },
+        "allowed_tools": {
+          "type": "array",
+          "description": "Names of MCP tools from this server the agent may invoke. Closed-by-default; empty array means none.",
+          "items": { "type": "string", "minLength": 1 },
           "uniqueItems": true
         }
       }


### PR DESCRIPTION
## Summary

- Adds optional \`tools.mcp[]\` array to the Permission Manifest schema (closed-by-default per ADR-018).
- Mirrors the type in Go (\`pkg/manifest\`) and Rust (\`crates/policy\`); embedded schema drift-test stays green.
- Two unit tests on each side: parse a valid \`tools.mcp[]\` example; reject malformed entry (missing \`server_uri\`).

Closes #43. First sub-issue of the MCP umbrella #42.

## Per

- ADR-018 §Decision item 4
- ADR-004 (Permission Manifest)
- Compatibility Charter §"Allowed evolution" — adding new optional properties is non-breaking; \`schemaVersion\` stays \"1\".

## Schema shape

\`\`\`yaml
tools:
  mcp:
    - server_name: "fs-helper"
      server_uri: "stdio:/usr/local/bin/mcp-fs"
      allowed_tools: ["read_file", "list_dir"]
\`\`\`

\`mcpServerGrant\` requires \`server_name\`, \`server_uri\`, \`allowed_tools\`; \`additionalProperties: false\`. \`allowed_tools: []\` means none.

## Out of scope

Wiring \`tools.mcp[]\` through the mediator + cross-language conformance harness land in:
- #44 F2-MCP-B (mediator extension \`mediate_mcp_tool_call\`)
- #45 F2-MCP-C (cross-language conformance rows)
- #46 F2-MCP-D (example MCP-using manifest)

## Test plan

- [x] \`cargo test --workspace --all-targets\` (29/29 passing locally)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`go test ./pkg/manifest/\` (drift-test + 2 new MCP tests passing)
- [x] \`gofmt\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)