### PR TITLE
test(conformance): cross-language MCP allowlist (ADR-018, F2-MCP-C)

### DIFF
--- a/crates/policy/tests/conformance.rs
+++ b/crates/policy/tests/conformance.rs
@@ -74,6 +74,12 @@ enum Query {
         #[serde(default)]
         resource_uri: String,
     },
+    /// Per ADR-018 / F2-MCP-C (#45). Closed-by-default lookup against
+    /// `tools.mcp[]`: allowed iff (server_name, tool_name) is listed.
+    McpToolCall {
+        mcp_server: String,
+        mcp_tool: String,
+    },
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
@@ -161,6 +167,10 @@ fn conformance_rust_side() {
                 protocol,
             } => policy.check_network_inbound(host, *port, (*protocol).into()),
             Query::Exec { resource_uri } => policy.check_exec(Path::new(resource_uri)),
+            Query::McpToolCall {
+                mcp_server,
+                mcp_tool,
+            } => policy.check_mcp_tool(mcp_server, mcp_tool),
         };
 
         let actual = decision_kind(&decision);

--- a/tests/conformance/cases.json
+++ b/tests/conformance/cases.json
@@ -242,6 +242,50 @@
         "session_start": "2026-04-29T10:00:00Z"
       },
       "expected": "allow"
+    },
+    {
+      "_doc": "ADR-018 / F2-MCP-C: allowed server + allowed tool. tools.mcp[] explicitly grants research-tools/search.",
+      "name": "mcp_allowed_server_allowed_tool_allows",
+      "manifest": "manifests/mcp-allowlist.manifest.yaml",
+      "query": {
+        "kind": "mcp_tool_call",
+        "mcp_server": "research-tools",
+        "mcp_tool": "search"
+      },
+      "expected": "allow"
+    },
+    {
+      "_doc": "ADR-018 / F2-MCP-C: allowed server but disallowed tool — closed-by-default rejects unlisted tool names even when the server is in tools.mcp[].",
+      "name": "mcp_allowed_server_disallowed_tool_denies",
+      "manifest": "manifests/mcp-allowlist.manifest.yaml",
+      "query": {
+        "kind": "mcp_tool_call",
+        "mcp_server": "research-tools",
+        "mcp_tool": "delete_everything"
+      },
+      "expected": "deny"
+    },
+    {
+      "_doc": "ADR-018 / F2-MCP-C: server not in tools.mcp[] at all — closed-by-default denies regardless of tool name.",
+      "name": "mcp_disallowed_server_denies",
+      "manifest": "manifests/mcp-allowlist.manifest.yaml",
+      "query": {
+        "kind": "mcp_tool_call",
+        "mcp_server": "evil-server",
+        "mcp_tool": "search"
+      },
+      "expected": "deny"
+    },
+    {
+      "_doc": "ADR-018 / F2-MCP-C: empty allowed_tools means no tools are allowed from that server, even though the server is listed.",
+      "name": "mcp_empty_allowed_tools_denies",
+      "manifest": "manifests/mcp-allowlist.manifest.yaml",
+      "query": {
+        "kind": "mcp_tool_call",
+        "mcp_server": "empty-server",
+        "mcp_tool": "search"
+      },
+      "expected": "deny"
     }
   ]
 }

--- a/tests/conformance/manifests/mcp-allowlist.manifest.yaml
+++ b/tests/conformance/manifests/mcp-allowlist.manifest.yaml
@@ -1,0 +1,19 @@
+# Conformance fixture for the MCP allowlist (ADR-018, F2-MCP-C / issue #45).
+# Two server entries:
+#   - "research-tools" with two allowed tools (search, summarize)
+#   - "empty-server" with allowed_tools: [] (closed-by-default; tool calls
+#     against it are always denied)
+schemaVersion: "1"
+agent:
+  name: "mcp-conformance"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/mcp-conformance/inst-001"
+tools:
+  mcp:
+    - server_name: "research-tools"
+      server_uri: "stdio:/usr/local/bin/mcp-research"
+      allowed_tools: ["search", "summarize"]
+    - server_name: "empty-server"
+      server_uri: "stdio:/usr/local/bin/mcp-empty"
+      allowed_tools: []


### PR DESCRIPTION
## Summary

Extends \`tests/conformance/cases.json\` so the Go validator and Rust enforcer agree on every MCP allowlist decision.

Closes #45. Third sub-issue of the MCP umbrella #42.

## What lands

- New fixture \`tests/conformance/manifests/mcp-allowlist.manifest.yaml\` — two server entries, one with allowed tools and one with empty \`allowed_tools\` (closed-by-default edge case).
- Four new cases:
  - \`mcp_allowed_server_allowed_tool_allows\`
  - \`mcp_allowed_server_disallowed_tool_denies\`
  - \`mcp_disallowed_server_denies\`
  - \`mcp_empty_allowed_tools_denies\`
- Rust conformance runner gains a \`Query::McpToolCall\` variant dispatching to \`Policy::check_mcp_tool\`.

The Go runner needed no change — \`QueryMCPToolCall\` and the \`MCPServer\`/\`MCPTool\` fields already landed in F2-MCP-B (#44).

## Test plan

- [x] \`go test ./pkg/manifest/ -run TestConformance\` (36/36 passing)
- [x] \`cargo test -p aegis-policy --test conformance\` (passing)
- [x] \`cargo fmt\` + \`cargo clippy --workspace -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)