### PR TITLE
fix(models-publish): use relative path for oras push

### DIFF
--- a/.github/workflows/models-publish.yml
+++ b/.github/workflows/models-publish.yml
@@ -126,7 +126,14 @@ jobs:
           echo "$ORAS_PASSWORD" | oras login ghcr.io --username "$ORAS_USERNAME" --password-stdin
 
           ref='${{ steps.target.outputs.ref }}'
+          # `oras push` refuses absolute paths by default to keep the
+          # layer-name annotation portable across registries — push
+          # from inside the artifact dir so the layer name is just the
+          # bare filename.
           path='${{ steps.download.outputs.path }}'
+          artifact_dir="$(dirname "$path")"
+          file_name="$(basename "$path")"
+          cd "$artifact_dir"
           oras push "$ref" \
             --artifact-type "application/vnd.aegis-node.model.gguf.v1" \
             --annotation "org.opencontainers.image.source=https://huggingface.co/${{ inputs.hf_repo }}" \
@@ -136,7 +143,7 @@ jobs:
             --annotation "dev.aegis-node.upstream.repo=${{ inputs.hf_repo }}" \
             --annotation "dev.aegis-node.upstream.revision=${{ inputs.hf_revision }}" \
             --annotation "dev.aegis-node.upstream.filename=${{ inputs.gguf_filename }}" \
-            "${path}:application/vnd.aegis-node.model.gguf.v1"
+            "${file_name}:application/vnd.aegis-node.model.gguf.v1"
 
           desc=$(oras manifest fetch --descriptor "$ref")
           manifest_digest=$(echo "$desc" | jq -r '.digest')


### PR DESCRIPTION
## Summary

Second dispatch ([run 25135009034](https://github.com/tosin2013/aegis-node/actions/runs/25135009034)) got past the HF download but failed at \`oras push\`:

\`\`\`
Error: absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check
\`\`\`

\`oras\` refuses absolute paths by default to keep the layer-name annotation portable across registries. Push from inside the artifact dir so the layer name is the bare filename — same artifact bytes, cleaner descriptor.

## Test plan

- [ ] After merge: re-dispatch the workflow. Same inputs as before (\`Qwen/Qwen2.5-1.5B-Instruct-GGUF\` · \`qwen2.5-1.5b-instruct-q4_k_m.gguf\` · \`91cad51170dc346986eccefdc2dd33a9da36ead9\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)