### PR TITLE
feat(validate): aegis validate CLI + 4 output formats (F10-B)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,72 @@
+name: Validate manifests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Per F10 / ADR-012 / issue #60. Builds the `aegis` Go CLI and runs
+# `aegis validate` against every committed Permission Manifest in the
+# repo: schema examples, conformance fixtures, validate testdata. A
+# rule firing on a shipped manifest fails CI — operators see the
+# linter as authoritative, and we ship clean examples.
+
+jobs:
+  validate:
+    name: aegis validate (every committed manifest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Tidy
+        run: go mod tidy
+
+      - name: Build aegis CLI
+        run: go build -o bin/aegis ./cmd/aegis
+
+      - name: Validate schema examples
+        run: |
+          set -eo pipefail
+          shopt -s nullglob
+          for m in schemas/manifest/v1/examples/*.manifest.yaml; do
+            echo "::group::$m"
+            ./bin/aegis validate --format=github "$m"
+            echo "::endgroup::"
+          done
+
+      - name: Validate conformance fixtures (advisory only)
+        run: |
+          set -eo pipefail
+          shopt -s nullglob
+          # Conformance manifests under tests/conformance/manifests/ are
+          # engineered to exercise specific Decide() outcomes; some
+          # deliberately trip lint rules (e.g. exec-grant.manifest.yaml
+          # uses a bare basename to test program-matching semantics).
+          # We print findings for visibility but do not fail the job —
+          # use --format=text so we don't pollute PR-check annotations
+          # with intentional findings.
+          for m in tests/conformance/manifests/*.manifest.yaml; do
+            echo "=== $m ==="
+            ./bin/aegis validate --format=text "$m" || true
+          done
+
+      - name: Validate testdata fixtures (expected to trip rules)
+        run: |
+          set -eo pipefail
+          shopt -s nullglob
+          # pkg/validate/testdata/aegis*.yaml are *engineered* to trip
+          # exactly one rule each; running --format=text and discarding
+          # the exit code documents the rule firing in CI logs without
+          # failing the workflow. clean.yaml must lint clean.
+          for m in pkg/validate/testdata/aegis*.yaml; do
+            echo "::group::$m (trip-fixture)"
+            ./bin/aegis validate --format=text "$m" || true
+            echo "::endgroup::"
+          done
+          ./bin/aegis validate --format=text pkg/validate/testdata/clean.yaml

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -1,15 +1,84 @@
 // Aegis-Node CLI — control-plane entry point.
 //
-// Per ADR-002 (Split-Language Architecture). Phase 0 scaffold.
+// Per ADR-002 (Split-Language Architecture). The Go binary owns
+// control-plane operations: linting manifests pre-deploy (`aegis
+// validate` per F10 / ADR-012), and — once the operator scaffold
+// matures — Kubernetes CRD reconciliation. Runtime / per-tool-call
+// mediation lives in the Rust `aegis` binary (crates/cli).
+//
+// Subcommand dispatch is hand-rolled around flag.NewFlagSet rather
+// than pulled-in cobra/urfave to keep the Go-side dep set lean and the
+// supply-chain surface narrow per ADR-013's spirit.
 package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/tosin2013/aegis-node/pkg/version"
 )
 
 func main() {
-	fmt.Fprintf(os.Stdout, "aegis %s — Phase 0 scaffold\n", version.Version)
+	if err := dispatch(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		if _, ok := err.(errExit); !ok {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(exitCode(err))
+	}
+}
+
+// dispatch routes argv to the subcommand handler. Extracted from main
+// so tests can drive the CLI without process boundaries.
+func dispatch(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return errExit(2)
+	}
+	switch args[0] {
+	case "validate":
+		return runValidate(args[1:], stdout, stderr)
+	case "version", "--version", "-V":
+		fmt.Fprintf(stdout, "aegis %s\n", version.Version)
+		return nil
+	case "help", "--help", "-h":
+		printUsage(stdout)
+		return nil
+	default:
+		fmt.Fprintf(stderr, "unknown subcommand %q\n\n", args[0])
+		printUsage(stderr)
+		return errExit(2)
+	}
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `aegis — Aegis-Node control-plane CLI
+
+Usage:
+  aegis <subcommand> [flags]
+
+Subcommands:
+  validate <manifest.yaml>    Lint a Permission Manifest pre-deploy (F10)
+  version                     Print the build version
+  help                        Show this message
+
+For per-subcommand flags:
+  aegis validate --help
+`)
+}
+
+// errExit carries an exit code through error returns. main translates
+// it to os.Exit; tests inspect it directly.
+type errExit int
+
+func (e errExit) Error() string { return fmt.Sprintf("exit %d", int(e)) }
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if e, ok := err.(errExit); ok {
+		return int(e)
+	}
+	return 1
 }

--- a/cmd/aegis/validate.go
+++ b/cmd/aegis/validate.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/tosin2013/aegis-node/pkg/manifest"
+	"github.com/tosin2013/aegis-node/pkg/validate"
+	"github.com/tosin2013/aegis-node/pkg/validate/format"
+)
+
+// runValidate handles `aegis validate <manifest.yaml> [flags]`. Exit
+// codes:
+//
+//	0  no findings, or only info/warn findings
+//	1  one or more SeverityError findings (after config overrides)
+//	2  usage error (bad flags, missing path, parse error)
+//
+// CI integrations consume the exit code; output is shaped by --format.
+func runValidate(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		fmtFlag    = fs.String("format", "text", "Output format: text|github|junit|json")
+		configPath = fs.String("config", ".aegis-validate.yaml",
+			"Path to severity-override config (missing file is OK)")
+		listRules = fs.Bool("list-rules", false,
+			"Print every registered rule + default severity + rationale and exit")
+	)
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `aegis validate — lint a Permission Manifest
+
+Usage:
+  aegis validate [flags] <manifest.yaml>
+  aegis validate --list-rules
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		// flag printed its own error; map to exit 2.
+		return errExit(2)
+	}
+
+	if *listRules {
+		printRules(stdout)
+		return nil
+	}
+
+	if fs.NArg() == 0 {
+		fs.Usage()
+		return errExit(2)
+	}
+	if fs.NArg() > 1 {
+		fmt.Fprintln(stderr, "validate accepts exactly one manifest path")
+		return errExit(2)
+	}
+
+	out, err := format.Parse(*fmtFlag)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return errExit(2)
+	}
+
+	path := fs.Arg(0)
+	m, err := manifest.Load(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "load %s: %v\n", path, err)
+		return errExit(2)
+	}
+
+	opts, err := validate.LoadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return errExit(2)
+	}
+
+	findings := validate.Lint(m, opts)
+	if err := format.Render(stdout, path, findings, out); err != nil {
+		fmt.Fprintf(stderr, "render: %v\n", err)
+		return errExit(1)
+	}
+	if validate.HasErrors(findings) {
+		return errExit(1)
+	}
+	return nil
+}
+
+func printRules(w io.Writer) {
+	rules := validate.Rules()
+	for _, r := range rules {
+		fmt.Fprintf(w, "%s [%s]\n", r.ID, defaultSeverityName(r.Default))
+		fmt.Fprintf(w, "  %s\n", r.Summary)
+		if r.Rationale != "" {
+			fmt.Fprintf(w, "  rationale: %s\n", r.Rationale)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+func defaultSeverityName(s validate.Severity) string {
+	return s.String()
+}

--- a/cmd/aegis/validate_test.go
+++ b/cmd/aegis/validate_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDispatchUsage covers the no-arg / help / version paths.
+func TestDispatchUsage(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantExit int
+		stdout   string
+	}{
+		{"no args", []string{}, 2, ""},
+		{"help long", []string{"--help"}, 0, "Usage:"},
+		{"help short", []string{"help"}, 0, "Usage:"},
+		{"version", []string{"version"}, 0, "aegis "},
+		{"unknown subcommand", []string{"frobulate"}, 2, ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			err := dispatch(tc.args, &stdout, &stderr)
+			if exitCode(err) != tc.wantExit {
+				t.Errorf("exit: got %d want %d (err=%v, stderr=%q)",
+					exitCode(err), tc.wantExit, err, stderr.String())
+			}
+			if tc.stdout != "" && !strings.Contains(stdout.String(), tc.stdout) {
+				t.Errorf("stdout missing %q: %q", tc.stdout, stdout.String())
+			}
+		})
+	}
+}
+
+func TestValidateCleanExample(t *testing.T) {
+	example := filepath.Join("..", "..", "schemas", "manifest", "v1", "examples",
+		"agent-with-mcp.manifest.yaml")
+	var stdout, stderr bytes.Buffer
+	err := dispatch([]string{"validate", example}, &stdout, &stderr)
+	if exitCode(err) != 0 {
+		t.Errorf("clean example should exit 0, got %d (stderr=%q)", exitCode(err), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "clean — 0 findings") {
+		t.Errorf("clean output missing 'clean — 0 findings':\n%s", stdout.String())
+	}
+}
+
+func TestValidateTripFixtureExitsOne(t *testing.T) {
+	fixture := filepath.Join("..", "..", "pkg", "validate", "testdata",
+		"aegis001-fs-read-system-root.yaml")
+	var stdout, stderr bytes.Buffer
+	err := dispatch([]string{"validate", fixture}, &stdout, &stderr)
+	if exitCode(err) != 1 {
+		t.Errorf("error fixture should exit 1, got %d", exitCode(err))
+	}
+	if !strings.Contains(stdout.String(), "AEGIS001") {
+		t.Errorf("output missing rule ID:\n%s", stdout.String())
+	}
+}
+
+func TestValidateRejectsUnknownFormat(t *testing.T) {
+	example := filepath.Join("..", "..", "schemas", "manifest", "v1", "examples",
+		"read-only-research.manifest.yaml")
+	var stdout, stderr bytes.Buffer
+	err := dispatch([]string{"validate", "--format=yaml", example}, &stdout, &stderr)
+	if exitCode(err) != 2 {
+		t.Errorf("bad format flag should exit 2, got %d", exitCode(err))
+	}
+}
+
+func TestValidateListRules(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := dispatch([]string{"validate", "--list-rules"}, &stdout, &stderr)
+	if exitCode(err) != 0 {
+		t.Errorf("--list-rules should exit 0, got %d (stderr=%q)", exitCode(err), stderr.String())
+	}
+	for _, want := range []string{"AEGIS001", "AEGIS010", "rationale:"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("--list-rules output missing %q", want)
+		}
+	}
+}

--- a/pkg/validate/config.go
+++ b/pkg/validate/config.go
@@ -1,0 +1,78 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFile is the on-disk shape of `.aegis-validate.yaml`.
+//
+// Operators commit this file at the repo root (or pass `--config <path>`
+// to `aegis validate`) to elevate warnings into errors per their org's
+// review bar — or, less commonly, to downgrade an error.
+//
+// Example:
+//
+//	# .aegis-validate.yaml
+//	severity:
+//	  AEGIS006: error  # eternal write_grants are unacceptable here
+//	  AEGIS010: warn   # name-mismatch is a real bug, not just info
+type ConfigFile struct {
+	Severity map[string]string `yaml:"severity,omitempty"`
+}
+
+// LoadConfig parses path into a ConfigFile and converts it to
+// LintOptions ready to pass to Lint. Returns an empty LintOptions{} on
+// "file not found" so the no-config-file case Just Works.
+func LoadConfig(path string) (LintOptions, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return LintOptions{}, nil
+		}
+		return LintOptions{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cf ConfigFile
+	if err := yaml.Unmarshal(data, &cf); err != nil {
+		return LintOptions{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(cf.Severity) == 0 {
+		return LintOptions{}, nil
+	}
+	override := make(map[string]Severity, len(cf.Severity))
+	known := knownRuleIDs()
+	for ruleID, sev := range cf.Severity {
+		if !known[ruleID] {
+			return LintOptions{}, fmt.Errorf("%s: unknown rule %q", path, ruleID)
+		}
+		s, err := parseSeverity(sev)
+		if err != nil {
+			return LintOptions{}, fmt.Errorf("%s: rule %s: %w", path, ruleID, err)
+		}
+		override[ruleID] = s
+	}
+	return LintOptions{SeverityOverride: override}, nil
+}
+
+func parseSeverity(s string) (Severity, error) {
+	switch s {
+	case "info":
+		return SeverityInfo, nil
+	case "warn", "warning":
+		return SeverityWarn, nil
+	case "error":
+		return SeverityError, nil
+	default:
+		return 0, fmt.Errorf("unknown severity %q (want info|warn|error)", s)
+	}
+}
+
+func knownRuleIDs() map[string]bool {
+	m := make(map[string]bool, len(registry()))
+	for _, r := range registry() {
+		m[r.ID] = true
+	}
+	return m
+}

--- a/pkg/validate/config_test.go
+++ b/pkg/validate/config_test.go
@@ -1,0 +1,61 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigMissingFileIsOK(t *testing.T) {
+	opts, err := LoadConfig(filepath.Join(t.TempDir(), "absent.yaml"))
+	if err != nil {
+		t.Fatalf("missing file should be tolerated, got: %v", err)
+	}
+	if len(opts.SeverityOverride) != 0 {
+		t.Errorf("missing file should yield empty overrides, got %v", opts.SeverityOverride)
+	}
+}
+
+func TestLoadConfigParsesOverrides(t *testing.T) {
+	path := writeYAML(t, `severity:
+  AEGIS001: warn
+  AEGIS006: error
+`)
+	opts, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := opts.SeverityOverride["AEGIS001"]; got != SeverityWarn {
+		t.Errorf("AEGIS001: got %v want Warn", got)
+	}
+	if got := opts.SeverityOverride["AEGIS006"]; got != SeverityError {
+		t.Errorf("AEGIS006: got %v want Error", got)
+	}
+}
+
+func TestLoadConfigRejectsUnknownRule(t *testing.T) {
+	path := writeYAML(t, `severity:
+  AEGIS999: error
+`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for unknown rule")
+	}
+}
+
+func TestLoadConfigRejectsBadSeverity(t *testing.T) {
+	path := writeYAML(t, `severity:
+  AEGIS001: critical
+`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for unknown severity")
+	}
+}
+
+func writeYAML(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".aegis-validate.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}

--- a/pkg/validate/format/format.go
+++ b/pkg/validate/format/format.go
@@ -1,0 +1,269 @@
+// Package format renders []validate.Finding into one of the four
+// output formats `aegis validate` supports: text (default human-
+// readable), github (GitHub Actions annotations), junit (JUnit XML
+// for enterprise CI), and json (newline-delimited records, one per
+// Finding).
+//
+// Per F10-B / ADR-012 / issue #60. The schema for the JSON format
+// is committed under schemas/validate/findings.schema.json.
+//
+// Every formatter sorts input by (file, line, col, RuleID) before
+// emitting so output diffs cleanly across runs even when callers
+// pre-sort differently. Today line/col are zero (the YAML AST hookup
+// is a follow-up); the sort key still produces stable output.
+package format
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/tosin2013/aegis-node/pkg/validate"
+)
+
+// Format identifies an output format. Use Parse to convert from a
+// CLI flag value.
+type Format string
+
+const (
+	FormatText   Format = "text"
+	FormatGitHub Format = "github"
+	FormatJUnit  Format = "junit"
+	FormatJSON   Format = "json"
+)
+
+// Parse converts a string flag value into a Format, returning an
+// explicit list of valid choices on failure.
+func Parse(s string) (Format, error) {
+	switch s {
+	case "text", "github", "junit", "json":
+		return Format(s), nil
+	default:
+		return "", fmt.Errorf("unknown format %q (want text|github|junit|json)", s)
+	}
+}
+
+// Render writes findings to w using the named format. Caller-provided
+// `file` is the manifest path used in github / junit / json output;
+// pass "" if not applicable.
+func Render(w io.Writer, file string, findings []validate.Finding, fmtKind Format) error {
+	sorted := make([]validate.Finding, len(findings))
+	copy(sorted, findings)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Field != sorted[j].Field {
+			return sorted[i].Field < sorted[j].Field
+		}
+		return sorted[i].RuleID < sorted[j].RuleID
+	})
+	switch fmtKind {
+	case FormatText:
+		return renderText(w, file, sorted)
+	case FormatGitHub:
+		return renderGitHub(w, file, sorted)
+	case FormatJUnit:
+		return renderJUnit(w, file, sorted)
+	case FormatJSON:
+		return renderJSON(w, file, sorted)
+	default:
+		return fmt.Errorf("unknown format %q", fmtKind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// text
+// ---------------------------------------------------------------------------
+
+func renderText(w io.Writer, file string, findings []validate.Finding) error {
+	if len(findings) == 0 {
+		_, err := fmt.Fprintf(w, "%s: clean — 0 findings\n", filenameOr(file, "<stdin>"))
+		return err
+	}
+	for _, f := range findings {
+		// `path:line:col: severity rule message`. Line/col are 0 until
+		// the YAML AST hookup lands; the slot is reserved.
+		if _, err := fmt.Fprintf(w, "%s:0:0: %s %s %s — %s\n",
+			filenameOr(file, "<stdin>"),
+			f.SeverityName(),
+			f.RuleID,
+			f.Field,
+			f.Message); err != nil {
+			return err
+		}
+	}
+	errs, warns, infos := tally(findings)
+	_, err := fmt.Fprintf(w, "\n%d error(s), %d warning(s), %d info\n", errs, warns, infos)
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// github (Actions annotations)
+// ---------------------------------------------------------------------------
+
+func renderGitHub(w io.Writer, file string, findings []validate.Finding) error {
+	for _, f := range findings {
+		level := "notice"
+		switch f.Severity {
+		case validate.SeverityError:
+			level = "error"
+		case validate.SeverityWarn:
+			level = "warning"
+		}
+		// Per https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions
+		// ::level file=path,line=N,col=N,title=...::message
+		// Newlines in message must be %0A-encoded.
+		title := fmt.Sprintf("%s %s", f.RuleID, f.Field)
+		msg := encodeGHA(f.Message)
+		if _, err := fmt.Fprintf(w, "::%s file=%s,line=1,col=1,title=%s::%s\n",
+			level, file, encodeGHA(title), msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// encodeGHA escapes characters that have meaning in workflow commands.
+func encodeGHA(s string) string {
+	r := strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+		":", "%3A",
+		",", "%2C",
+	)
+	return r.Replace(s)
+}
+
+// ---------------------------------------------------------------------------
+// junit XML
+// ---------------------------------------------------------------------------
+
+type junitTestSuite struct {
+	XMLName  xml.Name        `xml:"testsuite"`
+	Name     string          `xml:"name,attr"`
+	Tests    int             `xml:"tests,attr"`
+	Failures int             `xml:"failures,attr"`
+	Errors   int             `xml:"errors,attr"`
+	Cases    []junitTestCase `xml:"testcase"`
+}
+
+type junitTestCase struct {
+	Name      string        `xml:"name,attr"`
+	ClassName string        `xml:"classname,attr"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Text    string `xml:",chardata"`
+}
+
+func renderJUnit(w io.Writer, file string, findings []validate.Finding) error {
+	suite := junitTestSuite{
+		Name: "aegis-validate",
+	}
+	// Each finding is a failed testcase. Clean manifest is one passing
+	// testcase so JUnit consumers see "1 test, 0 failures" rather than
+	// "0 tests" (which some dashboards interpret as missing).
+	if len(findings) == 0 {
+		suite.Tests = 1
+		suite.Cases = append(suite.Cases, junitTestCase{
+			Name:      "clean",
+			ClassName: filenameOr(file, "<stdin>"),
+		})
+	} else {
+		for _, f := range findings {
+			tc := junitTestCase{
+				Name:      fmt.Sprintf("%s @ %s", f.RuleID, f.Field),
+				ClassName: filenameOr(file, "<stdin>"),
+			}
+			if f.Severity == validate.SeverityError || f.Severity == validate.SeverityWarn {
+				tc.Failure = &junitFailure{
+					Message: f.Message,
+					Type:    f.SeverityName(),
+					Text:    f.Rationale,
+				}
+				if f.Severity == validate.SeverityError {
+					suite.Errors++
+				} else {
+					suite.Failures++
+				}
+			}
+			suite.Cases = append(suite.Cases, tc)
+			suite.Tests++
+		}
+	}
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(suite); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\n")
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// json
+// ---------------------------------------------------------------------------
+
+// jsonRecord is the on-disk representation of one Finding. The JSON
+// schema for this type lives at schemas/validate/findings.schema.json
+// so consumers can build typed tooling (SIEM rules, CI dashboards).
+type jsonRecord struct {
+	File      string `json:"file,omitempty"`
+	RuleID    string `json:"rule_id"`
+	Severity  string `json:"severity"`
+	Field     string `json:"field"`
+	Message   string `json:"message"`
+	Rationale string `json:"rationale,omitempty"`
+}
+
+func renderJSON(w io.Writer, file string, findings []validate.Finding) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	for _, f := range findings {
+		rec := jsonRecord{
+			File:      file,
+			RuleID:    f.RuleID,
+			Severity:  f.SeverityName(),
+			Field:     f.Field,
+			Message:   f.Message,
+			Rationale: f.Rationale,
+		}
+		if err := enc.Encode(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func tally(findings []validate.Finding) (errs, warns, infos int) {
+	for _, f := range findings {
+		switch f.Severity {
+		case validate.SeverityError:
+			errs++
+		case validate.SeverityWarn:
+			warns++
+		case validate.SeverityInfo:
+			infos++
+		}
+	}
+	return
+}
+
+func filenameOr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/pkg/validate/format/format_test.go
+++ b/pkg/validate/format/format_test.go
@@ -1,0 +1,217 @@
+package format
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/tosin2013/aegis-node/pkg/validate"
+)
+
+// fixtureFindings returns three findings spanning all three severities,
+// in deterministic order. Used by every formatter test so output stays
+// comparable across formats.
+func fixtureFindings() []validate.Finding {
+	return []validate.Finding{
+		{
+			RuleID:    "AEGIS001",
+			Severity:  validate.SeverityError,
+			Field:     "tools.filesystem.read[0]",
+			Message:   "path \"/etc\" is a system root",
+			Rationale: "Blanket read of system roots gives the agent access to credentials.",
+		},
+		{
+			RuleID:    "AEGIS006",
+			Severity:  validate.SeverityWarn,
+			Field:     "write_grants[0]",
+			Message:   "grant on \"/data/scratch.md\" has no duration and no expires_at",
+			Rationale: "Without a time bound, write_grants live forever.",
+		},
+		{
+			RuleID:    "AEGIS010",
+			Severity:  validate.SeverityInfo,
+			Field:     "agent.name",
+			Message:   "agent.name=\"foo\" doesn't match SPIFFE workload segment \"bar\"",
+			Rationale: "Convention is spiffe://<td>/agent/<workload>/<instance>.",
+		},
+	}
+}
+
+func TestParseRejectsUnknown(t *testing.T) {
+	if _, err := Parse("yaml"); err == nil {
+		t.Fatal("Parse should reject unknown formats")
+	}
+	for _, valid := range []string{"text", "github", "junit", "json"} {
+		if _, err := Parse(valid); err != nil {
+			t.Errorf("Parse(%q) failed: %v", valid, err)
+		}
+	}
+}
+
+func TestRenderTextSummaryAndCounts(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "manifest.yaml", fixtureFindings(), FormatText); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		"AEGIS001",
+		"AEGIS006",
+		"AEGIS010",
+		"manifest.yaml:0:0:",
+		"1 error(s), 1 warning(s), 1 info",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("text output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderTextEmptyIsClean(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "ok.yaml", nil, FormatText); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(buf.String(), "clean — 0 findings") {
+		t.Errorf("text empty output: %q", buf.String())
+	}
+}
+
+func TestRenderGitHubAnnotations(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "manifest.yaml", fixtureFindings(), FormatGitHub); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got := buf.String()
+	// Each level uses the right GHA prefix.
+	if !strings.Contains(got, "::error file=manifest.yaml,") {
+		t.Errorf("missing ::error annotation:\n%s", got)
+	}
+	if !strings.Contains(got, "::warning file=manifest.yaml,") {
+		t.Errorf("missing ::warning annotation:\n%s", got)
+	}
+	if !strings.Contains(got, "::notice file=manifest.yaml,") {
+		t.Errorf("missing ::notice annotation:\n%s", got)
+	}
+	// Special characters in messages are encoded.
+	if strings.Contains(got, "\n") && strings.Count(got, "\n") < 3 {
+		// Should have one newline per annotation, no embedded ones.
+		t.Errorf("GHA annotations should be one-per-line:\n%s", got)
+	}
+}
+
+func TestRenderGitHubEncodesSpecials(t *testing.T) {
+	findings := []validate.Finding{{
+		RuleID:   "AEGIS001",
+		Severity: validate.SeverityError,
+		Field:    "x",
+		Message:  "value, has commas: and colons",
+	}}
+	var buf bytes.Buffer
+	if err := Render(&buf, "m.yaml", findings, FormatGitHub); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "value, has commas:") {
+		t.Errorf("commas/colons in message must be percent-encoded:\n%s", got)
+	}
+	if !strings.Contains(got, "%2C") || !strings.Contains(got, "%3A") {
+		t.Errorf("expected %%2C and %%3A in encoded message:\n%s", got)
+	}
+}
+
+func TestRenderJUnitParsesAsXML(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "manifest.yaml", fixtureFindings(), FormatJUnit); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var suite junitTestSuite
+	if err := xml.Unmarshal(stripXMLHeader(buf.Bytes()), &suite); err != nil {
+		t.Fatalf("XML reparse failed: %v\nraw:\n%s", err, buf.String())
+	}
+	if suite.Name != "aegis-validate" {
+		t.Errorf("suite name: %q", suite.Name)
+	}
+	if suite.Tests != 3 {
+		t.Errorf("tests: got %d want 3", suite.Tests)
+	}
+	if suite.Errors != 1 {
+		t.Errorf("errors: got %d want 1", suite.Errors)
+	}
+	if suite.Failures != 1 {
+		t.Errorf("failures: got %d want 1", suite.Failures)
+	}
+}
+
+func TestRenderJUnitCleanCaseEmitsOnePass(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "ok.yaml", nil, FormatJUnit); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var suite junitTestSuite
+	if err := xml.Unmarshal(stripXMLHeader(buf.Bytes()), &suite); err != nil {
+		t.Fatalf("XML reparse failed: %v", err)
+	}
+	if suite.Tests != 1 || suite.Failures != 0 || suite.Errors != 0 {
+		t.Errorf("clean junit: got tests=%d failures=%d errors=%d (want 1/0/0)",
+			suite.Tests, suite.Failures, suite.Errors)
+	}
+}
+
+func TestRenderJSONRoundTripsAgainstSchema(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "manifest.yaml", fixtureFindings(), FormatJSON); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	// Each line is one record.
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 records, got %d:\n%s", len(lines), buf.String())
+	}
+	for i, line := range lines {
+		var rec jsonRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Errorf("record %d not valid JSON: %v", i, err)
+		}
+		if rec.RuleID == "" || rec.Severity == "" || rec.Field == "" || rec.Message == "" {
+			t.Errorf("record %d missing required field: %+v", i, rec)
+		}
+		if rec.File != "manifest.yaml" {
+			t.Errorf("record %d file: %q", i, rec.File)
+		}
+	}
+}
+
+func TestRenderStableSortAcrossFormats(t *testing.T) {
+	// Reverse-shuffle the input; output order must still be by (Field, RuleID).
+	in := fixtureFindings()
+	for i, j := 0, len(in)-1; i < j; i, j = i+1, j-1 {
+		in[i], in[j] = in[j], in[i]
+	}
+	for _, fmtKind := range []Format{FormatText, FormatGitHub, FormatJUnit, FormatJSON} {
+		var a, b bytes.Buffer
+		if err := Render(&a, "m.yaml", in, fmtKind); err != nil {
+			t.Fatalf("%s: %v", fmtKind, err)
+		}
+		// Same content, original order — should produce identical output.
+		original := fixtureFindings()
+		if err := Render(&b, "m.yaml", original, fmtKind); err != nil {
+			t.Fatalf("%s: %v", fmtKind, err)
+		}
+		if a.String() != b.String() {
+			t.Errorf("%s: output differs after re-ordering input — sort is not stable\nshuffled:\n%s\noriginal:\n%s",
+				fmtKind, a.String(), b.String())
+		}
+	}
+}
+
+// stripXMLHeader drops the `<?xml ...?>` line so xml.Unmarshal can
+// handle the body alone.
+func stripXMLHeader(b []byte) []byte {
+	if i := bytes.Index(b, []byte("?>")); i >= 0 {
+		return b[i+2:]
+	}
+	return b
+}

--- a/schemas/validate/findings.schema.json
+++ b/schemas/validate/findings.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aegis-node.dev/schemas/validate/findings.schema.json",
+  "title": "Aegis-Node `aegis validate` JSON output (per-record)",
+  "description": "Per F10-B / ADR-012 / issue #60. The JSON output of `aegis validate --format=json` is newline-delimited JSON: one object per line, conforming to this schema. Order is stable across runs (sorted by file, field, rule_id) so consumers can diff outputs.",
+  "type": "object",
+  "required": ["rule_id", "severity", "field", "message"],
+  "additionalProperties": false,
+  "properties": {
+    "file": {
+      "type": "string",
+      "description": "Path to the manifest the finding refers to. Omitted when `aegis validate` reads from stdin."
+    },
+    "rule_id": {
+      "type": "string",
+      "pattern": "^AEGIS[0-9]+$",
+      "description": "Canonical rule identifier (e.g. AEGIS001)."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["info", "warn", "error"],
+      "description": "Effective severity after applying any per-rule overrides from .aegis-validate.yaml."
+    },
+    "field": {
+      "type": "string",
+      "description": "JSON-pointer-ish path into the manifest (e.g. `tools.filesystem.read[0]`, `write_grants[2].resource`)."
+    },
+    "message": {
+      "type": "string",
+      "description": "One-line description of the specific instance of the rule violation (includes the offending value)."
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Longer explanation of why the rule exists. Stable across instances of the same rule; safe to dedupe in dashboards."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Wires the F10-A linter into a Go \`aegis validate\` CLI subcommand, ships four output formats (text / GitHub Actions / JUnit XML / JSON), adds a project-local \`.aegis-validate.yaml\` config loader, and stands up a CI workflow that runs the linter against every committed manifest.

Closes #60. Second sub-issue of the F10 umbrella #58.

## CLI

\`\`\`bash
$ aegis validate schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml
schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml: clean — 0 findings

$ aegis validate pkg/validate/testdata/aegis001-fs-read-system-root.yaml
pkg/validate/testdata/aegis001-fs-read-system-root.yaml:0:0: error AEGIS001 tools.filesystem.read[0] — path "/etc" is a system root; narrow to the data the agent actually needs

1 error(s), 0 warning(s), 0 info
$ echo \$?
1

$ aegis validate --list-rules
$ aegis validate --format=github <m>     # PR annotations
$ aegis validate --format=junit <m>      # CI dashboards
$ aegis validate --format=json <m>       # SIEM / typed tooling
\`\`\`

Exit codes: \`0\` clean, \`1\` errors, \`2\` usage.

## Notable

- **Subcommand dispatcher hand-rolled around \`flag.NewFlagSet\`** — no cobra/urfave dep. Keeps the supply-chain surface narrow per ADR-013's spirit.
- **Stable sort across all four formats** — \`TestRenderStableSortAcrossFormats\` shuffles input and asserts identical output for every format.
- **GHA encoding** — commas, colons, newlines, percent signs in messages are percent-encoded per the [workflow-commands spec](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions).
- **JSON schema at \`schemas/validate/findings.schema.json\`** — downstream tooling can build against a stable contract.
- **CI workflow** — lints every \`schemas/manifest/v1/examples/*.manifest.yaml\` with \`--format=github\` (PR annotations); runs conformance fixtures + trip-testdata in advisory mode (some intentionally fire rules).

## Out of scope (F10 follow-ups)

- YAML AST hookup so \`Finding\` carries real line:col (currently 0:0).
- Plain-text "policy summary report" listing what the manifest grants. Lands once the F10 review stack stabilizes.

## Test plan

- [x] \`go test ./pkg/validate/... ./cmd/aegis/\` — 22 tests passing
  - 9 format tests (incl. XML reparse + JSON-record verify)
  - 4 config tests (missing file, valid, bad rule, bad severity)
  - 9 dispatcher / validate-handler tests
- [x] \`go vet ./pkg/validate/... ./cmd/aegis/\` clean
- [x] \`gofmt -l\` clean
- [x] \`go build -o bin/aegis ./cmd/aegis\` smoke-tested against real manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)