### PR TITLE
docs: operator workflow for HF → OCI mirroring (OCI-C, issue #68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Every tool call routes through: **identity rebind → policy decision → gate d
 
 - **[Architectural Decision Records](docs/adrs/)** — 21 ADRs covering the security primitives, runtime architecture, supply chain, dev environment, agent ↔ tool protocol (MCP), write-grant precedence, the recorded demo program, and HuggingFace-as-upstream model distribution.
 - **[Compatibility Charter](docs/COMPATIBILITY_CHARTER.md)** — what the project promises not to break across versions (manifest, ledger, IPC).
-- **[Supply Chain Verification](docs/SUPPLY_CHAIN.md)** — `cosign verify` / `oras pull` flow for the signed devbox image and (later) model artifacts.
+- **[Supply Chain Verification](docs/SUPPLY_CHAIN.md)** — `cosign verify` / `oras pull` flow for the signed devbox image and model artifacts.
+- **[Model Mirroring](docs/MODEL_MIRRORING.md)** — operator workflow for publishing a HuggingFace model to your internal OCI registry, signed with your org's cosign trust root (per ADR-013 + ADR-021).
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — DCO sign-off, dev workflow, ADR process.
 - **[RELEASE_PLAN.md](RELEASE_PLAN.md)** — 7 baseline milestones (v0.1.0 → v3.0.0). v1.0.0 anchors to the U.S. CMMC 2.0 deadline (2026-11-02).
 - **[TODO.md](TODO.md)** — phase-grouped task plan plus paired test+production tasks decomposed from each ADR.

--- a/docs/MODEL_MIRRORING.md
+++ b/docs/MODEL_MIRRORING.md
@@ -1,0 +1,269 @@
+# Mirroring an Upstream Model — Operator Workflow
+
+This is the practical "how to publish a model your runtime can pull"
+doc. It walks an operator through the same pipeline the Aegis-Node
+project itself uses to publish demo models, scaled for an org's
+internal registry, scanning policy, and cosign trust root.
+
+**Per**:
+- [ADR-013](adrs/013-oci-artifacts-for-model-distribution.md) — models
+  ship as signed OCI artifacts.
+- [ADR-021](adrs/021-huggingface-as-upstream-oci-as-trust-boundary.md)
+  — HuggingFace is the canonical upstream; OCI + cosign is the trust
+  boundary the runtime sees.
+- [`.github/workflows/models-publish.yml`](../.github/workflows/models-publish.yml)
+  — the project's reference implementation; this doc adapts it.
+- OCI-C tracking issue: [#68](https://github.com/tosin2013/aegis-node/issues/68).
+
+## TL;DR
+
+```
+HuggingFace (upstream)
+   │  hf download <repo> <file> --revision <commit-sha>
+   ▼
+Operator workstation / CI runner
+   │  scan (AV + injection corpus + license review)
+   │  oras push  → <internal-registry>/<repo>@sha256:<manifest-digest>
+   │  cosign sign (your org's keyless OIDC or KMS key)
+   ▼
+Internal registry (Harbor / Artifactory / ECR / Quay)
+   │  aegis pull <ref>@sha256:<digest> --keyless-identity <org regex>
+   ▼
+Air-gapped session boot
+```
+
+Five steps. Every gate is auditable by a security reviewer with
+standard tooling (`hf`, `oras`, `cosign`, `sha256sum`).
+
+## Step 1: Pick the upstream and pin a commit SHA
+
+Operators in production should pin **HuggingFace commit SHAs**, not
+branch/tag refs — branches move. The published Qwen artifact is
+pinned to `91cad51170dc346986eccefdc2dd33a9da36ead9`.
+
+```bash
+# Resolve the current head SHA of the model repo's main branch.
+curl -s "https://huggingface.co/api/models/<owner>/<repo>" \
+  | jq -r '.sha'
+```
+
+Snapshot that SHA in your operator changelog so a security reviewer
+can correlate the artifact you publish with the exact upstream bytes.
+
+## Step 2: Download (commit-pinned)
+
+```bash
+hf download \
+  --revision <40-char-commit-sha> \
+  --local-dir ./artifact \
+  <owner>/<repo> \
+  <filename>.gguf
+```
+
+Why `hf` (not `huggingface-cli`): `huggingface-cli` was deprecated in
+the `huggingface_hub >= 0.32.0` rename. `hf` ships with the same
+package; semantics are identical.
+
+## Step 3: Scan and license-review
+
+This is the gate the project's `models-publish.yml` does **not**
+exercise — orgs own their scanning policy. Standard checklist:
+
+- **Malware AV** — ClamAV, your enterprise scanner, your CI scanner.
+- **Prompt-injection corpus** — run a battery of known jailbreak /
+  injection prompts against the model and record the violation rate.
+  No fixed pass/fail bar; document the result so the security review
+  can decide.
+- **License review** — confirm the upstream's license permits your
+  intended use (re-distribution to internal users, commercial,
+  air-gap, etc.). Apache 2.0 / MIT / similarly-permissive is the
+  no-legal-review path; Llama 3 / Llama 4 / vendor-restricted models
+  need legal sign-off per your org policy.
+- **Provenance check** — cross-reference the upstream commit SHA
+  against the upstream's own release notes / model card. Reject if
+  the SHA is force-pushed / rewritten.
+
+Record everything in your changelog; the changelog itself becomes an
+audit artifact.
+
+## Step 4: Push as an OCI artifact
+
+The artifact layout the project uses (single-blob GGUF with a custom
+artifact-type and traceability annotations):
+
+```bash
+cd ./artifact
+oras push <internal-registry>/<repo>:<tag> \
+  --artifact-type "application/vnd.aegis-node.model.gguf.v1" \
+  --annotation "org.opencontainers.image.source=https://huggingface.co/<owner>/<repo>" \
+  --annotation "org.opencontainers.image.revision=<commit-sha>" \
+  --annotation "org.opencontainers.image.title=<filename>.gguf" \
+  --annotation "dev.aegis-node.upstream=huggingface" \
+  --annotation "dev.aegis-node.upstream.repo=<owner>/<repo>" \
+  --annotation "dev.aegis-node.upstream.revision=<commit-sha>" \
+  --annotation "dev.aegis-node.upstream.filename=<filename>.gguf" \
+  "<filename>.gguf:application/vnd.aegis-node.model.gguf.v1"
+```
+
+The annotations are advisory but powerful: any tool inspecting the
+manifest can trace the artifact back to its HF upstream. Add your
+own org-specific keys (e.g. `<corp>.security.scan.report-url`,
+`<corp>.licensing.legal-ticket`) so future audits can find the
+evidence inline.
+
+`cd` into the artifact directory before `oras push` — `oras` rejects
+absolute paths in the layer-name component to keep the manifest
+portable across registries.
+
+## Step 5: Sign with cosign
+
+Two acceptable flows. Pick the one that matches your org's signing
+identity.
+
+### 5a. Sigstore keyless (recommended for non-air-gapped)
+
+Same flow ADR-017 establishes for the project's devbox image. Tie the
+signature to the workflow's GitHub OIDC identity (or your CI's
+equivalent OIDC provider):
+
+```bash
+COSIGN_YES=true cosign sign <internal-registry>/<repo>@<manifest-digest>
+```
+
+Verifiers consume:
+
+```bash
+cosign verify <internal-registry>/<repo>@<manifest-digest> \
+  --certificate-identity-regexp '<org-specific identity regex>' \
+  --certificate-oidc-issuer '<your OIDC issuer>'
+```
+
+Successful verification fetches the cert + Rekor entry; air-gapped
+consumers should pin the Rekor entry to disk and use `cosign verify
+--offline` (per ADR-017 §"Option B").
+
+### 5b. KMS-backed key (recommended for tightly-regulated orgs)
+
+```bash
+cosign sign \
+  --key 'awskms:///<arn>' \
+  <internal-registry>/<repo>@<manifest-digest>
+```
+
+Verify:
+
+```bash
+cosign verify \
+  --key '<public-key.pub>' \
+  <internal-registry>/<repo>@<manifest-digest>
+```
+
+The public key file is an artifact your security team distributes
+with their root certificate bundle.
+
+## Step 6: Pin the resulting digest in your operator config
+
+The runtime contract from
+[ADR-013 / OCI-A / `pull::pull`](../crates/cli/src/pull.rs) is:
+
+```bash
+aegis pull <internal-registry>/<repo>@sha256:<manifest-digest> \
+  --keyless-identity '<org-specific identity regex>' \
+  --keyless-oidc-issuer '<your OIDC issuer>'
+```
+
+`<manifest-digest>` is what `oras manifest fetch --descriptor` returns
+on push. **Tags alone are refused by `aegis pull`** — they can move,
+which would invalidate the F1 SVID-binding promise. Always ship by
+digest.
+
+For air-gapped sessions, the same ref works against your internal
+registry — no Sigstore network dependency once the cosign signature
+is verified once and the Rekor entry is bundled locally.
+
+## Putting it together: Aegis-Node's own pipeline as a worked example
+
+The project's [`models-publish.yml`](../.github/workflows/models-publish.yml)
+runs steps 2–5 unattended on `workflow_dispatch`. Inputs:
+
+```bash
+gh workflow run models-publish.yml --ref main \
+  -f hf_repo=Qwen/Qwen2.5-1.5B-Instruct-GGUF \
+  -f gguf_filename=qwen2.5-1.5b-instruct-q4_k_m.gguf \
+  -f hf_revision=91cad51170dc346986eccefdc2dd33a9da36ead9
+```
+
+Output (from [run 25135210278](https://github.com/tosin2013/aegis-node/actions/runs/25135210278)):
+
+```
+ref:                ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m:latest
+manifest_digest:    sha256:240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6
+blob_sha256:        6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e
+```
+
+Pulled at runtime via:
+
+```bash
+aegis pull \
+  ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6 \
+  --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
+  --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+The exact same flow runs from
+[`crates/cli/tests/pull_real_image.rs`](../crates/cli/tests/pull_real_image.rs)
+on every PR — so this doc isn't aspirational; the bytes you see in
+production are the bytes CI verified.
+
+## Adapting `models-publish.yml` to your org
+
+Fork the workflow into your operator repo, then make four changes:
+
+1. **Replace the registry hostname** in the `target_repo` default:
+   `ghcr.io/<your-org>/aegis-node-models/<model>`. Or pass
+   `target_repo` explicitly per dispatch.
+2. **Add a scanning step before `oras push`** — Step 3 above.
+   Suggested placement is after `Compute and record SHA-256` and
+   before `Push as single-blob OCI artifact`. Fail-closed: any
+   scanner non-zero exit aborts the push.
+3. **Adjust `permissions:`** — keyless signing needs `id-token:
+   write`; pushing to your internal registry needs whatever auth
+   token your registry accepts (often a deploy-token in `secrets`,
+   not the workflow's `GITHUB_TOKEN`).
+4. **Update the cosign verify identity regex** in the final step
+   to match your org's workflow identity. The regex must match the
+   Sigstore Fulcio cert that signing produces; mis-set, the
+   verify-the-signature-we-just-produced gate will fail loudly
+   (which is the correct behavior).
+
+## License gate — what the project mirrors and what it doesn't
+
+Per ADR-021 §"License scope", the Aegis-Node project's published
+mirror covers Apache 2.0 / MIT / similarly-permissive models only.
+The project does **not** publish:
+
+- Llama 3.x / Llama 4.x — vendor-license restrictions.
+- Vendor-tier-locked models (cohere, anthropic, openai) — those are
+  remote APIs, not GGUFs.
+- Models with research-only / non-commercial license terms.
+
+Operators are free to publish those to their own internal registry
+under their org's legal review. The mirror pipeline doesn't care
+about license; the *publishing decision* is the gate the project
+enforces upstream of running the workflow.
+
+## What this doc does NOT cover
+
+- **Runtime side of `aegis pull`** — already covered in
+  [SUPPLY_CHAIN.md](SUPPLY_CHAIN.md) §"\`aegis pull\` (OCI-A, ADR-013)".
+- **GGUF + chat-template-bound verification** — coming with OCI-B
+  ([#67](https://github.com/tosin2013/aegis-node/issues/67)). Until
+  it lands, a malicious actor with push access to your registry
+  *and* a valid org cosign identity could substitute the chat
+  template embedded in the GGUF. ADR-013 names this; OCI-B closes it.
+- **Re-publishing on upstream rev bumps** — when the HF upstream
+  bumps a model, you re-run the workflow with the new commit SHA.
+  Both old and new digests are valid artifacts; pin the new one in
+  your operator config when you've completed the scan + review.
+- **Mirror retention** — old digests stay published for replay /
+  audit purposes; the project doesn't garbage-collect.

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -103,8 +103,9 @@ Refusal cases — every one of these exits non-zero with a typed error:
 | Reference uses a tag instead of `@sha256:` | `UnpinnedRef` | refuse before any network call |
 | `oras` or `cosign` not on `$PATH` | `MissingTool` | refuse before any network call |
 | Cosign signature missing or fails | `CosignVerifyFailed` | refuse, blob not cached |
-| Pulled blob's SHA-256 ≠ pinned digest | `Sha256Mismatch` | refuse, blob discarded |
-| Cached blob corrupted between pulls | `Sha256Mismatch` | refuse, surface tampering |
+| Cached blob corrupted between pulls (tampering) | `Sha256Mismatch` | refuse, surface tampering |
+
+The integrity model: cosign verifies the manifest's signature; oras verifies each pulled blob against the manifest's layer descriptor; the two together cover registry-side integrity end-to-end. `aegis pull` does not re-compare the blob's content hash against the ref's `@sha256:` (those are different OCI concepts — the ref carries the *manifest digest*, not the blob digest). It does compute the blob's SHA-256 and persist it as a sidecar, used for cache-hit re-verification and future F1 SVID-binding.
 
 **End-to-end smoke test (Qwen2.5-1.5B-Instruct Q4_K_M).** The `models-publish.yml` workflow has shipped its first artifact — pull it through the full `aegis pull` flow:
 
@@ -121,9 +122,9 @@ GGUF + chat-template-bound verification (defends against template-only poisoning
 
 ## Mirroring an upstream model
 
-Per [ADR-021](adrs/021-huggingface-as-upstream-oci-as-trust-boundary.md), the runtime never reaches HuggingFace. Operators bring an HF model into a trust boundary they control by running the same `HF → scan → sign → push` pipeline the Aegis-Node project ships at [`.github/workflows/models-publish.yml`](../.github/workflows/models-publish.yml).
+Operators publishing their own models to an internal registry follow the same `HF → scan → sign → push` pipeline this project uses for its demo models. The full operator workflow — including scanning gates, KMS vs. Sigstore signing, license-review checklist, and a worked Qwen example — lives in **[docs/MODEL_MIRRORING.md](MODEL_MIRRORING.md)**.
 
-The published Qwen artifact above was produced by dispatching that workflow:
+Quick reference: dispatch the project's own pipeline against its demo input by running
 
 ```bash
 gh workflow run models-publish.yml --ref main \
@@ -132,15 +133,7 @@ gh workflow run models-publish.yml --ref main \
   -f hf_revision=91cad51170dc346986eccefdc2dd33a9da36ead9
 ```
 
-Operator-side adaptation (in your fork or your org's mirror repo):
-
-1. Copy `models-publish.yml` to your repo. Replace the registry hostname (`ghcr.io/<owner>/aegis-node-models/...`) with your internal registry.
-2. Add an org-specific scanning step before `oras push` (malware AV, prompt-injection corpus check, license review). The default workflow does not scan — your org owns that policy.
-3. Adjust the cosign signing identity. Keyless via Sigstore (recommended) ties signatures to the workflow's GitHub Actions OIDC, exactly as the project does. KMS-backed keys are also supported via cosign's `--key` flag.
-4. License gate: only Apache-2.0 / MIT / similarly-permissive models are appropriate for this no-review pipeline. Llama-licensed and other restrictively-licensed models need legal review per your org's policy.
-5. Pin the resulting `<ref>@sha256:<digest>` in your operator-facing docs the same way ADR-020 §"Pinned model" pins the project's demo artifact.
-
-Air-gapped consumers then pull from the operator's internal registry — no HF dependency at runtime, no Sigstore dependency on the air-gap side once the digest is pinned (per ADR-017's "Option A: verify online once and pin the digest").
+— then pin the resulting `<ref>@sha256:<digest>` in your operator config the same way ADR-020 §"Pinned model" pins this project's demo artifact.
 
 ## Reporting integrity issues
 


### PR DESCRIPTION
## Summary

Operator-facing how-to for publishing a HuggingFace model to your internal OCI registry, signed with your org's cosign trust root. Pulls together everything the project shipped under OCI-A (\`aegis pull\`) and ADR-021 (HF as upstream / OCI as trust boundary) into a single 6-step doc operators can adapt for their environment.

Closes #68. Final P1 sub-issue under the OCI umbrella #65 — once green, the umbrella closes.

## What lands

- **\`docs/MODEL_MIRRORING.md\`** — the operator workflow doc:
  - 6 numbered steps (pin upstream SHA → \`hf download\` → scan + license review → \`oras push\` → \`cosign sign\` → pin digest in config).
  - The Aegis-Node project's own pipeline as a worked example, with actual digests from [run 25135210278](https://github.com/tosin2013/aegis-node/actions/runs/25135210278).
  - Adaptation guide for forking \`models-publish.yml\` into an operator repo (4 specific changes).
  - License-scope policy.
  - Both Sigstore-keyless and KMS signing flows with verify recipes.

- **\`docs/SUPPLY_CHAIN.md\`** — defers to the new doc for the operator-side detail (one-paragraph pointer instead of an inline duplicate). Also corrects a stale row in the \`aegis pull\` refusal table — the post-#83 integrity model no longer compares blob-sha against ref-sha; replaced with an explicit description of the cosign + oras integrity model.

- **\`README.md\`** — adds the new doc to the documentation list alongside SUPPLY_CHAIN.md.

## Why this is the right shape

Issue #68 specifically calls for the workflow doc to **reference \`models-publish.yml\` as the project's reference implementation**. The doc now does that throughout — pointing operators at concrete code they can copy + adapt rather than building from prose. Every step has a copy-pasteable command. Every gate names the failure mode + how to detect it.

## Out of scope

- **Chat-template-bound verification** — OCI-B (#67). The doc names the gap explicitly (per ADR-013): a malicious actor with both push access AND a valid org cosign identity could substitute the chat template embedded in the GGUF. OCI-B closes that.

## Test plan

- [x] No code changes; CI is docs/schemas only.
- [x] Workflow inputs in the worked example match the project's first published Qwen artifact byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)