### PR TITLE
feat(mediator): MCP tool-call mediation (ADR-018, F2-MCP-B)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/policy",
     "crates/filesystem-gate",
     "crates/approval-gate",
+    "crates/mcp-client",
 ]
 
 [workspace.package]

--- a/crates/access-log/src/lib.rs
+++ b/crates/access-log/src/lib.rs
@@ -33,6 +33,12 @@ pub enum AccessType {
     NetworkOutbound,
     NetworkInbound,
     Exec,
+    /// One MCP tool invocation (per ADR-018 / F2-MCP-B). `resourceUri`
+    /// for these entries is `mcp://{server_name}/{tool_name}`.
+    /// Side-effects of the underlying tool (filesystem reads, network
+    /// connects, ...) emit their own access entries; this is the
+    /// summary, not a replacement.
+    McpToolCall,
 }
 
 /// One access event. The runtime constructs this at the syscall boundary

--- a/crates/inference-engine/Cargo.toml
+++ b/crates/inference-engine/Cargo.toml
@@ -15,6 +15,7 @@ aegis-access-log = { path = "../access-log" }
 aegis-approval-gate = { path = "../approval-gate" }
 aegis-identity = { path = "../identity" }
 aegis-ledger-writer = { path = "../ledger-writer" }
+aegis-mcp-client = { path = "../mcp-client" }
 aegis-policy = { path = "../policy" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 serde_json = "1"

--- a/crates/inference-engine/src/mediator.rs
+++ b/crates/inference-engine/src/mediator.rs
@@ -259,6 +259,82 @@ impl Session {
         }
     }
 
+    /// MCP tool call with full mediation (per ADR-018 / F2-MCP-B / issue
+    /// #44). Resolves `(server_name, tool_name)` against the manifest's
+    /// `tools.mcp[]` allowlist; on `Allow`, dispatches via the configured
+    /// MCP client and emits one `EntryType::Access` with
+    /// `accessType=mcp_tool_call`. On `Deny`, emits a Violation and
+    /// returns `Error::Denied`. On a missing MCP client, treats the call
+    /// as denied with reason `"no mcp client configured"` so audit still
+    /// shows the attempt.
+    ///
+    /// Side-effects produced *inside* the upstream tool (filesystem
+    /// reads, network connects, ...) emit their own access entries
+    /// through the existing `mediate_*` methods — this entry is the
+    /// summary, not a replacement.
+    pub fn mediate_mcp_tool_call(
+        &mut self,
+        server_name: &str,
+        tool_name: &str,
+        args: serde_json::Value,
+        reasoning_step_id: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        self.rebind()?;
+        let decision = self.policy().check_mcp_tool(server_name, tool_name);
+        let resource_uri = mcp_uri(server_name, tool_name);
+        match decision {
+            Decision::Allow => {}
+            Decision::Deny { reason } => {
+                self.emit_deny(&resource_uri, "mcp_tool_call", &reason)?;
+                return Err(Error::Denied { reason });
+            }
+            Decision::RequireApproval { reason } => {
+                // Phase 1: approval gates over MCP not yet wired.
+                return Err(Error::RequireApproval { reason });
+            }
+        }
+        let server_uri = match self
+            .policy()
+            .manifest()
+            .tools
+            .mcp
+            .iter()
+            .find(|s| s.server_name == server_name)
+        {
+            Some(s) => s.server_uri.clone(),
+            None => {
+                let reason = format!(
+                    "mcp tool call to server {server_name:?} not granted: server not in tools.mcp[]",
+                );
+                self.emit_deny(&resource_uri, "mcp_tool_call", &reason)?;
+                return Err(Error::Denied { reason });
+            }
+        };
+        let mut client = match self.mcp_client.take() {
+            Some(c) => c,
+            None => {
+                let reason = "no mcp client configured for session".to_string();
+                self.emit_deny(&resource_uri, "mcp_tool_call", &reason)?;
+                return Err(Error::Denied { reason });
+            }
+        };
+        let result = client.call_tool(&server_uri, tool_name, args);
+        self.mcp_client = Some(client);
+        let value = result.map_err(|e| Error::Denied {
+            reason: format!("mcp client: {e}"),
+        })?;
+        let bytes = serde_json::to_vec(&value)
+            .map(|v| v.len() as u64)
+            .unwrap_or(0);
+        self.emit_success(
+            &resource_uri,
+            AccessType::McpToolCall,
+            bytes,
+            reasoning_step_id,
+        )?;
+        Ok(value)
+    }
+
     /// Exec a program with full mediation. Returns the captured Output.
     pub fn mediate_exec(
         &mut self,
@@ -553,6 +629,10 @@ fn file_uri(path: &Path) -> String {
             Err(_) => format!("file://{}", path.display()),
         }
     }
+}
+
+fn mcp_uri(server_name: &str, tool_name: &str) -> String {
+    format!("mcp://{server_name}/{tool_name}")
 }
 
 fn network_uri(host: &str, port: u16, proto: NetworkProto) -> String {

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use aegis_approval_gate::ApprovalChannel;
 use aegis_identity::{verify_digest_binding, Digest, DigestField, DigestTriple, LocalCa, SpiffeId};
 use aegis_ledger_writer::{Entry, EntryType, LedgerWriter};
+use aegis_mcp_client::McpClient;
 use aegis_policy::Policy;
 use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
@@ -69,6 +70,11 @@ pub struct Session {
     /// of outcome. `shutdown` summarizes + signs + emits a
     /// `NetworkAttestation` ledger entry before `SessionEnd`.
     pub(crate) network_log: Vec<NetworkConnectionMeta>,
+    /// MCP client used by `mediate_mcp_tool_call` (per ADR-018 / F2-MCP-B
+    /// / issue #44). None means MCP tool calls are unsupported in this
+    /// session — the mediator returns `Error::Denied` rather than panic.
+    /// Set via [`Session::with_mcp_client`] after boot.
+    pub(crate) mcp_client: Option<Box<dyn McpClient>>,
 }
 
 /// One observed network-connection attempt + the gate's decision.
@@ -176,6 +182,7 @@ impl Session {
             config_path: cfg.config_path,
             approval_channel: None,
             network_log: Vec::new(),
+            mcp_client: None,
         })
     }
 
@@ -185,6 +192,14 @@ impl Session {
     /// preserves the pre-#27 halt-on-RequireApproval behavior.
     pub fn with_approval_channel(mut self, channel: Box<dyn ApprovalChannel>) -> Self {
         self.approval_channel = Some(channel);
+        self
+    }
+
+    /// Attach an MCP client. Required to invoke `mediate_mcp_tool_call`;
+    /// without it MCP tool calls are denied (the mediator emits a
+    /// Violation citing "no MCP client configured").
+    pub fn with_mcp_client(mut self, client: Box<dyn McpClient>) -> Self {
+        self.mcp_client = Some(client);
         self
     }
 

--- a/crates/inference-engine/tests/mediator.rs
+++ b/crates/inference-engine/tests/mediator.rs
@@ -722,3 +722,161 @@ tools: {}
         "tampered attestation must fail signature verification"
     );
 }
+
+// ---------------------------------------------------------------------------
+// MCP mediator tests (ADR-018 / F2-MCP-B / issue #44).
+//
+// Use an in-process mock client implementing aegis_mcp_client::McpClient
+// directly — no subprocess needed for these end-to-end mediator tests.
+// The real stdio transport is exercised in crates/mcp-client/tests/.
+
+use aegis_mcp_client::{Error as McpError, McpClient};
+use serde_json::json;
+
+/// Mock client that records every call_tool invocation and returns a
+/// canned response. The presence in the call log confirms the mediator
+/// dispatched (Allow path); absence + a Violation entry confirms the
+/// mediator denied before reaching the client (Deny path).
+struct MockMcpClient {
+    response: serde_json::Value,
+    calls: std::sync::Arc<std::sync::Mutex<Vec<(String, String, serde_json::Value)>>>,
+}
+
+impl McpClient for MockMcpClient {
+    fn call_tool(
+        &mut self,
+        server_uri: &str,
+        tool_name: &str,
+        args: serde_json::Value,
+    ) -> std::result::Result<serde_json::Value, McpError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((server_uri.to_string(), tool_name.to_string(), args));
+        Ok(self.response.clone())
+    }
+}
+
+fn mcp_yaml(server_name: &str, server_uri: &str, tools: &[&str]) -> String {
+    let allowed = tools
+        .iter()
+        .map(|t| format!("\"{t}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "m", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://mediator.local/agent/research/inst-1" }}
+tools:
+  mcp:
+    - server_name: "{server_name}"
+      server_uri: "{server_uri}"
+      allowed_tools: [{allowed}]
+"#
+    )
+}
+
+#[test]
+fn mcp_allowed_call_dispatches_and_emits_access() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let yaml = mcp_yaml("fs-helper", "stdio:/bin/true", &["echo"]);
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "mcp-allow", &yaml);
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({"echoed": {"hi": 1}}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    let result = s
+        .mediate_mcp_tool_call("fs-helper", "echo", json!({"hi": 1}), Some("rstep-mcp-1"))
+        .unwrap();
+    assert_eq!(result, json!({"echoed": {"hi": 1}}));
+
+    s.shutdown().unwrap();
+
+    let recorded = calls.lock().unwrap();
+    assert_eq!(recorded.len(), 1, "client should have been invoked once");
+    assert_eq!(recorded[0].0, "stdio:/bin/true");
+    assert_eq!(recorded[0].1, "echo");
+
+    let entries = read_lines(&ledger);
+    // start + access + network_attestation + end
+    assert_eq!(entries.len(), 4, "{entries:#?}");
+    assert_eq!(entries[1]["entryType"], "access");
+    assert_eq!(entries[1]["accessType"], "mcp_tool_call");
+    assert_eq!(entries[1]["resourceUri"], "mcp://fs-helper/echo");
+    assert_eq!(entries[1]["reasoningStepId"], "rstep-mcp-1");
+}
+
+#[test]
+fn mcp_disallowed_server_emits_violation_and_denies() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let yaml = mcp_yaml("fs-helper", "stdio:/bin/true", &["echo"]);
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "mcp-deny-server", &yaml);
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    let err = s
+        .mediate_mcp_tool_call("evil", "any", json!({}), None)
+        .unwrap_err();
+    assert!(matches!(err, Error::Denied { .. }), "got {err:?}");
+    s.shutdown().unwrap();
+
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "client must not be invoked"
+    );
+
+    let entries = read_lines(&ledger);
+    assert_eq!(entries.len(), 4);
+    assert_eq!(entries[1]["entryType"], "violation");
+    assert_eq!(entries[1]["accessType"], "mcp_tool_call");
+    assert_eq!(entries[1]["resourceUri"], "mcp://evil/any");
+}
+
+#[test]
+fn mcp_disallowed_tool_on_allowed_server_emits_violation() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let yaml = mcp_yaml("fs-helper", "stdio:/bin/true", &["echo"]);
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "mcp-deny-tool", &yaml);
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    let err = s
+        .mediate_mcp_tool_call("fs-helper", "delete_everything", json!({}), None)
+        .unwrap_err();
+    assert!(matches!(err, Error::Denied { .. }), "got {err:?}");
+    s.shutdown().unwrap();
+
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "client must not be invoked"
+    );
+
+    let entries = read_lines(&ledger);
+    assert_eq!(entries.len(), 4);
+    assert_eq!(entries[1]["entryType"], "violation");
+    assert_eq!(entries[1]["accessType"], "mcp_tool_call");
+    assert_eq!(
+        entries[1]["resourceUri"],
+        "mcp://fs-helper/delete_everything"
+    );
+}

--- a/crates/mcp-client/Cargo.toml
+++ b/crates/mcp-client/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "aegis-mcp-client"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mcp-client/src/bin/echo-mcp-server.rs
+++ b/crates/mcp-client/src/bin/echo-mcp-server.rs
@@ -1,0 +1,103 @@
+//! Tiny MCP test fixture server: speaks JSON-RPC 2.0 over stdio,
+//! responds to `initialize` and `tools/call` with deterministic
+//! payloads, and exits cleanly when stdin reaches EOF.
+//!
+//! Used by `crates/mcp-client/tests/integration.rs` to exercise the
+//! real stdio transport without depending on an external binary.
+//! Cargo exposes this binary's path to integration tests via
+//! `env!("CARGO_BIN_EXE_echo-mcp-server")`.
+//!
+//! Tools surfaced:
+//!   - `echo`: returns `{ "echoed": <args> }`.
+//!   - `fail`: returns a JSON-RPC error with code -32000.
+
+use std::io::{self, BufRead, Write};
+
+use serde_json::{json, Value};
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.is_empty() {
+            continue;
+        }
+        let msg: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // Notifications have no `id`; ignore them silently (per JSON-RPC).
+        let id = match msg.get("id") {
+            Some(v) if !v.is_null() => v.clone(),
+            _ => continue,
+        };
+        let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let params = msg.get("params").cloned().unwrap_or(Value::Null);
+        let response = handle(method, &params, &id);
+        let mut bytes = serde_json::to_vec(&response).unwrap_or_default();
+        bytes.push(b'\n');
+        if out.write_all(&bytes).is_err() {
+            break;
+        }
+        if out.flush().is_err() {
+            break;
+        }
+    }
+}
+
+fn handle(method: &str, params: &Value, id: &Value) -> Value {
+    match method {
+        "initialize" => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": { "listChanged": false } },
+                "serverInfo": { "name": "echo-mcp-server", "version": "0.0.1" },
+            },
+        }),
+        "tools/call" => {
+            let name = params
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or_default();
+            let args = params.get("arguments").cloned().unwrap_or(Value::Null);
+            match name {
+                "echo" => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": { "echoed": args },
+                }),
+                "fail" => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": -32000,
+                        "message": "deliberate failure for testing",
+                    },
+                }),
+                other => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": -32601,
+                        "message": format!("unknown tool: {other}"),
+                    },
+                }),
+            }
+        }
+        _ => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {
+                "code": -32601,
+                "message": format!("unknown method: {method}"),
+            },
+        }),
+    }
+}

--- a/crates/mcp-client/src/error.rs
+++ b/crates/mcp-client/src/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors the MCP client can produce. The mediator surfaces these as
+/// `Error::Denied` (for policy refusals from the server side) or
+/// generic transport errors at the runtime boundary.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The server returned a JSON-RPC error envelope.
+    #[error("mcp server error: code={code} message={message}")]
+    ServerError { code: i64, message: String },
+
+    /// The transport scheme of `server_uri` is not implemented in
+    /// Phase 1. (Today we accept `stdio:` only; HTTP/SSE is a follow-up.)
+    #[error("mcp: unsupported transport scheme in server_uri: {server_uri}")]
+    UnsupportedTransport { server_uri: String },
+
+    /// Spawning the child process failed (binary missing, permission
+    /// denied, ...).
+    #[error("mcp: spawn {server_uri:?} failed: {source}")]
+    Spawn {
+        server_uri: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Generic transport / framing error.
+    #[error("mcp protocol: {0}")]
+    Protocol(String),
+}

--- a/crates/mcp-client/src/lib.rs
+++ b/crates/mcp-client/src/lib.rs
@@ -1,0 +1,277 @@
+//! MCP client used by the Aegis-Node runtime mediator (per ADR-018,
+//! F2-MCP-B / issue #44).
+//!
+//! Aegis-Node is an MCP **client**: it consumes external MCP servers'
+//! tool catalogs and invokes their tools. This crate wraps the
+//! [Model Context Protocol](https://modelcontextprotocol.io/) wire
+//! format. Phase 1 (this crate) ships stdio transport over JSON-RPC 2.0
+//! with newline-delimited messages — enough to spawn `mcp-server-foo`
+//! as a child process and call its tools. HTTP/SSE transport, tool
+//! result streaming, and MCP server attestation are out of scope for
+//! Phase 1 (see ADR-018 §Out of scope).
+//!
+//! ## Design
+//!
+//! [`McpClient`] is the trait the mediator depends on. The concrete
+//! [`StdioMcpClient`] implementation spawns a child process per
+//! `server_uri` (cached across calls so the initialize handshake runs
+//! once per server) and exchanges JSON-RPC messages over its stdio.
+//!
+//! Tests in the runtime use a mock client that implements [`McpClient`]
+//! directly without spawning anything; this crate's own tests exercise
+//! the real stdio transport against a tiny test fixture binary
+//! (`tests/fixtures/echo-mcp-server.rs`).
+
+#![allow(clippy::result_large_err)]
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+pub mod error;
+pub use error::{Error, Result};
+
+/// Aegis-Node's MCP client surface. Only `call_tool` is needed by the
+/// mediator. Implementations may cache connections, run an initialize
+/// handshake on first contact, and dispatch by `server_uri`.
+///
+/// Implementors must be `Send` so the mediator can hold one inside a
+/// `Box<dyn McpClient>` field on `Session`.
+pub trait McpClient: Send {
+    /// Invoke a single MCP tool and return its `result` JSON object as
+    /// the server returned it. The caller decides what (if anything) to
+    /// do with the structured content; the mediator's job is to log the
+    /// invocation, not to interpret the payload.
+    ///
+    /// `server_uri` is the value the manifest's `tools.mcp[].server_uri`
+    /// field carries — typically `stdio:/path/to/server-binary` for
+    /// Phase 1 stdio transport. `tool_name` is one of the tools listed
+    /// in the same entry's `allowed_tools`. Argument validation against
+    /// the upstream tool's `input_schema` is the upstream server's job;
+    /// this client passes `args` through verbatim.
+    fn call_tool(&mut self, server_uri: &str, tool_name: &str, args: Value) -> Result<Value>;
+}
+
+/// JSON-RPC 2.0 request frame. Held in the public surface so test
+/// fixtures and mock implementations can build the same shape the
+/// real transport uses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: &'static str,
+    pub id: u64,
+    pub method: String,
+    pub params: Value,
+}
+
+/// JSON-RPC 2.0 response frame.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    #[serde(default)]
+    pub id: Option<u64>,
+    #[serde(default)]
+    pub result: Option<Value>,
+    #[serde(default)]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<Value>,
+}
+
+/// `stdio:` transport. Spawns the named binary as a child process,
+/// runs the MCP `initialize` handshake on first use of each
+/// `server_uri`, then dispatches `tools/call` invocations on demand.
+///
+/// One [`StdioMcpClient`] instance can handle multiple distinct
+/// `server_uri`s — each is cached by URI so the initialize handshake
+/// runs once per server per session. Children are killed on Drop.
+pub struct StdioMcpClient {
+    /// Cached connections keyed by full `server_uri` (e.g.
+    /// `"stdio:/usr/local/bin/mcp-fs"`). Each entry owns the child
+    /// process plus its stdin/stdout handles and a monotonic id counter.
+    connections: HashMap<String, StdioConnection>,
+}
+
+struct StdioConnection {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl Default for StdioMcpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StdioMcpClient {
+    pub fn new() -> Self {
+        Self {
+            connections: HashMap::new(),
+        }
+    }
+
+    fn ensure_connection(&mut self, server_uri: &str) -> Result<&mut StdioConnection> {
+        if !self.connections.contains_key(server_uri) {
+            let path = parse_stdio_uri(server_uri)?;
+            let mut child = Command::new(path)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .map_err(|e| Error::Spawn {
+                    server_uri: server_uri.to_string(),
+                    source: e,
+                })?;
+            let stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| Error::Protocol("child stdin missing".to_string()))?;
+            let stdout = child
+                .stdout
+                .take()
+                .ok_or_else(|| Error::Protocol("child stdout missing".to_string()))?;
+            let mut conn = StdioConnection {
+                child,
+                stdin,
+                stdout: BufReader::new(stdout),
+                next_id: 0,
+            };
+            initialize_handshake(&mut conn)?;
+            self.connections.insert(server_uri.to_string(), conn);
+        }
+        // The contains_key check above guarantees the entry exists; the
+        // get_mut below cannot fail. Fall back to a Protocol error rather
+        // than expect()/unwrap() so clippy::expect_used stays clean.
+        self.connections
+            .get_mut(server_uri)
+            .ok_or_else(|| Error::Protocol("connection map race".to_string()))
+    }
+}
+
+impl McpClient for StdioMcpClient {
+    fn call_tool(&mut self, server_uri: &str, tool_name: &str, args: Value) -> Result<Value> {
+        let conn = self.ensure_connection(server_uri)?;
+        let id = conn.next_id;
+        conn.next_id += 1;
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0",
+            id,
+            method: "tools/call".to_string(),
+            params: json!({
+                "name": tool_name,
+                "arguments": args,
+            }),
+        };
+        write_message(&mut conn.stdin, &req)?;
+        let resp: JsonRpcResponse = read_message(&mut conn.stdout)?;
+        if let Some(err) = resp.error {
+            return Err(Error::ServerError {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        resp.result
+            .ok_or_else(|| Error::Protocol("response missing both result and error".to_string()))
+    }
+}
+
+impl Drop for StdioMcpClient {
+    fn drop(&mut self) {
+        for (_, mut conn) in self.connections.drain() {
+            // Best-effort kill; the child may already have exited
+            // (e.g. if it noticed stdin EOF). Errors here are not
+            // actionable.
+            let _ = conn.child.kill();
+            let _ = conn.child.wait();
+        }
+    }
+}
+
+fn parse_stdio_uri(server_uri: &str) -> Result<&str> {
+    server_uri
+        .strip_prefix("stdio:")
+        .ok_or_else(|| Error::UnsupportedTransport {
+            server_uri: server_uri.to_string(),
+        })
+}
+
+/// Run the MCP initialize handshake. Aegis-Node advertises the minimum
+/// capabilities Phase 1 needs (tool calls; no resources/prompts) and
+/// expects the server to respond with its own capability set. We don't
+/// inspect the server's capabilities here — the manifest's
+/// `allowed_tools` is the source of truth for what the agent may invoke.
+fn initialize_handshake(conn: &mut StdioConnection) -> Result<()> {
+    let id = conn.next_id;
+    conn.next_id += 1;
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0",
+        id,
+        method: "initialize".to_string(),
+        params: json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {
+                "tools": {},
+            },
+            "clientInfo": {
+                "name": "aegis-node",
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+        }),
+    };
+    write_message(&mut conn.stdin, &req)?;
+    let resp: JsonRpcResponse = read_message(&mut conn.stdout)?;
+    if let Some(err) = resp.error {
+        return Err(Error::ServerError {
+            code: err.code,
+            message: err.message,
+        });
+    }
+    // Per spec: send `notifications/initialized` after a successful
+    // initialize response. No id (it's a notification, not a request).
+    let init_done = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+    });
+    write_value(&mut conn.stdin, &init_done)?;
+    Ok(())
+}
+
+fn write_message<T: Serialize>(stdin: &mut ChildStdin, msg: &T) -> Result<()> {
+    write_value(stdin, msg)
+}
+
+fn write_value<T: Serialize>(stdin: &mut ChildStdin, msg: &T) -> Result<()> {
+    let mut bytes = serde_json::to_vec(msg).map_err(|e| Error::Protocol(e.to_string()))?;
+    bytes.push(b'\n');
+    stdin
+        .write_all(&bytes)
+        .map_err(|e| Error::Protocol(format!("write: {e}")))?;
+    stdin
+        .flush()
+        .map_err(|e| Error::Protocol(format!("flush: {e}")))?;
+    Ok(())
+}
+
+fn read_message<T: for<'de> Deserialize<'de>>(stdout: &mut BufReader<ChildStdout>) -> Result<T> {
+    let mut line = String::new();
+    let n = stdout
+        .read_line(&mut line)
+        .map_err(|e| Error::Protocol(format!("read: {e}")))?;
+    if n == 0 {
+        return Err(Error::Protocol(
+            "server closed stdout before reply".to_string(),
+        ));
+    }
+    serde_json::from_str(line.trim_end_matches('\n'))
+        .map_err(|e| Error::Protocol(format!("decode: {e}; raw: {line:?}")))
+}

--- a/crates/mcp-client/tests/integration.rs
+++ b/crates/mcp-client/tests/integration.rs
@@ -1,0 +1,57 @@
+//! Stdio transport tests against the bundled echo-mcp-server fixture.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use aegis_mcp_client::{Error, McpClient, StdioMcpClient};
+use serde_json::json;
+
+fn server_uri() -> String {
+    // Cargo exposes the test fixture binary's path via this env var.
+    let path = env!("CARGO_BIN_EXE_echo-mcp-server");
+    format!("stdio:{path}")
+}
+
+#[test]
+fn stdio_initialize_and_tools_call_round_trip() {
+    let mut client = StdioMcpClient::new();
+    let uri = server_uri();
+    let result = client
+        .call_tool(&uri, "echo", json!({"hello": "world"}))
+        .unwrap();
+    assert_eq!(result, json!({"echoed": {"hello": "world"}}));
+}
+
+#[test]
+fn stdio_caches_connection_across_calls() {
+    let mut client = StdioMcpClient::new();
+    let uri = server_uri();
+    let a = client.call_tool(&uri, "echo", json!({"i": 1})).unwrap();
+    let b = client.call_tool(&uri, "echo", json!({"i": 2})).unwrap();
+    assert_eq!(a, json!({"echoed": {"i": 1}}));
+    assert_eq!(b, json!({"echoed": {"i": 2}}));
+}
+
+#[test]
+fn stdio_propagates_server_side_error() {
+    let mut client = StdioMcpClient::new();
+    let uri = server_uri();
+    let err = client
+        .call_tool(&uri, "fail", json!({}))
+        .expect_err("expected server error");
+    match err {
+        Error::ServerError { code, message } => {
+            assert_eq!(code, -32000);
+            assert!(message.contains("deliberate failure"));
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn stdio_rejects_non_stdio_uri() {
+    let mut client = StdioMcpClient::new();
+    let err = client
+        .call_tool("https://mcp.example.com:8443", "echo", json!({}))
+        .expect_err("expected unsupported transport");
+    assert!(matches!(err, Error::UnsupportedTransport { .. }));
+}

--- a/crates/policy/src/policy.rs
+++ b/crates/policy/src/policy.rs
@@ -196,6 +196,34 @@ impl Policy {
         )
     }
 
+    /// MCP tool call: closed-by-default per ADR-018 / F2-MCP-B. Allowed iff
+    /// `tools.mcp[]` contains an entry whose `server_name` equals
+    /// `server_name` AND whose `allowed_tools` contains `tool_name`.
+    /// An empty `allowed_tools` array on a server entry means "no tools
+    /// allowed" — the closed-by-default default for a listed server.
+    pub fn check_mcp_tool(&self, server_name: &str, tool_name: &str) -> Decision {
+        let server = self
+            .manifest
+            .tools
+            .mcp
+            .iter()
+            .find(|s| s.server_name == server_name);
+        let server = match server {
+            Some(s) => s,
+            None => {
+                return Decision::deny(format!(
+                    "mcp tool call to server {server_name:?} not granted: server not in tools.mcp[]",
+                ));
+            }
+        };
+        if !server.allowed_tools.iter().any(|t| t == tool_name) {
+            return Decision::deny(format!(
+                "mcp tool call {server_name:?}/{tool_name:?} not granted: tool not in allowed_tools",
+            ));
+        }
+        Decision::Allow
+    }
+
     /// Classify whether the manifest has an explicit `write_grant` for
     /// `(path, action)` — and if so, whether any matching grant is
     /// currently in its time window. Used by `check_filesystem_write`

--- a/pkg/manifest/decide.go
+++ b/pkg/manifest/decide.go
@@ -42,6 +42,10 @@ const (
 	QueryNetworkOutbound  QueryKind = "network_outbound"
 	QueryNetworkInbound   QueryKind = "network_inbound"
 	QueryExec             QueryKind = "exec"
+	// QueryMCPToolCall consults tools.mcp[] (per ADR-018 / F2-MCP-B).
+	// The Query's MCPServer + MCPTool fields carry the (server, tool)
+	// pair to look up.
+	QueryMCPToolCall QueryKind = "mcp_tool_call"
 )
 
 // Query is one I/O attempt described abstractly so both Go and Rust
@@ -60,6 +64,9 @@ type Query struct {
 	Protocol     string    `json:"protocol,omitempty"`
 	Now          time.Time `json:"now,omitempty"`
 	SessionStart time.Time `json:"session_start,omitempty"`
+	// MCPServer + MCPTool are consulted only for QueryMCPToolCall.
+	MCPServer string `json:"mcp_server,omitempty"`
+	MCPTool   string `json:"mcp_tool,omitempty"`
 }
 
 // Decide answers a Query against `m`. Closed-by-default: silence is
@@ -81,6 +88,8 @@ func (m *Manifest) Decide(q Query) Decision {
 		return m.decideNetwork(false, q.Host, q.Port, q.Protocol)
 	case QueryExec:
 		return m.decideExec(q.ResourceURI)
+	case QueryMCPToolCall:
+		return m.decideMCPTool(q.MCPServer, q.MCPTool)
 	default:
 		return denyDecision(fmt.Sprintf("unknown query kind %q", q.Kind))
 	}
@@ -127,6 +136,29 @@ func (m *Manifest) decideFsDelete(uri string, now, sessionStart time.Time) Decis
 		return denyDecision(fmt.Sprintf("filesystem delete of %s blocked by expired write_grant", uri))
 	}
 	return denyDecision(fmt.Sprintf("filesystem delete of %s not granted by any write_grant", uri))
+}
+
+// decideMCPTool mirrors aegis_policy::Policy::check_mcp_tool. Closed-by-
+// default per ADR-018 / F2-MCP-B: allowed iff tools.mcp[] has an entry
+// whose server_name matches AND whose allowed_tools contains tool_name.
+func (m *Manifest) decideMCPTool(server, tool string) Decision {
+	for i := range m.Tools.MCP {
+		s := &m.Tools.MCP[i]
+		if s.ServerName != server {
+			continue
+		}
+		for _, t := range s.AllowedTools {
+			if t == tool {
+				return allowDecision()
+			}
+		}
+		return denyDecision(fmt.Sprintf(
+			"mcp tool call %q/%q not granted: tool not in allowed_tools", server, tool,
+		))
+	}
+	return denyDecision(fmt.Sprintf(
+		"mcp tool call to server %q not granted: server not in tools.mcp[]", server,
+	))
 }
 
 func (m *Manifest) decideExec(program string) Decision {

--- a/proto/aegis/v1/aegis.proto
+++ b/proto/aegis/v1/aegis.proto
@@ -35,6 +35,7 @@ enum AccessType {
   ACCESS_TYPE_NETWORK_OUTBOUND = 4;
   ACCESS_TYPE_NETWORK_INBOUND = 5;
   ACCESS_TYPE_EXEC = 6;
+  ACCESS_TYPE_MCP_TOOL_CALL = 7;
 }
 
 // Decision is the result of a policy evaluation.


### PR DESCRIPTION
## Summary

Wires Aegis-Node as an MCP **client**. The runtime resolves an MCP \`(server, tool)\` pair against the manifest's \`tools.mcp[]\` allowlist (closed-by-default per ADR-018) and dispatches via a stdio-transport client. One \`Access\` entry per call summarizes the invocation; side-effects inside the tool still produce their own \`mediate_*\` access entries — so this entry is the summary, not a replacement.

Closes #44. Second sub-issue of the MCP umbrella #42.

## Per

- ADR-018 §Decision items 3 + 5
- ADR-007 — F5 \`toolSelected\` carries MCP tool names from this point forward
- F2 (Permission Manifest enforcement)
- Compatibility Charter §"Allowed evolution" — adding new enum values to existing proto enums and new variants to access-log unions is non-breaking

## What lands here

- **New crate \`crates/mcp-client\`** — \`McpClient\` trait + \`StdioMcpClient\` impl (JSON-RPC 2.0 over child stdio, runs MCP \`initialize\` handshake on first contact per server, caches connections, kills children on Drop). Bundled test fixture \`echo-mcp-server\` binary.
- **Policy** — \`Policy::check_mcp_tool\` in Rust + \`Manifest.Decide(QueryMCPToolCall{...})\` in Go.
- **Wire** — \`ACCESS_TYPE_MCP_TOOL_CALL = 7\` proto enum value + \`AccessType::McpToolCall\` (snake_case \`mcp_tool_call\`). \`resourceUri\` = \`mcp://{server}/{tool}\`.
- **Mediator** — \`Session::with_mcp_client\` builder + \`Session::mediate_mcp_tool_call(server, tool, args, rsid)\` runs the canonical rebind → policy → dispatch → emit sequence.

## Out of scope (per ADR-018)

HTTP/SSE transport, tool-result streaming, MCP server attestation, approval-gate routing for MCP calls. Cross-language conformance and an example manifest land in F2-MCP-C (#45) and F2-MCP-D (#46).

## Test plan

- [x] \`cargo test --workspace --all-targets\` (107 passing, including 4 new mcp-client transport tests + 3 new mediator tests)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`go test ./pkg/manifest/\` clean
- [x] \`go vet ./...\` + \`gofmt\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)