### PR TITLE
fix(models-publish): use `hf` instead of deprecated `huggingface-cli`

### DIFF
--- a/.github/workflows/models-publish.yml
+++ b/.github/workflows/models-publish.yml
@@ -94,7 +94,9 @@ jobs:
           set -euo pipefail
           mkdir -p artifact
           cd artifact
-          huggingface-cli download \
+          # `hf` is the post-rename successor to the deprecated
+          # `huggingface-cli`; same semantics, different binary name.
+          hf download \
             --revision '${{ inputs.hf_revision }}' \
             --local-dir . \
             '${{ inputs.hf_repo }}' \


### PR DESCRIPTION
## Summary

First dispatch of \`models-publish.yml\` (run [25134808068](https://github.com/tosin2013/aegis-node/actions/runs/25134808068)) failed at the HF download step:

\`\`\`
Warning: \`huggingface-cli\` is deprecated and no longer works. Use \`hf\` instead.
Hint: \`hf\` is already installed! Use it directly.
\`\`\`

The \`huggingface_hub\` CLI was rebranded — same semantics, different binary name (\`huggingface-cli\` → \`hf\`). Switch the workflow to \`hf download\`, re-dispatch.

## Test plan

- [x] Workflow YAML diff is one line.
- [ ] After merge: re-dispatch with \`Qwen/Qwen2.5-1.5B-Instruct-GGUF\` + \`qwen2.5-1.5b-instruct-q4_k_m.gguf\` + commit \`91cad51170dc346986eccefdc2dd33a9da36ead9\`. Capture the published digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)