### PR TITLE
test(replay-viewer): F8-C DOM snapshot test (ADR-010)

### DIFF
--- a/.github/workflows/replay-viewer-snapshot.yml
+++ b/.github/workflows/replay-viewer-snapshot.yml
@@ -1,0 +1,40 @@
+name: Replay viewer (DOM snapshot)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/replay-viewer/**'
+      - 'crates/ledger-writer/examples/replay-fixture.rs'
+      - '.github/workflows/replay-viewer-snapshot.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'tools/replay-viewer/**'
+      - 'crates/ledger-writer/examples/replay-fixture.rs'
+      - '.github/workflows/replay-viewer-snapshot.yml'
+
+# Per F8-C / ADR-010 / issue #64. Runs the offline viewer through a
+# headless DOM (jsdom — no browser binary needed) against the
+# committed fixture and asserts the rendered DOM matches the committed
+# expected snapshot. A regression that drifts the audit experience
+# fails the workflow on every PR.
+
+jobs:
+  snapshot:
+    name: F8-C DOM snapshot
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/replay-viewer/snapshot
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: tools/replay-viewer/snapshot/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Check snapshot
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ coverage.out
 # Go vendor (if used)
 /vendor/
 
+# Node — only the replay-viewer's snapshot test uses Node deps.
+node_modules/
+
 # Editor / OS noise
 .DS_Store
 *.swp

--- a/tools/replay-viewer/snapshot/README.md
+++ b/tools/replay-viewer/snapshot/README.md
@@ -1,0 +1,56 @@
+# Replay viewer DOM snapshot test
+
+Per **F8-C / ADR-010 / issue [#64](https://github.com/tosin2013/aegis-node/issues/64)**.
+
+Headless DOM regression check that pins the viewer's rendering of
+`fixtures/sample-session.jsonl` against a committed snapshot
+(`expected.json`). If a viewer or fixture change drifts the audit
+experience, this test catches it at PR time.
+
+## Why jsdom (and not Playwright)
+
+The viewer is small, vanilla JS, uses no browser-specific APIs we care
+about beyond standard DOM + Web Crypto. Playwright would download
+~300 MB of Chromium per CI run for negligible coverage gain. jsdom is
+~9 MB, runs the test in ~1 s, and pins exactly the runtime we need.
+
+The trade-off: jsdom isn't a real browser, so this test won't catch
+Chrome/Firefox/Safari rendering quirks. **F8-A's air-gap CI guard**
+(`tools/replay-viewer/check-airgap.sh`) is what enforces the "works in
+any browser, no network" property; this test enforces "the rendered
+structure matches what we committed."
+
+## Run locally
+
+```bash
+cd tools/replay-viewer/snapshot
+npm ci
+npm test                  # check mode (CI uses this)
+npm run regenerate        # rewrite expected.json after intentional changes
+```
+
+`npm test` exits 0 if the rendered DOM summary matches `expected.json`,
+non-zero with an inline diff hint otherwise.
+
+## What's pinned
+
+The snapshot captures structural invariants only — not whitespace, CSS,
+or pixel rendering. That keeps it reviewable + diff-friendly:
+
+- **integrity banner** — state (`verified` / `indeterminate` / `broken`)
+  and human-readable label
+- **summary chips** — file name, session id, entry count, root hash
+- **per-entry** — sequence number, type, type-pill text, timestamp,
+  every key/value row in the body
+
+A future viewer change that adds a new field to a card flips the test
+red until you re-run `npm run regenerate` to acknowledge the drift.
+That's exactly the gate F8-C is meant to provide.
+
+## When this fails on a PR
+
+1. Read the inline diff the runner prints.
+2. Decide: intentional drift (new field, fixed wording) vs regression.
+3. If intentional, run `npm run regenerate` and commit the updated
+   `expected.json` in the same PR.
+4. If a regression, fix the viewer and rerun.

--- a/tools/replay-viewer/snapshot/expected.json
+++ b/tools/replay-viewer/snapshot/expected.json
@@ -1,0 +1,275 @@
+{
+  "integrity": {
+    "state": "verified",
+    "label": "integrity: VERIFIED"
+  },
+  "chips": [
+    {
+      "value": "sample-session.jsonl"
+    },
+    {
+      "value": "session-replay-fixture"
+    },
+    {
+      "value": "11"
+    },
+    {
+      "value": "3f11690f1378ff227572d997a942646f8409c565ed74375c614594440566af13"
+    }
+  ],
+  "entryCount": 11,
+  "entries": [
+    {
+      "seq": "#0",
+      "type": "session_start",
+      "pill": "session_start",
+      "timestamp": "2026-04-29T14:00:00.000000000Z",
+      "rows": [
+        [
+          "spiffeId",
+          "spiffe://aegis-node.local/agent/research-mcp/inst-001"
+        ],
+        [
+          "modelDigestHex",
+          "a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3"
+        ],
+        [
+          "manifestDigestHex",
+          "b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4"
+        ],
+        [
+          "configDigestHex",
+          "c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5"
+        ]
+      ]
+    },
+    {
+      "seq": "#1",
+      "type": "reasoning_step",
+      "pill": "reasoning_step",
+      "timestamp": "2026-04-29T14:00:01.000000000Z",
+      "rows": [
+        [
+          "reasoningStepId",
+          "rstep-q1-readsales"
+        ],
+        [
+          "toolSelected",
+          "read_text_file"
+        ],
+        [
+          "toolsConsidered",
+          "read_text_file, list_directory, write_file"
+        ]
+      ]
+    },
+    {
+      "seq": "#2",
+      "type": "access",
+      "pill": "access",
+      "timestamp": "2026-04-29T14:00:02.000000000Z",
+      "rows": [
+        [
+          "resourceUri",
+          "mcp://filesystem/read_text_file"
+        ],
+        [
+          "accessType",
+          "mcp_tool_call"
+        ],
+        [
+          "bytesAccessed",
+          "482"
+        ],
+        [
+          "reasoningStepId",
+          "rstep-q1-readsales"
+        ]
+      ]
+    },
+    {
+      "seq": "#3",
+      "type": "access",
+      "pill": "access",
+      "timestamp": "2026-04-29T14:00:03.000000000Z",
+      "rows": [
+        [
+          "resourceUri",
+          "file:///data/reports/q1.md"
+        ],
+        [
+          "accessType",
+          "read"
+        ],
+        [
+          "bytesAccessed",
+          "482"
+        ],
+        [
+          "reasoningStepId",
+          "rstep-q1-readsales"
+        ]
+      ]
+    },
+    {
+      "seq": "#4",
+      "type": "reasoning_step",
+      "pill": "reasoning_step",
+      "timestamp": "2026-04-29T14:00:04.000000000Z",
+      "rows": [
+        [
+          "reasoningStepId",
+          "rstep-writesum"
+        ],
+        [
+          "toolSelected",
+          "write_file"
+        ],
+        [
+          "toolsConsidered",
+          "write_file"
+        ]
+      ]
+    },
+    {
+      "seq": "#5",
+      "type": "violation",
+      "pill": "violation",
+      "timestamp": "2026-04-29T14:00:05.000000000Z",
+      "rows": [
+        [
+          "violationReason",
+          "mcp tool call \"filesystem\"/\"write_file\" not granted: tool not in allowed_tools"
+        ],
+        [
+          "resourceUri",
+          "mcp://filesystem/write_file"
+        ],
+        [
+          "accessType",
+          "mcp_tool_call"
+        ]
+      ]
+    },
+    {
+      "seq": "#6",
+      "type": "approval_request",
+      "pill": "approval_request",
+      "timestamp": "2026-04-29T14:00:06.000000000Z",
+      "rows": [
+        [
+          "actionSummary",
+          "Write summary to /data/output/summary.md"
+        ],
+        [
+          "resourceUri",
+          "file:///data/output/summary.md"
+        ],
+        [
+          "accessType",
+          "write"
+        ],
+        [
+          "expiresAt",
+          "2026-04-29T14:02:06Z"
+        ],
+        [
+          "reasoningStepId",
+          "rstep-writesum"
+        ]
+      ]
+    },
+    {
+      "seq": "#7",
+      "type": "approval_granted",
+      "pill": "approval_granted",
+      "timestamp": "2026-04-29T14:00:07.000000000Z",
+      "rows": [
+        [
+          "decision",
+          "granted"
+        ],
+        [
+          "approverId",
+          "spiffe://aegis-node.local/operator/security"
+        ],
+        [
+          "decidedAt",
+          "2026-04-29T14:00:06Z"
+        ],
+        [
+          "reasoningStepId",
+          "rstep-writesum"
+        ]
+      ]
+    },
+    {
+      "seq": "#8",
+      "type": "access",
+      "pill": "access",
+      "timestamp": "2026-04-29T14:00:08.000000000Z",
+      "rows": [
+        [
+          "resourceUri",
+          "file:///data/output/summary.md"
+        ],
+        [
+          "accessType",
+          "write"
+        ],
+        [
+          "bytesAccessed",
+          "214"
+        ],
+        [
+          "reasoningStepId",
+          "rstep-writesum"
+        ]
+      ]
+    },
+    {
+      "seq": "#9",
+      "type": "network_attestation",
+      "pill": "network_attestation",
+      "timestamp": "2026-04-29T14:00:09.000000000Z",
+      "rows": [
+        [
+          "totalConnections",
+          "0"
+        ],
+        [
+          "allowedCount",
+          "0"
+        ],
+        [
+          "approvedCount",
+          "0"
+        ],
+        [
+          "deniedCount",
+          "0"
+        ],
+        [
+          "connectionsDigestHex",
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        ],
+        [
+          "signatureHex",
+          "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+        ]
+      ]
+    },
+    {
+      "seq": "#10",
+      "type": "session_end",
+      "pill": "session_end",
+      "timestamp": "2026-04-29T14:00:10.000000000Z",
+      "rows": [
+        [
+          "spiffeId",
+          "spiffe://aegis-node.local/agent/research-mcp/inst-001"
+        ]
+      ]
+    }
+  ]
+}

--- a/tools/replay-viewer/snapshot/package-lock.json
+++ b/tools/replay-viewer/snapshot/package-lock.json
@@ -1,0 +1,521 @@
+{
+  "name": "aegis-replay-viewer-snapshot",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aegis-replay-viewer-snapshot",
+      "version": "0.1.0",
+      "dependencies": {
+        "jsdom": "29.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/replay-viewer/snapshot/package.json
+++ b/tools/replay-viewer/snapshot/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "aegis-replay-viewer-snapshot",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Headless DOM snapshot test for the F8 replay viewer (F8-C / issue #64).",
+  "scripts": {
+    "test": "node run.mjs check",
+    "regenerate": "node run.mjs regenerate"
+  },
+  "dependencies": {
+    "jsdom": "29.1.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tools/replay-viewer/snapshot/run.mjs
+++ b/tools/replay-viewer/snapshot/run.mjs
@@ -1,0 +1,150 @@
+// Headless DOM snapshot test for the F8 replay viewer.
+// Per F8-C / ADR-010 / issue #64.
+//
+// Approach:
+//   1. Load tools/replay-viewer/index.html in jsdom (no real browser
+//      needed — the viewer is vanilla JS + DOM, no fetch / no remote
+//      anything per the F8-A air-gap contract).
+//   2. Provide globalThis.crypto (jsdom doesn't ship Web Crypto in v22-29).
+//   3. Drive the viewer's exposed render flow: parseJsonl -> verifyChain
+//      -> render. We bypass the file-picker change event because jsdom's
+//      FileReader/DataTransfer integration is brittle; the viewer exposes
+//      these primitives at the top of its <script> by construction.
+//   4. Walk the resulting DOM and produce a structured summary (per-entry
+//      type + key text snippets + integrity banner state). JSON is the
+//      diff-friendliest form for review.
+//   5. `check`     — compare summary against expected.json, exit non-zero
+//                    on drift.
+//      `regenerate`— overwrite expected.json. Run after intentional
+//                    viewer/fixture changes.
+//
+// Usage:
+//   node run.mjs check        # CI mode
+//   node run.mjs regenerate   # local: refresh expected.json
+//
+// Why jsdom over Playwright:
+//   The viewer is small, pure JS, and uses no browser-specific APIs we
+//   care about beyond the standard DOM + Web Crypto. Playwright would
+//   add ~300 MB of Chromium download to CI for negligible coverage gain.
+//   jsdom is ~9 MB, runs the test in ~1 s, and pins exactly the runtime
+//   we need.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { webcrypto } from "node:crypto";
+import { JSDOM, VirtualConsole } from "jsdom";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VIEWER = join(__dirname, "..", "index.html");
+const FIXTURE = join(__dirname, "..", "fixtures", "sample-session.jsonl");
+const EXPECTED = join(__dirname, "expected.json");
+
+// --- 1. Load the viewer in a jsdom DOM. Run scripts immediately so the
+// inline <script> defines parseJsonl / verifyChain / render on window.
+const html = readFileSync(VIEWER, "utf8");
+const virtualConsole = new VirtualConsole();
+virtualConsole.on("error", (e) => console.error("[jsdom error]", e));
+
+const dom = new JSDOM(html, {
+  runScripts: "dangerously",
+  pretendToBeVisual: true,
+  virtualConsole,
+});
+const { window } = dom;
+
+// --- 2. Web Crypto polyfill (jsdom doesn't ship it as of 29.x).
+if (!window.crypto || !window.crypto.subtle) {
+  Object.defineProperty(window, "crypto", { value: webcrypto, configurable: true });
+}
+
+// --- 3. Drive parseJsonl -> verifyChain -> render programmatically.
+// The viewer's <script> defines these at top-level, so they're available
+// on window after construction.
+const fixtureText = readFileSync(FIXTURE, "utf8");
+const entries = window.parseJsonl(fixtureText);
+const integrity = await window.verifyChain(fixtureText);
+window.render(entries, "sample-session.jsonl", integrity);
+
+// --- 4. Walk the rendered DOM and produce a structured summary.
+const summary = extractSummary(window.document);
+
+// --- 5. Compare or regenerate.
+const mode = process.argv[2] ?? "check";
+if (mode === "regenerate") {
+  writeFileSync(EXPECTED, JSON.stringify(summary, null, 2) + "\n");
+  console.log(`wrote ${EXPECTED}`);
+  process.exit(0);
+}
+if (mode !== "check") {
+  console.error(`usage: node run.mjs [check|regenerate]`);
+  process.exit(2);
+}
+
+const expected = JSON.parse(readFileSync(EXPECTED, "utf8"));
+const got = summary;
+if (JSON.stringify(expected) === JSON.stringify(got)) {
+  console.log(`OK: ${entries.length} entries, integrity=${integrity.state}`);
+  process.exit(0);
+}
+
+// Drift — print a small diff hint and the full got payload so a
+// reviewer can decide "intentional, regenerate" vs "regression".
+console.error("FAIL: rendered DOM does not match expected snapshot.");
+console.error(
+  "  rerun `node tools/replay-viewer/snapshot/run.mjs regenerate` if the change is intentional.\n",
+);
+console.error("=== expected ===");
+console.error(JSON.stringify(expected, null, 2));
+console.error("=== got ===");
+console.error(JSON.stringify(got, null, 2));
+process.exit(1);
+
+// ---------------------------------------------------------------------
+// Summary extraction. Targets the structural invariants we care about,
+// not whitespace / CSS. Keeps the snapshot readable and diff-stable.
+// ---------------------------------------------------------------------
+
+function extractSummary(doc) {
+  const banner = doc.querySelector(".integrity-banner");
+  const summary = doc.getElementById("summary");
+  const chips = [];
+  if (summary) {
+    for (const c of summary.querySelectorAll("span > code")) {
+      chips.push({ value: text(c) });
+    }
+  }
+  const entries = [];
+  for (const card of doc.querySelectorAll(".entry")) {
+    const type = card.getAttribute("data-type") || "unknown";
+    const seqEl = card.querySelector(".seq");
+    const tsEl = card.querySelector(".ts");
+    const pillEl = card.querySelector(".type-pill");
+    const rows = [];
+    for (const r of card.querySelectorAll(".body .row")) {
+      const k = r.querySelector(".k");
+      const v = r.querySelector(".v");
+      if (k && v) rows.push([text(k), text(v)]);
+    }
+    entries.push({
+      seq: seqEl ? text(seqEl) : null,
+      type,
+      pill: pillEl ? text(pillEl) : null,
+      timestamp: tsEl ? text(tsEl) : null,
+      rows,
+    });
+  }
+  return {
+    integrity: {
+      state: banner ? banner.className.replace("integrity-banner ", "").trim() : "missing",
+      label: banner ? text(banner) : "(no banner)",
+    },
+    chips,
+    entryCount: entries.length,
+    entries,
+  };
+}
+
+function text(el) {
+  return (el.textContent || "").replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
## Summary

Headless regression check: loads \`tools/replay-viewer/index.html\` into jsdom, drives \`parseJsonl → verifyChain → render\` against the committed fixture, and asserts the resulting DOM matches \`expected.json\`. If a future viewer or fixture change drifts the audit experience, this fails the workflow at PR time.

Closes #64. Final sub-issue of the F8 umbrella #61 — **F8 is complete** with this merge.

## jsdom vs Playwright

Picked **jsdom** over Playwright:

- Viewer is small, vanilla JS, uses standard DOM + Web Crypto only — no browser-specific APIs we test.
- Playwright would download ~300 MB of Chromium per CI run for negligible extra coverage.
- jsdom is ~9 MB, runs the test in ~1 s.
- F8-A's air-gap CI guard already enforces "works in any browser, no network." F8-C enforces "the rendered structure matches what we committed."

Trade-off: jsdom isn't a real browser, so this won't catch Chrome/Firefox/Safari rendering quirks. Acceptable — we're testing structure, not pixels.

## What the snapshot captures

Structural invariants only:

- **integrity banner** — state (\`verified\` / \`indeterminate\` / \`broken\`) and human-readable label
- **summary chips** — file name, session id, entry count, root hash
- **per-entry** — sequence, type, type-pill text, timestamp, every body row (key + value)

Whitespace, CSS, and pixel rendering are not pinned.

## Manually verified

- Pristine fixture → check passes; \`integrity=verified\`; root matches Rust \`verify_file\` byte-for-byte (\`3f11690f...0566af13\`)
- Tampered fixture (one char flipped on line 5) → check fails with \`state=broken\` at line 6 + inline diff identifying the drift

## When this fails on a PR

1. Read the inline diff the runner prints.
2. Intentional drift (new field, fixed wording) → \`npm run regenerate\` and commit the updated \`expected.json\`.
3. Regression → fix the viewer.

## Test plan

- [x] \`npm test\` against committed fixture: PASS
- [x] Negative test (tampered fixture): FAIL with state=broken
- [x] CI workflow runs only when \`tools/replay-viewer/**\` or the fixture generator changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)