### PR TITLE
docs(example): research agent + filesystem MCP server (ADR-018, F2-MCP-D)

### DIFF
--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -247,6 +247,27 @@ fn emit_violation_appends_violation_entry() {
     let _ = EntryType::Violation; // sanity
 }
 
+/// Per ADR-018 / issue #46. Loads the agent-with-mcp example (research
+/// agent + Anthropic filesystem MCP server, read-only subset) and
+/// asserts the engine agrees with the manifest's intent.
+#[test]
+fn agent_with_mcp_example_enforces_read_only_subset() {
+    let p = Policy::from_yaml_file(Path::new(
+        "../../schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml",
+    ))
+    .unwrap();
+
+    // Listed tool: read_text_file => allow.
+    assert!(p.check_mcp_tool("filesystem", "read_text_file").is_allow());
+
+    // Same server, but write_file is deliberately omitted from
+    // allowed_tools — the example is read-only.
+    assert!(p.check_mcp_tool("filesystem", "write_file").is_deny());
+
+    // Server not listed => deny regardless of tool name.
+    assert!(p.check_mcp_tool("evil-server", "read_text_file").is_deny());
+}
+
 /// Per ADR-018 / issue #43. Parses a valid `tools.mcp[]` example.
 #[test]
 fn mcp_server_grant_parses() {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -150,6 +150,59 @@ tools:
 	}
 }
 
+// Per ADR-018 / issue #46. Loads the agent-with-mcp example manifest
+// (research agent + Anthropic filesystem MCP server, read-only subset).
+// Catches drift if the example is hand-edited into a malformed shape.
+func TestLoadAgentWithMCPExample(t *testing.T) {
+	m, err := Load("../../schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml")
+	if err != nil {
+		t.Fatalf("load example: %v", err)
+	}
+	if len(m.Tools.MCP) != 1 {
+		t.Fatalf("tools.mcp: got %d entries, want 1", len(m.Tools.MCP))
+	}
+	server := m.Tools.MCP[0]
+	if server.ServerName != "filesystem" {
+		t.Errorf("server_name: %q", server.ServerName)
+	}
+	if server.ServerURI != "stdio:/usr/local/bin/mcp-server-filesystem" {
+		t.Errorf("server_uri: %q", server.ServerURI)
+	}
+	if len(server.AllowedTools) == 0 {
+		t.Fatal("allowed_tools must be non-empty for this fixture")
+	}
+	// Read-only invariant: none of the listed tools may be a writer.
+	writers := map[string]bool{
+		"write_file":       true,
+		"edit_file":        true,
+		"move_file":        true,
+		"create_directory": true,
+	}
+	for _, tool := range server.AllowedTools {
+		if writers[tool] {
+			t.Errorf("agent-with-mcp must stay read-only; %q is a writer", tool)
+		}
+	}
+
+	// Decide() agreement with the new tools.mcp[] semantics.
+	allowed := m.Decide(Query{
+		Kind:      QueryMCPToolCall,
+		MCPServer: "filesystem",
+		MCPTool:   "read_text_file",
+	})
+	if allowed.Kind != DecisionAllow {
+		t.Errorf("read_text_file should be allowed: got %q", allowed.Kind)
+	}
+	denied := m.Decide(Query{
+		Kind:      QueryMCPToolCall,
+		MCPServer: "filesystem",
+		MCPTool:   "write_file",
+	})
+	if denied.Kind != DecisionDeny {
+		t.Errorf("write_file should be denied: got %q", denied.Kind)
+	}
+}
+
 // Per ADR-018 / issue #43. Parses a valid `tools.mcp[]` example.
 func TestMCPServerGrantParses(t *testing.T) {
 	yaml := `schemaVersion: "1"

--- a/schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml
+++ b/schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml
@@ -1,0 +1,59 @@
+# Example Permission Manifest — research agent that uses the official
+# Anthropic filesystem MCP server (@modelcontextprotocol/server-filesystem)
+# in read-only mode.
+#
+# Per ADR-018 (F2-MCP-D / issue #46). Demonstrates the layered enforcement
+# Aegis-Node provides for MCP tool calls:
+#
+#   1. tools.mcp[] gates the *call* — closed-by-default per server + tool.
+#   2. The MCP server's underlying side effects (e.g. read_text_file
+#      issuing a real fs read) flow through Session::mediate_filesystem_*
+#      and are authorized by tools.filesystem.read separately.
+#
+# Both layers must permit the operation. The MCP allowlist is not a
+# replacement for the syscall gate; it's an additional check that names
+# the protocol-level intent.
+#
+# Real-world launch (out of band of the manifest):
+#
+#   npx -y @modelcontextprotocol/server-filesystem /data /docs
+#
+# The agent connects via stdio and may invoke any tool listed in
+# allowed_tools; everything else is denied + emits an F2 violation.
+
+schemaVersion: "1"
+agent:
+  name: "research-mcp"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/research-mcp/inst-001"
+tools:
+  # Read-only filesystem coverage for the side-effects of the MCP
+  # server's read tools. Without this, the call would clear the MCP
+  # allowlist but the underlying fs read would still be denied.
+  filesystem:
+    read:
+      - "/data"
+      - "/docs"
+  network:
+    outbound: deny
+    inbound: deny
+  mcp:
+    # Anthropic's reference filesystem MCP server, launched via stdio.
+    # Phase 1 transport is `stdio:` only; HTTP/SSE is a follow-up.
+    - server_name: "filesystem"
+      server_uri: "stdio:/usr/local/bin/mcp-server-filesystem"
+      # Read-only subset of the upstream tool catalog. Write/delete tools
+      # (write_file, edit_file, move_file, create_directory) are
+      # deliberately omitted — closed-by-default keeps them denied
+      # regardless of what the upstream server advertises.
+      allowed_tools:
+        - "read_text_file"
+        - "read_multiple_files"
+        - "list_directory"
+        - "list_directory_with_sizes"
+        - "directory_tree"
+        - "search_files"
+        - "get_file_info"
+        - "list_allowed_directories"
+write_grants: []


### PR DESCRIPTION
## Summary

First example manifest using \`tools.mcp[]\`: a research agent that connects to Anthropic's reference filesystem MCP server (\`@modelcontextprotocol/server-filesystem\`) over stdio with the read-only subset of its tool catalog.

Closes #46. With #43, #44, #45 already merged, this also closes the MCP umbrella #42.

## Why filesystem

The upstream server exposes both readers (\`read_text_file\`, \`list_directory\`, ...) and writers (\`write_file\`, \`edit_file\`, \`move_file\`, \`create_directory\`). The example pins it to the read-only subset; closed-by-default keeps the writers denied even though the upstream server advertises them.

## Layered enforcement on display

1. **\`tools.mcp[]\`** gates the *call* — closed-by-default per (server, tool).
2. **\`tools.filesystem.read\`** still gates the *side effect* — when the MCP server's \`read_text_file\` issues a real fs read, that read flows through \`Session::mediate_filesystem_read\` separately.

Both layers must permit the operation.

## Tests

- **Go**: parses the example, asserts the read-only invariant, confirms \`Decide()\` returns \`allow\` for \`read_text_file\` and \`deny\` for \`write_file\`.
- **Rust**: same expectations against \`Policy::check_mcp_tool\`.

## Test plan

- [x] \`go test ./pkg/manifest/\` (37 tests passing)
- [x] \`cargo test --workspace --all-targets\` clean
- [x] \`cargo fmt --all --check\` + \`cargo clippy --workspace -- -D warnings\` clean

## Sources

- [Anthropic MCP filesystem server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)