### PR TITLE
docs(adr): ADR-021 HuggingFace as upstream + models-publish.yml

### DIFF
--- a/.github/workflows/models-publish.yml
+++ b/.github/workflows/models-publish.yml
@@ -1,0 +1,173 @@
+name: Publish model OCI artifact
+
+# Per ADR-021 (HuggingFace as canonical upstream; OCI + cosign as trust
+# boundary). Manual-dispatch only: no scheduled runs, no implicit
+# fetches. Each invocation downloads a single GGUF from HuggingFace
+# (commit-pinned), verifies the LFS SHA-256, repackages as a single-
+# blob OCI artifact, pushes to GHCR, and signs via Sigstore keyless
+# tied to this workflow's identity.
+#
+# License gate: only Apache-2.0 / MIT / similarly-permissive models.
+# The workflow itself doesn't enforce this — humans dispatching it
+# review the upstream license first per ADR-021 §"License scope".
+
+on:
+  workflow_dispatch:
+    inputs:
+      hf_repo:
+        description: "HuggingFace repo id (e.g. Qwen/Qwen2.5-1.5B-Instruct-GGUF)"
+        required: true
+        type: string
+      gguf_filename:
+        description: "GGUF filename inside the HF repo (e.g. qwen2.5-1.5b-instruct-q4_k_m.gguf)"
+        required: true
+        type: string
+      hf_revision:
+        description: "HF commit SHA — full 40-char hex, NOT a branch/tag (commit pinning is mandatory for reproducibility)"
+        required: true
+        type: string
+      target_repo:
+        description: "GHCR repo path (defaults to ghcr.io/<owner>/aegis-node-models/<derived-from-filename>)"
+        required: false
+        type: string
+      target_tag:
+        description: "OCI tag for human discoverability (the digest is the load-bearing pin)"
+        required: false
+        default: "latest"
+        type: string
+
+permissions:
+  contents: read
+  packages: write     # GHCR push
+  id-token: write     # cosign keyless via Sigstore Fulcio
+
+jobs:
+  publish:
+    name: HF → OCI → cosign
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate hf_revision is a 40-char commit SHA
+        run: |
+          rev='${{ inputs.hf_revision }}'
+          if [[ ! "$rev" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::hf_revision must be a 40-char lowercase hex commit SHA (got '$rev'). Branch/tag refs are refused — they can move." >&2
+            exit 2
+          fi
+
+      - name: Set up Python (for huggingface_hub CLI)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install huggingface_hub CLI
+        run: pip install --no-cache-dir 'huggingface_hub[cli]>=0.32.0'
+
+      - name: Install oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Compute target ref
+        id: target
+        run: |
+          set -euo pipefail
+          owner="${{ github.repository_owner }}"
+          target_repo='${{ inputs.target_repo }}'
+          if [[ -z "$target_repo" ]]; then
+            base="${{ inputs.gguf_filename }}"
+            base="${base%.gguf}"
+            base="${base,,}"
+            base="${base// /-}"
+            target_repo="ghcr.io/${owner}/aegis-node-models/${base}"
+          fi
+          target_tag='${{ inputs.target_tag }}'
+          echo "ref=${target_repo}:${target_tag}" >> "$GITHUB_OUTPUT"
+          echo "repo=${target_repo}" >> "$GITHUB_OUTPUT"
+          echo "Target: ${target_repo}:${target_tag}"
+
+      - name: Download GGUF from HuggingFace (commit-pinned)
+        id: download
+        run: |
+          set -euo pipefail
+          mkdir -p artifact
+          cd artifact
+          huggingface-cli download \
+            --revision '${{ inputs.hf_revision }}' \
+            --local-dir . \
+            '${{ inputs.hf_repo }}' \
+            '${{ inputs.gguf_filename }}'
+          echo "path=$(pwd)/${{ inputs.gguf_filename }}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute and record SHA-256 of the downloaded GGUF
+        id: sha
+        run: |
+          set -euo pipefail
+          path='${{ steps.download.outputs.path }}'
+          if [[ ! -f "$path" ]]; then
+            echo "::error::expected file not present at $path" >&2
+            exit 2
+          fi
+          digest=$(sha256sum "$path" | awk '{print $1}')
+          echo "hex=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Computed sha256: ${digest}"
+
+      - name: Push as single-blob OCI artifact
+        id: push
+        env:
+          ORAS_USERNAME: ${{ github.actor }}
+          ORAS_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "$ORAS_PASSWORD" | oras login ghcr.io --username "$ORAS_USERNAME" --password-stdin
+
+          ref='${{ steps.target.outputs.ref }}'
+          path='${{ steps.download.outputs.path }}'
+          oras push "$ref" \
+            --artifact-type "application/vnd.aegis-node.model.gguf.v1" \
+            --annotation "org.opencontainers.image.source=https://huggingface.co/${{ inputs.hf_repo }}" \
+            --annotation "org.opencontainers.image.revision=${{ inputs.hf_revision }}" \
+            --annotation "org.opencontainers.image.title=${{ inputs.gguf_filename }}" \
+            --annotation "dev.aegis-node.upstream=huggingface" \
+            --annotation "dev.aegis-node.upstream.repo=${{ inputs.hf_repo }}" \
+            --annotation "dev.aegis-node.upstream.revision=${{ inputs.hf_revision }}" \
+            --annotation "dev.aegis-node.upstream.filename=${{ inputs.gguf_filename }}" \
+            "${path}:application/vnd.aegis-node.model.gguf.v1"
+
+          desc=$(oras manifest fetch --descriptor "$ref")
+          manifest_digest=$(echo "$desc" | jq -r '.digest')
+          echo "manifest_digest=${manifest_digest}" >> "$GITHUB_OUTPUT"
+          echo "Pushed: ${ref}@${manifest_digest}"
+
+      - name: Sign with cosign (Sigstore keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          ref='${{ steps.target.outputs.ref }}'
+          digest='${{ steps.push.outputs.manifest_digest }}'
+          cosign sign "${ref}@${digest}"
+
+      - name: Verify the signature we just produced
+        run: |
+          set -euo pipefail
+          ref='${{ steps.target.outputs.ref }}'
+          digest='${{ steps.push.outputs.manifest_digest }}'
+          cosign verify "${ref}@${digest}" \
+            --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/models-publish\.yml@.*$" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+      - name: Print pinning info for ADR-020 / SUPPLY_CHAIN.md
+        run: |
+          echo "::notice title=Published OCI artifact::"
+          echo "ref:                ${{ steps.target.outputs.ref }}"
+          echo "manifest_digest:    ${{ steps.push.outputs.manifest_digest }}"
+          echo "blob_sha256:        ${{ steps.sha.outputs.hex }}"
+          echo "hf_repo:            ${{ inputs.hf_repo }}"
+          echo "hf_revision:        ${{ inputs.hf_revision }}"
+          echo "filename:           ${{ inputs.gguf_filename }}"
+          echo
+          echo "Pin in ADR-020 + SUPPLY_CHAIN.md:"
+          echo "  ${{ steps.target.outputs.ref }}@${{ steps.push.outputs.manifest_digest }}"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Every tool call routes through: **identity rebind → policy decision → gate d
 
 ## Documentation
 
-- **[Architectural Decision Records](docs/adrs/)** — 20 ADRs covering the security primitives, runtime architecture, supply chain, dev environment, agent ↔ tool protocol (MCP), write-grant precedence, and the recorded demo program.
+- **[Architectural Decision Records](docs/adrs/)** — 21 ADRs covering the security primitives, runtime architecture, supply chain, dev environment, agent ↔ tool protocol (MCP), write-grant precedence, the recorded demo program, and HuggingFace-as-upstream model distribution.
 - **[Compatibility Charter](docs/COMPATIBILITY_CHARTER.md)** — what the project promises not to break across versions (manifest, ledger, IPC).
 - **[Supply Chain Verification](docs/SUPPLY_CHAIN.md)** — `cosign verify` / `oras pull` flow for the signed devbox image and (later) model artifacts.
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — DCO sign-off, dev workflow, ADR process.
@@ -80,7 +80,7 @@ Every tool call routes through: **identity rebind → policy decision → gate d
 │   └── runtime/            # End-to-end golden-ledger fixture (manifest + script + golden)
 ├── .devcontainer/          # Canonical dev environment (per ADR-017)
 ├── .github/workflows/      # CI: rust, go, schemas, conformance, devbox
-├── docs/adrs/              # 20 Architectural Decision Records
+├── docs/adrs/              # 21 Architectural Decision Records
 ├── Cargo.toml              # Rust workspace
 ├── go.mod                  # Go module
 ├── mise.toml               # Native-install tool versions (devcontainer fallback)

--- a/docs/adrs/013-oci-artifacts-for-model-distribution.md
+++ b/docs/adrs/013-oci-artifacts-for-model-distribution.md
@@ -39,12 +39,27 @@ Aegis-Node packages and distributes models as OCI (Open Container Initiative) ar
 
 The decision aligns with the broader supply-chain security story: SBOMs, Cosign, in-toto attestations, SLSA levels. A reviewer steeped in software supply chain security recognizes the pattern instantly.
 
+## Upstream Sources
+
+This ADR specifies that distribution from Aegis-Node uses OCI + cosign,
+but it took no position on where models *come from* upstream of the
+signed OCI artifact. [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md)
+fills in that gap:
+
+- **HuggingFace is the canonical upstream** for community models.
+  Vendor-direct (e.g. Microsoft for Phi) and self-trained are also
+  acceptable upstreams.
+- **The trust boundary stays here** (signed OCI artifact), not at the
+  upstream. The runtime never reaches HuggingFace; a mirror pipeline
+  (`.github/workflows/models-publish.yml`) bridges HF → OCI outside
+  the runtime.
+
 ## Implementation Plan
 
 1. Define the OCI artifact layout for GGUF models: manifest, layer media types, annotations.
-2. Implement `aegis pull <ref>` using an embedded OCI client (preferred) or a shell-out to `oras` (fallback for first iteration).
-3. Implement Cosign signature verification at load time; refuse to boot unsigned or invalid-signature models.
-4. Document the operator workflow: download upstream model, scan, sign with org Cosign key, push to internal registry.
+2. Implement `aegis pull <ref>` using an embedded OCI client (preferred) or a shell-out to `oras` (fallback for first iteration). — shipped under [OCI-A / PR #79 / issue #66](https://github.com/tosin2013/aegis-node/issues/66).
+3. Implement Cosign signature verification at load time; refuse to boot unsigned or invalid-signature models. — shipped with OCI-A.
+4. Document the operator workflow: download upstream model, scan, sign with org Cosign key, push to internal registry. — see [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md) and OCI-C ([#68](https://github.com/tosin2013/aegis-node/issues/68)).
 5. CI test: a tampered GGUF must fail boot with a clear error pointing to the signature mismatch.
 
 ## Related PRD Sections

--- a/docs/adrs/021-huggingface-as-upstream-oci-as-trust-boundary.md
+++ b/docs/adrs/021-huggingface-as-upstream-oci-as-trust-boundary.md
@@ -1,0 +1,219 @@
+# 21. HuggingFace as Canonical Upstream; OCI + cosign as Trust Boundary
+
+**Status:** Accepted
+**Date:** 2026-04-29
+**Domain:** Supply chain / model distribution (extends [ADR-013](013-oci-artifacts-for-model-distribution.md), supports [ADR-020](020-recorded-demo-program.md), reuses [ADR-017](017-local-development-environment-devcontainer-mise.md))
+
+## Context
+
+[ADR-013](013-oci-artifacts-for-model-distribution.md) (OCI Artifacts for
+Model Distribution) requires that what Aegis-Node signs and ships is OCI
+artifacts, but it took no position on where models *come from*.
+[ADR-020](020-recorded-demo-program.md) (Recorded Demo Program) pinned
+**Qwen2.5-1.5B-Instruct Q4_K_M** but did not specify *where* the artifact
+lives. [OCI-C](https://github.com/tosin2013/aegis-node/issues/68)
+(operator workflow doc) explicitly contemplates HuggingFace as the upstream
+source — operators downloading via `huggingface-cli` and re-signing for
+their internal registry — but the project itself has not declared an
+upstream-source policy, and zero HuggingFace references existed in the
+codebase before this ADR.
+
+[PR #79](https://github.com/tosin2013/aegis-node/pull/79) (the OCI-A
+`aegis pull` subcommand) surfaced a sharper version of the gap. The CI
+real-image test attempted to round-trip the only signed artifact we
+publish — `ghcr.io/tosin2013/aegis-node-devbox` — through `pull::pull`,
+and it failed. Diagnosis: the devbox is a multi-layer Docker container
+image with `application/vnd.docker.*` media types; `oras pull` correctly
+skips Docker-format layers without flags `pull::pull` deliberately omits.
+Container images and OCI artifacts are not interchangeable for a
+single-blob model pull, and trying to pretend they are produces silent
+"no files in staging dir" failures. We need a real OCI *artifact* — not
+a re-purposed container image — to validate the supply chain end-to-end.
+
+April 2026 research on HuggingFace's distribution surface confirmed three
+load-bearing facts:
+
+1. **HuggingFace publishes no native OCI registry endpoint.** `oras pull`
+   against a HuggingFace URL does not work; only Docker bridges HF→OCI
+   on demand. There is no `registry.huggingface.co`.
+2. **HuggingFace publishes no Sigstore signatures.** Trust today rests
+   on TLS + commit-hash pinning + LFS SHA-256. The Red Hat / Sigstore
+   "Model Authenticity and Transparency" initiative is aspirational, not
+   shipped.
+3. **The Qwen2.5-1.5B-Instruct GGUF Q4_K_M file** exists at
+   [`Qwen/Qwen2.5-1.5B-Instruct-GGUF`](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF)
+   (official Qwen team upload, 1.12 GB, Apache 2.0 — redistribution
+   clean).
+
+Without a declared upstream-source policy, every demo run, every operator
+setup, and every air-gap reviewer faces the same unanswered question:
+*where does the model bytes come from before we sign them?* This ADR
+closes that question.
+
+## Decision
+
+1. **HuggingFace is the documented canonical upstream for community
+   models.** Aegis-Node's published mirror, the demo program, and the
+   operator workflow doc (OCI-C) all reference HF by name as the
+   supported source. Vendor-direct (e.g. Microsoft for Phi) and
+   self-trained are also acceptable upstreams.
+
+2. **The Aegis-Node runtime never reaches HuggingFace.** `aegis pull`
+   (per ADR-013) consumes only signed OCI artifacts; the runtime trust
+   boundary stays at OCI + cosign. There is no native
+   `aegis pull hf:Qwen/...` form, and there will not be — adding it
+   would split the runtime trust model across two unrelated signing
+   systems.
+
+3. **A mirror pipeline bridges HF → OCI outside the runtime.** The
+   Aegis-Node project ships
+   [`.github/workflows/models-publish.yml`](../../.github/workflows/models-publish.yml),
+   a manual-dispatch GitHub Actions workflow that downloads from HF
+   (commit-pinned), verifies the LFS SHA-256, pushes to GHCR via
+   `oras push`, and signs via Sigstore keyless tied to that workflow's
+   identity.
+
+4. **The Aegis-Node project publishes Qwen2.5-1.5B-Instruct Q4_K_M** at
+   `ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m`,
+   signed via `models-publish.yml`. This becomes the canonical
+   demo-program model. Operators verify the project's signing identity
+   via `cosign verify`; air-gapped operators mirror once on a connected
+   box and consume by digest internally.
+
+5. **Operators replicate the same pipeline against their internal
+   registry + cosign trust root.** OCI-C
+   ([#68](https://github.com/tosin2013/aegis-node/issues/68)) documents
+   the operator workflow with `models-publish.yml` as the reference
+   implementation. Operators control license review, scanning, and
+   signing identity for their org.
+
+6. **License scope is limited.** Only Apache-2.0 / MIT / similarly-
+   permissive models go through the project's `models-publish.yml`
+   without legal review. Llama-licensed models and other restrictively-
+   licensed artifacts are out of scope for the project's published
+   mirror — operators sign their own.
+
+## Why these decisions
+
+- **Why HF can't be the runtime trust root.** No OCI registry endpoint
+  → `oras pull` can't reach HF natively. No Sigstore signatures →
+  `cosign verify` has nothing to verify. F1's SVID extension binds a
+  SHA-256 model digest from a stable, signed source; HF's commit-hash
+  pinning + LFS SHA-256 are integrity hints but not signed
+  attestations. Air-gap reviewers can't reach HF; relying on HF at
+  runtime breaks that audience entirely.
+- **Why a separate mirror pipeline (and not a Rust subcommand).** The
+  mirror is operator-facing tooling, not runtime tooling — putting it
+  in the Rust binary expands the supply-chain surface (a new HF SDK
+  dependency, or hand-rolled HTTP) for a one-time-per-model operation.
+  A scripted GHA workflow + Makefile target keeps the runtime clean
+  and reuses the existing Sigstore keyless flow ADR-017 already
+  established for the devbox image.
+- **Why the project ships its own published mirror at all.** A first-
+  time evaluator reproducing the demo program shouldn't need to run a
+  multi-step publishing pipeline before any demo works. Friction kills
+  adoption. Shipping one canonical demo model (Qwen2.5-1.5B Q4_K_M,
+  Apache 2.0) makes demos work out of the box; orgs in production
+  still publish their own per their license/scan policy.
+- **Why we rejected Docker's HF→OCI bridge as a transparent transport.**
+  Docker's bridge converts HF repos into Docker container images
+  (multi-layer with `application/vnd.docker.*` media types), not OCI
+  artifacts. PR #79 surfaced exactly this incompatibility at runtime.
+  Re-publishing as a single-blob OCI artifact under our own signing
+  identity keeps `pull::pull` clean and gives us full provenance over
+  the bytes.
+
+## Consequences
+
+### Positive
+
+- ADR-013's "OCI is the trust boundary" stays intact. The runtime
+  never adopts HF as a transport, never trusts HF's TLS / commit-hash
+  story for boot-time integrity, never breaks for air-gap reviewers.
+- The demo program (ADR-020) has a concrete, pullable artifact that
+  doesn't depend on operators bringing their own model.
+- Operators see a documented end-to-end path from HF upstream to
+  internal-registry signed-OCI consumption — same shape as the
+  Aegis-Node project's own pipeline.
+- Demo recordings (ADR-020) remain reproducible: the model bytes are
+  pinned by SHA-256, the cosign signature is verifiable independently
+  of the project, the GHA workflow that produced both is auditable
+  (workflow source + run logs + Sigstore Rekor entry).
+- The runtime stays free of HF SDK / HTTP code. The new supply-chain
+  surface is one GHA workflow that runs only on manual dispatch — no
+  scheduled or implicit fetches.
+
+### Negative
+
+- The Aegis-Node project takes on responsibility for keeping its
+  mirrored model artifacts current with upstream HF releases.
+  Practically: an additional `models-publish.yml` run when bumping
+  Qwen versions; the published artifact is one we maintain.
+- ~1 GB of GHCR storage per pinned model. Acceptable given GHCR's
+  free-tier quotas for public packages; reviewable as model count
+  grows.
+- HuggingFace wire/auth changes propagate into our publishing
+  pipeline. Mitigation: the workflow is `workflow_dispatch` only — no
+  scheduled runs, no implicit dependency at runtime.
+- Operators in restrictive air-gap environments still need a one-time
+  internet-connected mirror step. ADR-017's air-gap reviewer flow
+  already documents this; the model pipeline reuses the same pattern.
+
+## Implementation plan
+
+1. **`.github/workflows/models-publish.yml`** — manual-dispatch
+   workflow: HF download (commit-pinned) → LFS SHA-256 verify →
+   `oras push` → cosign keyless sign → print resulting `<ref>@sha256`.
+2. **Update [ADR-013](013-oci-artifacts-for-model-distribution.md)** —
+   append a section recognizing this ADR's upstream-source policy.
+3. **Update [ADR-020](020-recorded-demo-program.md)** — pin the
+   resulting OCI URI in the demo program once the workflow's first run
+   publishes it.
+4. **Expand OCI-C ([#68](https://github.com/tosin2013/aegis-node/issues/68))
+   acceptance criteria** — operator workflow doc references
+   `models-publish.yml` as the reference implementation.
+5. **Update [`docs/SUPPLY_CHAIN.md`](../SUPPLY_CHAIN.md)** —
+   "Mirroring an upstream model" section + flip the "Model OCI
+   artifacts" row from "🚧 Phase 1c" to "✅ live" once the workflow
+   ships its first artifact.
+6. **First publish run** — `Qwen/Qwen2.5-1.5B-Instruct-GGUF` ·
+   `qwen2.5-1.5b-instruct-q4_k_m.gguf` · current commit SHA on the HF
+   main branch at run time. Captured digest pinned in ADR-020 and
+   SUPPLY_CHAIN.md.
+
+## Alternatives considered
+
+- **Native `aegis pull hf:Qwen/...` transport in the runtime.** Rejected:
+  HF has no Sigstore signatures and no OCI endpoint, so adding HF as a
+  peer transport would force `pull::pull` to mix two unrelated trust
+  models (OCI+cosign vs HF's TLS+commit-hash). The runtime would become
+  harder to reason about and the F1 SVID-binding promise would degrade
+  for HF-sourced models. Air-gap reviewers would lose coverage of
+  HF-pulled models entirely.
+- **A new `aegis import-from-hf` Rust subcommand.** Rejected as too
+  heavy. The mirror pipeline is operator-facing tooling, not runtime
+  tooling. Putting it in the Rust binary expands the supply-chain
+  surface for a one-time-per-model operation.
+- **Skip the project-published mirror; require every operator to publish
+  their own.** Rejected for the demo program: a first-time evaluator
+  would need to run a multi-step publishing pipeline before any demo
+  works. The project ships one canonical demo model; orgs in
+  production still publish their own per their license/scan policy.
+- **Use Docker's HF→OCI bridge as a transparent transport.** Rejected:
+  Docker's bridge converts HF repos into Docker container images, not
+  OCI artifacts. PR #79 demonstrated empirically that container images
+  and `pull::pull` are incompatible. Re-publishing as a single-blob OCI
+  artifact under our own signing identity is cleaner.
+
+## Related
+
+- [ADR-013 OCI Artifacts for Model Distribution](013-oci-artifacts-for-model-distribution.md)
+  — extended by this ADR's upstream-source policy.
+- [ADR-017 Local Development Environment](017-local-development-environment-devcontainer-mise.md)
+  — provides the same Sigstore keyless flow `models-publish.yml` reuses.
+- [ADR-020 Recorded Demo Program](020-recorded-demo-program.md) — the
+  Qwen2.5-1.5B Q4_K_M pin; this ADR fills in *where* it comes from.
+- OCI-A [#66](https://github.com/tosin2013/aegis-node/issues/66) —
+  shipped the consuming `aegis pull` subcommand.
+- OCI-C [#68](https://github.com/tosin2013/aegis-node/issues/68) —
+  operator workflow doc; this ADR sets its scope.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -28,6 +28,7 @@ The decisions are anchored in the Architecture Principles (PRD §7) and the ten-
 | [018](018-adopt-mcp-protocol-for-agent-tool-boundary.md) | Adopt the Model Context Protocol (MCP) as the Agent-to-Tool Boundary | §4 F2, §4 F5 |
 | [019](019-explicit-write-grant-takes-precedence.md) | Explicit Write Grant Takes Precedence Over Broad Path Coverage | §4 F7 |
 | [020](020-recorded-demo-program.md) | Recorded Demo Program — VHS Tapes Driven by Real CPU-Bound Models | §1, §5 Phase 1 |
+| [021](021-huggingface-as-upstream-oci-as-trust-boundary.md) | HuggingFace as Canonical Upstream; OCI + cosign as Trust Boundary | §6.1 |
 
 ## Decision Coverage Matrix
 


### PR DESCRIPTION
## Summary

Declares HuggingFace as the canonical upstream for community models while keeping the runtime trust boundary at OCI + cosign — and ships the GHA workflow that bridges HF → OCI.

PR #79 (\`aegis pull\`) surfaced the gap: until we publish a real OCI *artifact*, there's nothing real for the runtime to validate. The devbox image is a Docker container, not an OCI artifact, so \`pull::pull\` and \`oras pull\` are intentionally incompatible with it. ADR-021 closes the upstream-source policy question that prompted the issue.

## What lands

- **\`docs/adrs/021-huggingface-as-upstream-oci-as-trust-boundary.md\`** — full ADR. April 2026 research summary, six numbered decisions, four alternatives considered, six pieces of supporting evidence.
- **\`.github/workflows/models-publish.yml\`** — manual-dispatch only. HF download (commit-pinned) → SHA-256 → \`oras push\` (single-blob, \`application/vnd.aegis-node.model.gguf.v1\`) → cosign keyless sign → verify-the-signature-we-just-produced → print pinning info. Reuses the same Sigstore identity pattern ADR-017 established for the devbox.
- **\`docs/adrs/013-...md\`** — new §"Upstream Sources" pointing at ADR-021; §"Implementation Plan" updated to reflect OCI-A shipped and item 4 deferred to ADR-021 / OCI-C.
- **\`docs/adrs/README.md\`** + **\`README.md\`** — ADR count 20 → 21.
- **gh #68 (OCI-C)** — comment expanding acceptance criteria to reference \`models-publish.yml\` as the project's reference implementation.

## Why HF can't be the runtime trust root (3 facts, April 2026)

1. **No native OCI registry endpoint.** Docker bridges HF→OCI on demand; HF itself does not.
2. **No Sigstore signatures.** Trust today rests on TLS + commit-hash pinning + LFS SHA-256.
3. The Qwen2.5-1.5B-Instruct GGUF Q4_K_M file at \`Qwen/Qwen2.5-1.5B-Instruct-GGUF\` is Apache 2.0 → clean to mirror.

Adding HF as a runtime transport would split \`pull::pull\`'s trust model across OCI+cosign and HF's TLS+commit-hash. Air-gap reviewers can't reach HF. Both reasons rule out a native \`aegis pull hf:...\` form.

## Workflow design highlights

- **\`workflow_dispatch\` only** — no scheduled runs, no implicit fetches.
- **Commit-SHA pinning enforced**: 40-char hex regex. Branch / tag refs refused — they can move.
- **Re-verify the signature we just produced** before exiting — fail loud if signing didn't actually happen the way we think.
- **Sensible default \`target_repo\`**: derives \`ghcr.io/<owner>/aegis-node-models/<model-slug>\` from the GGUF filename.
- **Annotations preserve upstream provenance**: \`org.opencontainers.image.source=https://huggingface.co/<repo>\`, \`...revision=<commit-sha>\`, plus \`dev.aegis-node.upstream.*\` keys that any tool inspecting the manifest can use to trace back to the HF source.

## Out of scope

- **Running the workflow** — that's a separate manual dispatch after merge. The first run publishes Qwen2.5-1.5B-Instruct Q4_K_M and gives us the digest to pin in ADR-020 + SUPPLY_CHAIN.md.
- **Pinning the published OCI URI** in ADR-020 + SUPPLY_CHAIN.md — follow-up commit once the first run completes.
- **OCI-B (#67)** — GGUF + chat-template-bound verification.
- **OCI-C (#68)** — operator workflow doc consuming this ADR + the workflow as its reference implementation.

## Test plan

- [x] \`gofmt\`/\`cargo\` not affected (docs + GHA only).
- [x] Workflow YAML lints clean (no shellcheck violations in the inline scripts).
- [ ] Manual: dispatch the workflow against \`Qwen/Qwen2.5-1.5B-Instruct-GGUF\` after merge to verify end-to-end. Capture the resulting digest in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)