### PR TITLE
feat(supply-chain): chat-template binding via signed annotation (ADR-022, OCI-B (a))

### DIFF
--- a/.github/workflows/models-publish.yml
+++ b/.github/workflows/models-publish.yml
@@ -116,6 +116,37 @@ jobs:
           echo "hex=${digest}" >> "$GITHUB_OUTPUT"
           echo "Computed sha256: ${digest}"
 
+      # Per ADR-022: the publisher computes format-specific facts (here
+      # the chat-template hash) and asserts them via cosign-signed
+      # manifest annotations. The runtime never parses GGUF bytes; it
+      # trusts the cosign-covered annotation. Use the official
+      # ggml-org `gguf` Python package — when GGUF v4 ships, this is
+      # the first place to update.
+      - name: Extract tokenizer.chat_template SHA-256
+        id: chat_template
+        run: |
+          set -euo pipefail
+          pip install --no-cache-dir 'gguf>=0.10.0'
+          python3 - <<'PY'
+          from gguf import GGUFReader
+          import hashlib, os, sys
+          r = GGUFReader('${{ steps.download.outputs.path }}', 'r')
+          field = r.get_field('tokenizer.chat_template')
+          if field is None:
+              print('::error::tokenizer.chat_template absent from GGUF — refuse to publish (ADR-022)', file=sys.stderr)
+              sys.exit(2)
+          # GGUFReader STRING values come back as a list of numpy uint8
+          # arrays (one per part). For a STRING the first part is the
+          # bytes; concat to be safe across versions of gguf-py.
+          parts = b''.join(bytes(field.parts[i]) for i in field.data)
+          digest = hashlib.sha256(parts).hexdigest()
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'sha256={digest}\n')
+              f.write(f'length={len(parts)}\n')
+          print(f'chat-template length: {len(parts)} bytes')
+          print(f'chat-template sha256: {digest}')
+          PY
+
       - name: Push as single-blob OCI artifact
         id: push
         env:
@@ -143,6 +174,7 @@ jobs:
             --annotation "dev.aegis-node.upstream.repo=${{ inputs.hf_repo }}" \
             --annotation "dev.aegis-node.upstream.revision=${{ inputs.hf_revision }}" \
             --annotation "dev.aegis-node.upstream.filename=${{ inputs.gguf_filename }}" \
+            --annotation "dev.aegis-node.chat-template.sha256=${{ steps.chat_template.outputs.sha256 }}" \
             "${file_name}:application/vnd.aegis-node.model.gguf.v1"
 
           desc=$(oras manifest fetch --descriptor "$ref")
@@ -171,12 +203,14 @@ jobs:
       - name: Print pinning info for ADR-020 / SUPPLY_CHAIN.md
         run: |
           echo "::notice title=Published OCI artifact::"
-          echo "ref:                ${{ steps.target.outputs.ref }}"
-          echo "manifest_digest:    ${{ steps.push.outputs.manifest_digest }}"
-          echo "blob_sha256:        ${{ steps.sha.outputs.hex }}"
-          echo "hf_repo:            ${{ inputs.hf_repo }}"
-          echo "hf_revision:        ${{ inputs.hf_revision }}"
-          echo "filename:           ${{ inputs.gguf_filename }}"
+          echo "ref:                  ${{ steps.target.outputs.ref }}"
+          echo "manifest_digest:      ${{ steps.push.outputs.manifest_digest }}"
+          echo "blob_sha256:          ${{ steps.sha.outputs.hex }}"
+          echo "chat_template_sha256: ${{ steps.chat_template.outputs.sha256 }}"
+          echo "chat_template_length: ${{ steps.chat_template.outputs.length }} bytes"
+          echo "hf_repo:              ${{ inputs.hf_repo }}"
+          echo "hf_revision:          ${{ inputs.hf_revision }}"
+          echo "filename:             ${{ inputs.gguf_filename }}"
           echo
-          echo "Pin in ADR-020 + SUPPLY_CHAIN.md:"
+          echo "Pin in ADR-020 + SUPPLY_CHAIN.md + tests/pull_real_image.rs:"
           echo "  ${{ steps.target.outputs.ref }}@${{ steps.push.outputs.manifest_digest }}"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Every tool call routes through: **identity rebind → policy decision → gate d
 
 ## Documentation
 
-- **[Architectural Decision Records](docs/adrs/)** — 21 ADRs covering the security primitives, runtime architecture, supply chain, dev environment, agent ↔ tool protocol (MCP), write-grant precedence, the recorded demo program, and HuggingFace-as-upstream model distribution.
+- **[Architectural Decision Records](docs/adrs/)** — 22 ADRs covering the security primitives, runtime architecture, supply chain, dev environment, agent ↔ tool protocol (MCP), write-grant precedence, the recorded demo program, HuggingFace-as-upstream model distribution, and trust-boundary format agnosticism.
 - **[Compatibility Charter](docs/COMPATIBILITY_CHARTER.md)** — what the project promises not to break across versions (manifest, ledger, IPC).
 - **[Supply Chain Verification](docs/SUPPLY_CHAIN.md)** — `cosign verify` / `oras pull` flow for the signed devbox image and model artifacts.
 - **[Model Mirroring](docs/MODEL_MIRRORING.md)** — operator workflow for publishing a HuggingFace model to your internal OCI registry, signed with your org's cosign trust root (per ADR-013 + ADR-021).

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -269,5 +269,8 @@ fn cmd_pull(args: PullArgs) -> Result<()> {
     println!("reference: {}", pulled.reference.canonical());
     println!("sha256: {}", pulled.sha256_hex);
     println!("blob_path: {}", pulled.blob_path.display());
+    if let Some(template_sha) = &pulled.chat_template_sha256_hex {
+        println!("chat_template_sha256: {template_sha}");
+    }
     Ok(())
 }

--- a/crates/cli/src/pull.rs
+++ b/crates/cli/src/pull.rs
@@ -1,7 +1,9 @@
 //! `aegis pull` — fetch + verify a model artifact from an OCI registry.
 //!
-//! Per ADR-013 (OCI Artifacts for Model Distribution) and OCI-A
-//! ([issue #66](https://github.com/tosin2013/aegis-node/issues/66)).
+//! Per ADR-013 (OCI Artifacts for Model Distribution), ADR-021 (HF →
+//! OCI mirror), ADR-022 (trust-boundary format agnosticism), and
+//! issues [#66](https://github.com/tosin2013/aegis-node/issues/66) /
+//! [#67](https://github.com/tosin2013/aegis-node/issues/67).
 //!
 //! Phase 1 ships a shell-out implementation around the `oras` and
 //! `cosign` binaries that the supply-chain workflow already requires
@@ -14,23 +16,32 @@
 //!    pulling a moving target invalidates the F1 digest binding.
 //! 2. **Stage the pull in a temp dir.** No partial state ever touches
 //!    the cache.
-//! 3. **Run `oras pull`** to fetch the descriptor + blob. `oras`
+//! 3. **Fetch the manifest** via `oras manifest fetch`, parse its JSON,
+//!    extract the `dev.aegis-node.chat-template.sha256` annotation. For
+//!    artifacts whose media type is `MODEL_GGUF_MEDIA_TYPE` the
+//!    annotation is required (publisher misconfiguration → typed
+//!    `MissingChatTemplateAnnotation` refusal); for non-model artifacts
+//!    (e.g. devbox image) it is optional. Per ADR-022: the runtime
+//!    trust boundary verifies a signed claim; it never parses the GGUF.
+//! 4. **Run `oras pull`** to fetch the descriptor + blob. `oras`
 //!    verifies each pulled blob against the manifest's layer
 //!    descriptor — that's where blob-bytes-vs-manifest integrity
 //!    happens.
-//! 4. **Run `cosign verify`** against the configured key (or keyless
+//! 5. **Run `cosign verify`** against the configured key (or keyless
 //!    via Sigstore's public Fulcio + Rekor — keyless is the default
 //!    when `--cosign-key` is omitted, matching ADR-017). cosign
 //!    verifies the manifest's signature, which transitively covers
-//!    the layer descriptors.
-//! 5. **Compute the blob's SHA-256** and persist it as a sidecar
+//!    the layer descriptors *and* every annotation read in step 3.
+//! 6. **Compute the blob's SHA-256** and persist it as a sidecar
 //!    (`sha256.txt`) for the F1 boot path's SVID-binding use and
 //!    for cache-hit re-verification on subsequent pulls. We do NOT
 //!    compare this against the ref's `@sha256:` — that's the
 //!    *manifest* digest (per OCI spec), a different value from the
 //!    blob's content hash. cosign + oras together provide the
 //!    integrity guarantee; we surface the blob's hash for callers.
-//! 6. **Move into the cache** at `<cache-dir>/<manifest-sha>/blob.bin`.
+//! 7. **Persist the chat-template digest** (when present) as
+//!    `chat_template.sha256.txt` for the F1 boot binding (OCI-B (b)).
+//! 8. **Move into the cache** at `<cache-dir>/<manifest-sha>/blob.bin`.
 //!    The atomic rename keeps the cache consistent — either the
 //!    artifact is fully verified and present, or it isn't.
 //!
@@ -47,6 +58,19 @@ use std::process::Command;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+/// OCI media type for a single-blob GGUF model artifact published by
+/// Aegis-Node's `models-publish.yml` (per ADR-021). Publishers that use
+/// this media type MUST also set the chat-template annotation —
+/// `aegis pull` enforces that in `extract_chat_template_annotation`.
+pub const MODEL_GGUF_MEDIA_TYPE: &str = "application/vnd.aegis-node.model.gguf.v1";
+
+/// OCI manifest annotation carrying the SHA-256 of the GGUF's
+/// `tokenizer.chat_template` bytes. Defends against template-only
+/// poisoning per ADR-013 §"Decision" item 4 and ADR-022 §"Decision":
+/// the trust boundary verifies a signed claim instead of parsing the
+/// GGUF itself.
+pub const CHAT_TEMPLATE_SHA_ANNOTATION: &str = "dev.aegis-node.chat-template.sha256";
+
 /// Outcome of a successful `aegis pull`. The cache path is what
 /// callers (and `Session::boot`) consume.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +81,16 @@ pub struct PulledArtifact {
     pub blob_path: PathBuf,
     /// SHA-256 digest of the blob, lowercase hex.
     pub sha256_hex: String,
+    /// SHA-256 of the GGUF's `tokenizer.chat_template` bytes, lowercase
+    /// hex — read from the cosign-covered manifest annotation
+    /// `dev.aegis-node.chat-template.sha256`. `None` for non-model
+    /// artifacts (e.g., the devbox image). Required for artifacts whose
+    /// media type is `MODEL_GGUF_MEDIA_TYPE`. Defends against
+    /// template-only poisoning per ADR-013 §"Decision" item 4. The
+    /// runtime never parses the GGUF itself (per ADR-022): we trust the
+    /// publisher's signed claim, defended in depth by llama.cpp's own
+    /// parser at inference time.
+    pub chat_template_sha256_hex: Option<String>,
 }
 
 /// Typed errors. Surface mapped 1:1 to verification gates so an
@@ -102,6 +136,36 @@ pub enum PullError {
     /// descriptor was swapped post-signing — either way, refuse.
     #[error("sha256 mismatch: ref pinned {expected}, computed {got} (artifact discarded)")]
     Sha256Mismatch { expected: String, got: String },
+
+    /// `oras manifest fetch` exited non-zero, or its output isn't valid
+    /// JSON. We need the manifest to read the chat-template annotation;
+    /// without it the F1 binding would be unmoored.
+    #[error("oras manifest fetch failed: {detail}")]
+    ManifestFetchFailed { detail: String },
+
+    /// Manifest declares the model-GGUF media type but is missing the
+    /// `dev.aegis-node.chat-template.sha256` annotation. Per ADR-022
+    /// the publisher is responsible for setting this; refusing here
+    /// means a misconfigured publish surfaces loudly instead of leaving
+    /// a session unboundable.
+    #[error(
+        "manifest declares model artifact-type {media_type:?} but lacks the \
+         {annotation:?} annotation (publisher misconfiguration; \
+         re-run models-publish.yml or analogous)"
+    )]
+    MissingChatTemplateAnnotation {
+        media_type: String,
+        annotation: &'static str,
+    },
+
+    /// The annotation is present but its value isn't a 64-char
+    /// lowercase hex SHA-256. We refuse rather than guess what the
+    /// publisher meant.
+    #[error("manifest annotation {annotation:?} is not a 64-char hex sha256: {value:?}")]
+    InvalidAnnotationValue {
+        annotation: &'static str,
+        value: String,
+    },
 
     /// Catch-all for filesystem errors (creating temp dirs, moves,
     /// etc.). Wrapped so callers don't have to match `io::Error` raw.
@@ -281,12 +345,22 @@ pub fn pull(reference: &str, cfg: &PullConfig) -> Result<PulledArtifact> {
                 got,
             });
         }
+        let chat_template_sha256_hex = read_chat_template_sidecar(&target_dir)?;
         return Ok(PulledArtifact {
             reference: parsed.clone(),
             blob_path: target_blob,
             sha256_hex: recorded,
+            chat_template_sha256_hex,
         });
     }
+
+    // Fetch the cosign-covered manifest and extract the chat-template
+    // annotation BEFORE pulling the blob. cosign verifies the manifest's
+    // signature (which transitively covers all annotations); reading the
+    // annotation here means the trust-boundary code in this function
+    // never has to parse the GGUF itself (per ADR-022).
+    let manifest = run_oras_manifest_fetch(&parsed)?;
+    let chat_template_sha256_hex = extract_chat_template_annotation(&manifest)?;
 
     // Stage in a sibling temp dir so a partial pull never pollutes
     // the cache root.
@@ -304,18 +378,41 @@ pub fn pull(reference: &str, cfg: &PullConfig) -> Result<PulledArtifact> {
 
     std::fs::create_dir_all(&target_dir)?;
     // Persist sidecars alongside the blob:
-    //   ref.txt     — canonical reference, for traceability
-    //   sha256.txt  — blob's actual SHA-256, used by the F1 boot path
-    //                 and by future cache-hit re-verification
+    //   ref.txt                   — canonical reference, for traceability
+    //   sha256.txt                — blob's actual SHA-256, used by the
+    //                               F1 boot path and by future cache-hit
+    //                               re-verification
+    //   chat_template.sha256.txt  — chat-template SHA-256 read from the
+    //                               cosign-covered manifest annotation
+    //                               (Some for model artifacts; absent
+    //                               for non-model artifacts like devbox)
     std::fs::write(target_dir.join("ref.txt"), parsed.canonical().as_bytes())?;
     std::fs::write(&sidecar, blob_sha256_hex.as_bytes())?;
+    if let Some(hex) = &chat_template_sha256_hex {
+        std::fs::write(target_dir.join("chat_template.sha256.txt"), hex.as_bytes())?;
+    }
     std::fs::rename(&blob, &target_blob)?;
 
     Ok(PulledArtifact {
         reference: parsed.clone(),
         blob_path: target_blob,
         sha256_hex: blob_sha256_hex,
+        chat_template_sha256_hex,
     })
+}
+
+/// Read the chat-template sidecar from a populated cache dir, if it
+/// exists. Cache hits reuse the sidecar rather than re-fetching the
+/// manifest — the blob's own SHA-256 is re-verified above, and the
+/// sidecar was written from a cosign-verified annotation under the
+/// original pull.
+fn read_chat_template_sidecar(dir: &Path) -> Result<Option<String>> {
+    let p = dir.join("chat_template.sha256.txt");
+    if !p.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&p)?;
+    Ok(Some(raw.trim().to_string()))
 }
 
 fn require_tool(tool: &'static str) -> Result<()> {
@@ -351,6 +448,87 @@ fn run_oras_pull(parsed: &ParsedRef, into: &Path) -> Result<()> {
         });
     }
     Ok(())
+}
+
+/// Fetch the OCI manifest JSON for `parsed` via `oras manifest fetch`.
+/// Used by the trust-boundary code to read the cosign-covered
+/// chat-template annotation without ever parsing the GGUF (per ADR-022).
+fn run_oras_manifest_fetch(parsed: &ParsedRef) -> Result<serde_json::Value> {
+    let out = Command::new("oras")
+        .arg("manifest")
+        .arg("fetch")
+        .arg(parsed.canonical())
+        .output()?;
+    if !out.status.success() {
+        return Err(PullError::ManifestFetchFailed {
+            detail: format!(
+                "exit {:?}: {}",
+                out.status.code(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        });
+    }
+    serde_json::from_slice(&out.stdout).map_err(|e| PullError::ManifestFetchFailed {
+        detail: format!("manifest is not valid JSON: {e}"),
+    })
+}
+
+/// Pull the chat-template SHA-256 annotation out of an OCI manifest.
+/// Returns `None` for non-model artifacts (devbox image, third-party
+/// images that don't follow this convention). For artifacts whose
+/// `artifactType` (or top-level `mediaType`) is `MODEL_GGUF_MEDIA_TYPE`,
+/// the annotation is required and a missing or malformed value is a
+/// hard refusal.
+fn extract_chat_template_annotation(manifest: &serde_json::Value) -> Result<Option<String>> {
+    // OCI 1.1+ manifests use `artifactType` for the artifact's purpose;
+    // older single-blob artifacts ("config-as-content") put the same
+    // value in `config.mediaType`. Accept either to interop with both
+    // oras 1.1 and 1.2 outputs.
+    let artifact_type = manifest
+        .get("artifactType")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            manifest
+                .get("config")
+                .and_then(|c| c.get("mediaType"))
+                .and_then(|v| v.as_str())
+        })
+        .unwrap_or("");
+    let is_model = artifact_type == MODEL_GGUF_MEDIA_TYPE;
+
+    let annotation_value = manifest
+        .get("annotations")
+        .and_then(|a| a.get(CHAT_TEMPLATE_SHA_ANNOTATION))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    match annotation_value {
+        Some(raw) => {
+            if !is_valid_sha256_hex(&raw) {
+                return Err(PullError::InvalidAnnotationValue {
+                    annotation: CHAT_TEMPLATE_SHA_ANNOTATION,
+                    value: raw,
+                });
+            }
+            Ok(Some(raw))
+        }
+        None => {
+            if is_model {
+                Err(PullError::MissingChatTemplateAnnotation {
+                    media_type: artifact_type.to_string(),
+                    annotation: CHAT_TEMPLATE_SHA_ANNOTATION,
+                })
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
+fn is_valid_sha256_hex(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
 }
 
 fn run_cosign_verify(parsed: &ParsedRef, cfg: &PullConfig) -> Result<()> {

--- a/crates/cli/tests/pull.rs
+++ b/crates/cli/tests/pull.rs
@@ -1,17 +1,20 @@
 //! End-to-end orchestration tests for `aegis pull`.
 //!
-//! Per OCI-A / ADR-013 / issue #66. Real registries / cosign keys
-//! aren't reachable in CI — instead we drop fake `oras` and `cosign`
-//! shell scripts on PATH that mimic their interface (oras writes a
-//! known blob to its `-o` dir; cosign exits 0 for "verified" or 1
-//! for "refused"). That way the test exercises every gate in
-//! `pull::pull` (ref parse → oras invocation → cosign verify →
+//! Per OCI-A / OCI-B / ADR-013 / ADR-022 / issues #66 and #67. Real
+//! registries / cosign keys aren't reachable in CI — instead we drop
+//! fake `oras` and `cosign` shell scripts on PATH that mimic their
+//! interface:
+//!
+//! - fake `oras pull` writes a known blob to its `-o` dir
+//! - fake `oras manifest fetch` echoes a fixture JSON manifest
+//! - fake `cosign verify` exits 0 for "verified" or 1 for "refused"
+//!
+//! That way the test exercises every gate in `pull::pull` (ref parse →
+//! manifest fetch → annotation extraction → oras pull → cosign verify →
 //! sha256 recompute → cache move) without depending on the network.
 //!
-//! A real-registry round-trip lives in docs/SUPPLY_CHAIN.md as the
-//! operator workflow. F1 boot-path integration ("session boots
-//! against a pulled blob and the SVID's bound model digest matches")
-//! lands with the F1 wiring follow-up — out of scope for OCI-A.
+//! A real-registry round-trip lives in `tests/pull_real_image.rs` and
+//! runs against the live Qwen artifact `models-publish.yml` produces.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -22,41 +25,94 @@ use std::path::{Path, PathBuf};
 use aegis_cli::pull::{self, PullConfig, PullError};
 use sha2::{Digest, Sha256};
 
-/// Build a fake `oras` script that writes `blob_bytes` to its -o dir
-/// and a fake `cosign` script that exits with `cosign_exit_code`.
+const MODEL_GGUF_MEDIA_TYPE: &str = "application/vnd.aegis-node.model.gguf.v1";
+const NON_MODEL_MEDIA_TYPE: &str = "application/vnd.example.unknown.v1";
+
+/// Build a synthetic OCI manifest JSON with the given artifact-type and
+/// optional chat-template annotation. Mirrors what
+/// `oras manifest fetch` returns from a real registry.
+fn manifest_json(artifact_type: &str, chat_template_sha: Option<&str>) -> String {
+    let annotations = match chat_template_sha {
+        Some(s) => format!(r#""annotations":{{"dev.aegis-node.chat-template.sha256":"{s}"}},"#),
+        None => String::new(),
+    };
+    format!(
+        r#"{{
+            "schemaVersion":2,
+            "mediaType":"application/vnd.oci.image.manifest.v1+json",
+            "artifactType":"{artifact_type}",
+            "config":{{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:0000","size":0}},
+            "layers":[{{"mediaType":"{artifact_type}","digest":"sha256:1111","size":42}}],
+            {annotations}
+            "_test":"synthetic"
+        }}"#
+    )
+}
+
+/// Build fake `oras` + `cosign` scripts on a temp PATH dir.
 ///
-/// Returns a directory we can prepend to PATH.
-fn fake_tool_dir(blob_bytes: &[u8], blob_name: &str, cosign_exit_code: i32) -> PathBuf {
+/// `oras pull -o <dir> <ref>` copies a canned blob to `<dir>/<blob_name>`.
+/// `oras manifest fetch <ref>` echoes `manifest_json` on stdout.
+/// `cosign verify ...` exits with `cosign_exit_code`.
+fn fake_tool_dir(
+    blob_bytes: &[u8],
+    blob_name: &str,
+    cosign_exit_code: i32,
+    manifest_json: &str,
+) -> PathBuf {
     let dir = tempfile::tempdir().unwrap().keep();
-    // Encode the blob into the script as a here-doc base64 wouldn't
-    // round-trip binary cleanly, so we drop the bytes to a sidecar
-    // file the script copies on every invocation. This keeps the
-    // script tiny and binary-clean.
+
+    // Drop the blob bytes to a sidecar — easier than encoding them into
+    // a shell here-doc, and keeps binary content clean.
     let blob_src = dir.join("__blob.bin");
     fs::write(&blob_src, blob_bytes).unwrap();
+
+    // The fake `oras` writes the manifest JSON via `cat` of a sidecar
+    // file. That keeps escaping out of the shell heredoc — the JSON has
+    // braces and colons that bash gets fussy about.
+    let manifest_src = dir.join("__manifest.json");
+    fs::write(&manifest_src, manifest_json).unwrap();
 
     let oras_path = dir.join("oras");
     let oras = format!(
         r#"#!/usr/bin/env bash
-# fake oras: usage `oras pull -o <out_dir> <ref>` — copy the canned
-# blob into <out_dir>/<blob_name>.
+# fake oras: dispatches `pull` and `manifest fetch` subcommands.
 set -euo pipefail
-out_dir=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -o) out_dir="$2"; shift 2 ;;
-    *)  shift ;;
-  esac
-done
-if [[ -z "$out_dir" ]]; then
-  echo "fake oras: missing -o" >&2
-  exit 2
-fi
-mkdir -p "$out_dir"
-cp "{src}" "$out_dir/{blob_name}"
+sub="${{1:-}}"
+case "$sub" in
+  pull)
+    shift
+    out_dir=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -o) out_dir="$2"; shift 2 ;;
+        *)  shift ;;
+      esac
+    done
+    if [[ -z "$out_dir" ]]; then
+      echo "fake oras pull: missing -o" >&2
+      exit 2
+    fi
+    mkdir -p "$out_dir"
+    cp "{blob_src}" "$out_dir/{blob_name}"
+    ;;
+  manifest)
+    shift
+    if [[ "${{1:-}}" != "fetch" ]]; then
+      echo "fake oras manifest: only 'fetch' supported" >&2
+      exit 2
+    fi
+    cat "{manifest_src}"
+    ;;
+  *)
+    echo "fake oras: unknown subcommand '$sub'" >&2
+    exit 2
+    ;;
+esac
 "#,
-        src = blob_src.display(),
+        blob_src = blob_src.display(),
         blob_name = blob_name,
+        manifest_src = manifest_src.display(),
     );
     fs::write(&oras_path, oras).unwrap();
     chmod_exec(&oras_path);
@@ -82,8 +138,8 @@ fn chmod_exec(p: &Path) {
 }
 
 /// Prepend `dir` to PATH for the duration of the test, restoring it
-/// at scope end. Tests serialize on PATH via `tempfile::env_lock` —
-/// without that they clobber each other in parallel runs.
+/// at scope end. Tests serialize on PATH — without serialization they
+/// clobber each other in parallel runs.
 struct PathGuard {
     original: Option<std::ffi::OsString>,
     _lock: std::sync::MutexGuard<'static, ()>,
@@ -128,37 +184,33 @@ fn cfg(cache_dir: PathBuf) -> PullConfig {
 
 #[test]
 fn pull_succeeds_and_returns_blob_sha256() {
-    let blob = b"fake gguf bytes for a tiny model";
+    let blob = b"opaque non-model blob";
     let mut hasher = Sha256::new();
     hasher.update(blob);
     let blob_sha = hex::encode(hasher.finalize());
-    // Note: in real OCI the ref's `@sha256:` is the *manifest* digest,
-    // not the blob digest. The fake-tools world has no manifest layer,
-    // so we put any 64-char hex here — it just becomes the cache-key.
     let manifest_sha = "1".repeat(64);
-    let reference = format!("ghcr.io/example/tiny-model@sha256:{manifest_sha}");
+    let reference = format!("ghcr.io/example/something@sha256:{manifest_sha}");
 
-    let tools = fake_tool_dir(blob, "model.gguf", 0);
+    // Non-model artifact-type → annotation not required, sidecar absent.
+    let manifest = manifest_json(NON_MODEL_MEDIA_TYPE, None);
+    let tools = fake_tool_dir(blob, "thing.bin", 0, &manifest);
     let _path = PathGuard::prepend(&tools);
 
     let cache = tempfile::tempdir().unwrap();
     let pulled = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap();
 
-    // pull::pull surfaces the *blob* SHA-256 (what F1 binds into the
-    // SVID), not the ref's manifest digest.
     assert_eq!(pulled.sha256_hex, blob_sha);
     assert!(pulled.blob_path.exists(), "blob not in cache");
     let actual_bytes = fs::read(&pulled.blob_path).unwrap();
     assert_eq!(actual_bytes, blob);
-    // Cache layout: <cache>/<manifest-sha>/blob.bin + ref.txt + sha256.txt.
     let dir = pulled.blob_path.parent().unwrap();
-    assert!(
-        dir.ends_with(&manifest_sha),
-        "cache key should be manifest sha"
-    );
+    assert!(dir.ends_with(&manifest_sha));
     assert!(dir.join("ref.txt").exists());
     let recorded = fs::read_to_string(dir.join("sha256.txt")).unwrap();
     assert_eq!(recorded.trim(), blob_sha);
+    // Non-model → no chat-template surface, no sidecar.
+    assert_eq!(pulled.chat_template_sha256_hex, None);
+    assert!(!dir.join("chat_template.sha256.txt").exists());
 }
 
 #[test]
@@ -167,8 +219,11 @@ fn pull_refuses_when_cosign_verify_fails() {
     let manifest_sha = "2".repeat(64);
     let reference = format!("ghcr.io/example/tiny-model@sha256:{manifest_sha}");
 
-    // cosign exits 1 → CosignVerifyFailed.
-    let tools = fake_tool_dir(blob, "model.gguf", 1);
+    // cosign exits 1 → CosignVerifyFailed. Manifest doesn't matter for
+    // this gate (it runs after manifest fetch + annotation read but
+    // refusal is the same regardless).
+    let manifest = manifest_json(NON_MODEL_MEDIA_TYPE, None);
+    let tools = fake_tool_dir(blob, "model.gguf", 1, &manifest);
     let _path = PathGuard::prepend(&tools);
 
     let cache = tempfile::tempdir().unwrap();
@@ -194,7 +249,8 @@ fn pull_short_circuits_when_blob_already_cached() {
     let manifest_sha = "3".repeat(64);
     let reference = format!("ghcr.io/example/tiny-model@sha256:{manifest_sha}");
 
-    let tools = fake_tool_dir(blob, "model.gguf", 0);
+    let manifest = manifest_json(NON_MODEL_MEDIA_TYPE, None);
+    let tools = fake_tool_dir(blob, "model.gguf", 0, &manifest);
     let _path = PathGuard::prepend(&tools);
 
     let cache = tempfile::tempdir().unwrap();
@@ -219,7 +275,8 @@ fn pull_refuses_when_cached_blob_corrupted() {
     let manifest_sha = "4".repeat(64);
     let reference = format!("ghcr.io/example/tiny-model@sha256:{manifest_sha}");
 
-    let tools = fake_tool_dir(blob, "model.gguf", 0);
+    let manifest = manifest_json(NON_MODEL_MEDIA_TYPE, None);
+    let tools = fake_tool_dir(blob, "model.gguf", 0, &manifest);
     let _path = PathGuard::prepend(&tools);
 
     let cache = tempfile::tempdir().unwrap();
@@ -231,4 +288,108 @@ fn pull_refuses_when_cached_blob_corrupted() {
 
     let err = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap_err();
     assert!(matches!(err, PullError::Sha256Mismatch { .. }), "{err}");
+}
+
+#[test]
+fn pull_emits_chat_template_sidecar_from_model_artifact_annotation() {
+    let blob = b"opaque-gguf-bytes";
+    let template_sha = "a".repeat(64);
+    let manifest_sha = "5".repeat(64);
+    let reference = format!("ghcr.io/example/qwen-tiny@sha256:{manifest_sha}");
+
+    let manifest = manifest_json(MODEL_GGUF_MEDIA_TYPE, Some(&template_sha));
+    let tools = fake_tool_dir(blob, "model.gguf", 0, &manifest);
+    let _path = PathGuard::prepend(&tools);
+
+    let cache = tempfile::tempdir().unwrap();
+    let pulled = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap();
+
+    assert_eq!(
+        pulled.chat_template_sha256_hex.as_deref(),
+        Some(template_sha.as_str()),
+        "annotation value should propagate to the surfaced chat-template digest"
+    );
+    let dir = pulled.blob_path.parent().unwrap();
+    let template_sidecar = dir.join("chat_template.sha256.txt");
+    assert!(template_sidecar.exists());
+    assert_eq!(
+        fs::read_to_string(&template_sidecar).unwrap().trim(),
+        template_sha
+    );
+
+    // Cache hit reuses the sidecar without re-fetching the manifest.
+    fs::write(tools.join("oras"), "#!/bin/sh\nexit 77\n").unwrap();
+    chmod_exec(&tools.join("oras"));
+    let pulled2 = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap();
+    assert_eq!(
+        pulled2.chat_template_sha256_hex.as_deref(),
+        Some(template_sha.as_str())
+    );
+}
+
+#[test]
+fn pull_refuses_when_model_artifact_lacks_chat_template_annotation() {
+    let blob = b"opaque-gguf-bytes";
+    let manifest_sha = "6".repeat(64);
+    let reference = format!("ghcr.io/example/qwen-tiny@sha256:{manifest_sha}");
+
+    // Model artifact-type but no annotation → publisher misconfiguration,
+    // refuse rather than silently leave the F1 binding unmoored.
+    let manifest = manifest_json(MODEL_GGUF_MEDIA_TYPE, None);
+    let tools = fake_tool_dir(blob, "model.gguf", 0, &manifest);
+    let _path = PathGuard::prepend(&tools);
+
+    let cache = tempfile::tempdir().unwrap();
+    let err = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap_err();
+    assert!(
+        matches!(err, PullError::MissingChatTemplateAnnotation { .. }),
+        "{err}"
+    );
+    assert!(
+        !cache.path().join(manifest_sha).exists(),
+        "missing-annotation artifact must NOT be cached"
+    );
+}
+
+#[test]
+fn pull_refuses_when_chat_template_annotation_is_not_hex() {
+    let blob = b"opaque-gguf-bytes";
+    let manifest_sha = "7".repeat(64);
+    let reference = format!("ghcr.io/example/qwen-tiny@sha256:{manifest_sha}");
+
+    // Annotation present but malformed (uppercase + length 64 → fails
+    // the lowercase-hex check). cosign would catch tampering, but the
+    // hex validator catches a publisher bug before cosign would run.
+    let bad = "DEADBEEF".repeat(8); // 64 chars, but uppercase
+    assert_eq!(bad.len(), 64);
+    let manifest = manifest_json(MODEL_GGUF_MEDIA_TYPE, Some(&bad));
+    let tools = fake_tool_dir(blob, "model.gguf", 0, &manifest);
+    let _path = PathGuard::prepend(&tools);
+
+    let cache = tempfile::tempdir().unwrap();
+    let err = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap_err();
+    assert!(
+        matches!(err, PullError::InvalidAnnotationValue { .. }),
+        "{err}"
+    );
+}
+
+#[test]
+fn pull_accepts_non_model_artifact_without_annotation() {
+    // The devbox image, third-party tooling images, etc. don't declare
+    // the model-GGUF media type and aren't required to carry the
+    // chat-template annotation — `aegis pull` stays general-purpose.
+    let blob = b"some non-model bytes";
+    let manifest_sha = "8".repeat(64);
+    let reference = format!("ghcr.io/example/devbox@sha256:{manifest_sha}");
+
+    let manifest = manifest_json(NON_MODEL_MEDIA_TYPE, None);
+    let tools = fake_tool_dir(blob, "image.tar", 0, &manifest);
+    let _path = PathGuard::prepend(&tools);
+
+    let cache = tempfile::tempdir().unwrap();
+    let pulled = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap();
+    assert_eq!(pulled.chat_template_sha256_hex, None);
+    let dir = pulled.blob_path.parent().unwrap();
+    assert!(!dir.join("chat_template.sha256.txt").exists());
 }

--- a/crates/cli/tests/pull_real_image.rs
+++ b/crates/cli/tests/pull_real_image.rs
@@ -38,6 +38,13 @@ const PINNED_REF: &str = "ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instr
 const PINNED_MANIFEST_SHA: &str =
     "240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6";
 const PINNED_BLOB_SHA: &str = "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e";
+/// SHA-256 of the `tokenizer.chat_template` STRING value embedded in the
+/// pinned Qwen GGUF (extracted from the file at HF revision
+/// `91cad51170dc346986eccefdc2dd33a9da36ead9`). Exercises OCI-B's
+/// chat-template extraction against a real Jinja template — matches the
+/// 2509-byte `{%- if tools %}...` block visible at upstream.
+const PINNED_CHAT_TEMPLATE_SHA: &str =
+    "d5495a1e5db0611132a97e46a65dbb64a642a499421228b9c8b93229097fa9a4";
 
 /// Identity regex matching the `models-publish.yml` workflow that signed
 /// the artifact. Must stay in lockstep with the workflow file.
@@ -118,6 +125,32 @@ fn pull_qwen_model_round_trips_against_real_registry() {
         &head[..4],
         b"GGUF",
         "first 4 bytes are not the GGUF magic — pulled artifact is not a GGUF"
+    );
+
+    // OCI-B: chat-template SHA-256 was extracted from the GGUF metadata
+    // and is surfaced + persisted in a sidecar. Pinned against the
+    // upstream HF revision so a template swap (template-only poisoning,
+    // ADR-013 §4) trips this assertion before any session-boot binding
+    // is wired up.
+    assert_eq!(
+        pulled.chat_template_sha256_hex.as_deref(),
+        Some(PINNED_CHAT_TEMPLATE_SHA),
+        "extracted chat-template SHA-256 does not match the pinned digest \
+         (upstream chat-template may have changed — re-pin only after manual review)"
+    );
+    let template_sidecar = pulled
+        .blob_path
+        .parent()
+        .unwrap()
+        .join("chat_template.sha256.txt");
+    assert!(
+        template_sidecar.exists(),
+        "chat_template.sha256.txt sidecar missing — F1 SVID binding will have nothing to read"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&template_sidecar).unwrap().trim(),
+        PINNED_CHAT_TEMPLATE_SHA,
+        "chat_template.sha256.txt should record the pinned digest"
     );
 }
 

--- a/crates/cli/tests/pull_real_image.rs
+++ b/crates/cli/tests/pull_real_image.rs
@@ -9,11 +9,14 @@
 //! - real `cosign verify` against Sigstore's Fulcio cert + Rekor entry
 //! - the actual OCI artifact layout `models-publish.yml` produces
 //!
-//! The test pins the specific digest from the workflow's first
-//! successful run ([run 25135210278](https://github.com/tosin2013/aegis-node/actions/runs/25135210278))
+//! The test pins the specific digest from the OCI-B re-publish run
+//! ([run 25172111227](https://github.com/tosin2013/aegis-node/actions/runs/25172111227))
 //! rather than resolving `:latest` — so the assertion remains valid
 //! regardless of future workflow re-runs that retag the same model
-//! against a different revision.
+//! against a different revision. The original publish was at run
+//! 25135210278 (digest `sha256:240ece32...`); ADR-022's chat-template
+//! annotation requirement forced a re-publish (annotations change the
+//! manifest, therefore the digest), and this is the new pin.
 //!
 //! Skipped quietly when `oras` or `cosign` aren't on `$PATH`. CI's
 //! `rust.yml` installs both before running this so every PR gets the
@@ -26,17 +29,18 @@ use std::path::PathBuf;
 use aegis_cli::pull::{self, PullConfig};
 
 /// Project-published Qwen2.5-1.5B-Instruct Q4_K_M OCI artifact pinned to
-/// the digest produced by `models-publish.yml` run 25135210278. This is
-/// the same value pinned in ADR-020 §"Pinned model" and the
-/// SUPPLY_CHAIN.md smoke-test recipe.
+/// the digest produced by `models-publish.yml` run 25172111227 (the
+/// OCI-B re-publish that added the `dev.aegis-node.chat-template.sha256`
+/// annotation, per ADR-022). This is the same value pinned in ADR-020
+/// §"Pinned model" and the SUPPLY_CHAIN.md smoke-test recipe.
 ///
 /// `PINNED_REF` carries the **manifest digest** (per OCI spec — that's
 /// what `<ref>@sha256:` always means). `PINNED_BLOB_SHA` is the actual
 /// content hash of the GGUF bytes — what `pull::pull` returns and what
 /// the F1 boot path will bind into the SVID. They are different values.
-const PINNED_REF: &str = "ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6";
+const PINNED_REF: &str = "ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37";
 const PINNED_MANIFEST_SHA: &str =
-    "240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6";
+    "c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37";
 const PINNED_BLOB_SHA: &str = "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e";
 /// SHA-256 of the `tokenizer.chat_template` STRING value embedded in the
 /// pinned Qwen GGUF (extracted from the file at HF revision

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -111,7 +111,7 @@ The integrity model: cosign verifies the manifest's signature; oras verifies eac
 
 ```bash
 aegis pull \
-  ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6 \
+  ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37 \
   --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
   --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
 ```

--- a/docs/adrs/020-recorded-demo-program.md
+++ b/docs/adrs/020-recorded-demo-program.md
@@ -70,15 +70,15 @@ which caps the model size we can use without the recording feeling slow.
    **Published OCI artifact** (per [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md)):
 
    - **Reference:** `ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m:latest`
-   - **Digest:** `sha256:240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6`
+   - **Digest:** `sha256:c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37`
    - **Blob SHA-256:** `6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e`
    - **Upstream:** [Qwen/Qwen2.5-1.5B-Instruct-GGUF](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF) · file `qwen2.5-1.5b-instruct-q4_k_m.gguf` · revision `91cad51170dc346986eccefdc2dd33a9da36ead9`
-   - **Signed by:** `models-publish.yml` workflow ([run 25135210278](https://github.com/tosin2013/aegis-node/actions/runs/25135210278)) via Sigstore keyless.
+   - **Signed by:** `models-publish.yml` workflow ([run 25172111227](https://github.com/tosin2013/aegis-node/actions/runs/25172111227)) via Sigstore keyless. Carries the `dev.aegis-node.chat-template.sha256=d5495a1e...` annotation per [ADR-022](022-trust-boundary-format-agnosticism.md). The original publish (run 25135210278, digest `sha256:240ece32...`) predates ADR-022 and is no longer the operator pin.
 
    Demos pull this artifact at boot via:
 
    ```bash
-   aegis pull ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:240ece322070801d583241caaeced1a6b1ac55cbe42bf5379e95735ca89d4fa6 \
+   aegis pull ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37 \
      --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
      --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
    ```

--- a/docs/adrs/022-trust-boundary-format-agnosticism.md
+++ b/docs/adrs/022-trust-boundary-format-agnosticism.md
@@ -1,0 +1,227 @@
+# 22. Trust-Boundary Format Agnosticism — Verify Signed Claims, Don't Parse Files
+
+**Status:** Accepted
+**Date:** 2026-04-30
+**Domain:** Supply chain / runtime trust boundary (extends [ADR-013](013-oci-artifacts-for-model-distribution.md), [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md); supports [ADR-020](020-recorded-demo-program.md))
+
+## Context
+
+[ADR-013 §"Decision" item 4](013-oci-artifacts-for-model-distribution.md)
+commits to verifying both the GGUF file *and* the chat-template metadata
+at pull time, defending against template-only poisoning. [Issue #67](https://github.com/tosin2013/aegis-node/issues/67)
+(OCI-B) decomposes that work: pull-side extraction (this ADR), session-
+side SVID binding (follow-up).
+
+The first attempt at the pull-side work — on branch
+`feat/oci-b-chat-template`, never merged — added a hand-written 200-line
+GGUF v3 metadata parser to `crates/cli/src/gguf.rs`. That implementation
+worked; the unit tests passed; the real-image fixture extracted the
+expected 2509-byte Qwen template and produced
+`d5495a1e5db0611132a97e46a65dbb64a642a499421228b9c8b93229097fa9a4`. We
+discarded it anyway. This ADR records why.
+
+The user's objection sharpened the question. *If a custom parser is the
+right answer for GGUF, we will write a custom parser for ONNX next, and
+Safetensors after that, and a vendor-bundle parser the year after.* The
+trust boundary accumulates one format-aware codebase per format, forever.
+Each codebase is its own audit surface, its own CVE class, its own
+"what does this byte mean in version N+1" debate. That is not a
+defensible long-term posture for a security-focused agent runtime.
+
+April 2026 research (logged in the predecessor branch) found:
+
+- **Off-the-shelf Rust GGUF crates are wrong-shaped.** `gguf` (Jimexist)
+  is unmaintained since 2023; `gguf-rs` pulls CLI dependencies into the
+  library path; `gguf-rs-lib` is 7.8k LoC of read/write surface for
+  what is fundamentally a one-key read; `candle-core` drags 50+
+  transitive dependencies including the C library `onig`. None match
+  the "small, stdlib-only, just-this-one-key" profile that a trust-
+  boundary parser actually needs.
+- **The llama.cpp FFI binding (`llama-cpp-2`, [LLM-A #70](https://github.com/tosin2013/aegis-node/issues/70))
+  is the wrong layer.** llama.cpp parses GGUF at *inference* time,
+  inside the trust boundary. The pull path runs *before* tensors load —
+  using llama.cpp's parser there means dragging the inference-side
+  dependency tree (CUDA/Metal/Vulkan toggles, half-precision math, the
+  full ggml surface) into a step that should ship in seconds.
+- **The CVE landscape cuts the same direction.** GGUF parsers have an
+  active CVE history — buffer overflow in llama.cpp vocab loading
+  ([CVE-2025-49847](https://nvd.nist.gov/vuln/detail/CVE-2025-49847)),
+  integer overflow in the GGUF parser ([GHSA-vgg9-87g3-85w8](https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-vgg9-87g3-85w8),
+  CVE-2025-53630), SGLang RCE via malicious GGUF
+  ([CVE-2026-5760](https://thehackernews.com/2026/04/sglang-cve-2026-5760-cvss-98-enables.html)),
+  llama-cpp-python SSTI in model metadata
+  ([CVE-2024-34359](https://github.com/advisories/GHSA-56xg-wfcc-g829)).
+  The bugs all sit in length casts, bounds checks, and field
+  validation. A hand-rolled trust-boundary parser is most likely to
+  ship the *next* CVE in that family. A third-party crate may or may
+  not — but we own the consequence either way.
+
+The structural problem isn't *which parser*. The structural problem is
+having format-aware code at the trust boundary at all.
+
+## Decision
+
+**The runtime trust boundary verifies signed claims, never parses model
+file formats.**
+
+Specifically:
+
+1. **Publishers compute format-specific facts** — chat-template hash,
+   weight count, license string, quantization level, tokenizer-vocab
+   hash, anything else operators want to pin — at publish time, using
+   whatever tool agrees with the consumer. For GGUF that means the
+   official `gguf` Python package maintained by ggml-org; for ONNX,
+   `onnx-py`; for Safetensors, the format author's tooling. Maintenance
+   lives where the format definition lives.
+
+2. **Publishers assert those facts via cosign-signed manifest annotations**
+   on the OCI artifact. The signature is over the manifest JSON, which
+   includes `annotations` — so cosign covers the claim transitively.
+   Operators who don't trust a publisher's keyless identity already
+   refuse the artifact at `cosign verify`; trusting a publisher's
+   *claim* on top of trusting the publisher's *identity* is
+   axiomatically not an additional trust escalation.
+
+3. **The runtime reads the annotation and persists it as a sidecar.**
+   `aegis pull` runs `oras manifest fetch`, parses the JSON, extracts
+   the named annotation (`dev.aegis-node.chat-template.sha256` for the
+   first instance; analogous keys for future facts), validates the
+   value's shape (e.g., 64-char lowercase hex for SHA-256), and writes
+   `chat_template.sha256.txt` alongside the cached blob. Future F1
+   binding (OCI-B (b)) reads that sidecar.
+
+4. **Defense in depth comes from the consumer, not the trust boundary.**
+   At session boot — once [LLM-A #70](https://github.com/tosin2013/aegis-node/issues/70)
+   lands — llama.cpp will parse the GGUF as part of inference setup.
+   At that point, the F1 binding code can ask llama.cpp for its view
+   of the chat-template bytes and compare against the SVID-bound
+   digest. If they disagree, the session refuses. Llama.cpp is the
+   parser we can't avoid (we have to load the model anyway); reusing
+   it for cross-checking is free. The trust boundary itself stays
+   format-agnostic.
+
+5. **Annotation policy is fail-closed for declared model artifacts.**
+   For OCI artifacts whose `artifactType` is
+   `application/vnd.aegis-node.model.gguf.v1`, the chat-template
+   annotation is **required**. Missing → typed
+   `MissingChatTemplateAnnotation` refusal. For artifacts that don't
+   declare the model media type (e.g., the devbox image,
+   third-party tooling), the annotation is optional and `aegis pull`
+   stays general-purpose.
+
+This generalizes beyond GGUF. The same shape — publisher computes,
+publisher signs, runtime verifies — handles ONNX, Safetensors,
+vendor-specific formats, and whatever model packaging arrives next. New
+formats add publisher-side parser dependencies (in CI) and runtime
+annotation keys (one constant); they don't add trust-boundary parsing
+code.
+
+## Why not the alternatives
+
+- **Custom parser at the runtime trust boundary** — the rejected
+  approach this ADR records. Accumulating audit surface per format,
+  forever, with no way out. Even a small parser this year is the
+  template for the next four formats that will want similar handling.
+- **Pull in `gguf-rs-lib` (or similar third-party crate)** — moves
+  the audit cost from "we wrote it" to "we depend on it," but the
+  audit cost is still ours. 7.8k LoC of crate-imported parser still
+  sits inside the trust boundary; transitive dependencies still expand
+  it.
+- **Embed `llama-cpp-2` FFI just for header reads** — drags
+  inference-time deps into the pull path; runs the *consumer's*
+  parser at the *boundary* (wrong layer); blows compile time and
+  binary size for the pull subcommand by an order of magnitude.
+- **Use OCI sidecar layers for the chat-template instead of an
+  annotation** — viable but heavier (each fact becomes a separate
+  layer descriptor). Annotations are simpler and fit the "one-fact"
+  pattern. We may reach for sidecar layers when a fact's *bytes*
+  matter (e.g., a full SBOM, a license file). Pure hashes belong in
+  annotations.
+- **Skip the chat-template binding entirely; rely on cosign-of-blob**
+  — the original "what cosign covers" model. ADR-013 §4 already
+  explicitly rejects this: an attacker with push access *and* a
+  valid signing identity can re-publish the same weights with a
+  swapped template, and a blob-only binding doesn't catch it.
+
+## Consequences
+
+### Positive
+
+- **Trust-boundary code is small and immutable** with respect to
+  format evolution. New formats don't propagate into `crates/cli/src/pull.rs`.
+- **Format-author tooling stays the format author's problem.** When
+  GGUF v4 ships, the project updates one workflow step (the Python
+  `gguf` install pin), not the runtime.
+- **Auditing is bounded.** The full trust-boundary code is ~30 lines
+  of JSON-annotation-read in `pull.rs` + cosign + oras. That's
+  reviewable in one sitting; a custom parser is not.
+- **Operators can adopt the same pattern for their own facts.** An
+  operator who needs to pin (say) the embedding-vocab hash adds an
+  org-prefixed annotation, signs it with their identity, and pins
+  the value in their config. The runtime reads it the same way it
+  reads chat-template.
+- **Generalizes without re-litigating the architecture.** Future
+  ONNX / Safetensors / vendor-format ADRs reference this one and add
+  per-format publisher tooling; they don't re-justify the layering.
+
+### Negative
+
+- **Publishers are responsible for computing the right hash.** A
+  publisher's parser disagreeing with the consumer's parser — e.g.,
+  `gguf-py` returning different bytes than llama.cpp would — would
+  surface as a session-boot rebind violation under OCI-B (b). We
+  mitigate by recommending the format author's official tooling on
+  the publisher side (same maintainer set as the consumer), and by
+  the planned defense-in-depth check at session boot. We do not
+  attempt to verify alignment by re-parsing in the runtime — that
+  would re-introduce exactly what this ADR forbids.
+- **Operators can no longer pull "raw" untrusted GGUFs from random
+  registries and expect chat-template binding.** A model artifact
+  that doesn't declare the Aegis-Node media type, or doesn't carry
+  the annotation, falls through to the `chat_template_sha256_hex =
+  None` path and offers no F1 template-binding protection. We
+  consider this a *feature*: the binding is supposed to require an
+  attesting publisher.
+- **Workflow build cost grows.** `models-publish.yml` now installs
+  the `gguf` Python package on every dispatch (~10 MB, negligible).
+- **Re-publish required for already-published artifacts.** The
+  pre-existing Qwen artifact at
+  `ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:240ece32...`
+  was published before this change and has no annotation. The OCI-B
+  PR that lands this ADR re-runs `models-publish.yml` against the
+  same HF revision (`91cad51170dc346986eccefdc2dd33a9da36ead9`); a
+  new manifest digest results because annotations change the
+  manifest. Old digest stays accessible for replay but is no longer
+  the operator pin.
+
+## Implementation
+
+Lands as part of the [OCI-B (a)](https://github.com/tosin2013/aegis-node/issues/67)
+PR:
+
+1. `crates/cli/src/pull.rs` — add `run_oras_manifest_fetch` and
+   `extract_chat_template_annotation`; remove the discarded GGUF
+   parser.
+2. `.github/workflows/models-publish.yml` — install `gguf>=0.10.0`,
+   compute `tokenizer.chat_template` SHA-256 via `GGUFReader`, set
+   `dev.aegis-node.chat-template.sha256` annotation on `oras push`.
+3. Re-publish Qwen with the annotation; update the pinned manifest
+   digest in `tests/pull_real_image.rs`, ADR-020 §"Pinned model",
+   and `docs/SUPPLY_CHAIN.md`.
+4. Tests in `crates/cli/tests/pull.rs` cover annotation-present /
+   annotation-missing-on-model-artifact / non-model-artifact-without-
+   annotation / bad-hex-annotation paths.
+
+## Related
+
+- [ADR-013 OCI Artifacts for Model Distribution](013-oci-artifacts-for-model-distribution.md)
+  — §"Decision" item 4 motivates this ADR's mechanism.
+- [ADR-021 HuggingFace as Canonical Upstream](021-huggingface-as-upstream-oci-as-trust-boundary.md)
+  — same pipeline; this ADR adds the annotation step to it.
+- [ADR-020 Recorded Demo Program](020-recorded-demo-program.md) —
+  pinned Qwen artifact moves to a new manifest digest after re-publish.
+- [LLM-A #70](https://github.com/tosin2013/aegis-node/issues/70) —
+  llama.cpp FFI; once landed, becomes the defense-in-depth re-derivation
+  of the chat-template hash at session boot.
+- Future ONNX / Safetensors / vendor-format ADRs (none filed yet) will
+  follow this same publisher-asserts / runtime-verifies pattern.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -29,6 +29,7 @@ The decisions are anchored in the Architecture Principles (PRD §7) and the ten-
 | [019](019-explicit-write-grant-takes-precedence.md) | Explicit Write Grant Takes Precedence Over Broad Path Coverage | §4 F7 |
 | [020](020-recorded-demo-program.md) | Recorded Demo Program — VHS Tapes Driven by Real CPU-Bound Models | §1, §5 Phase 1 |
 | [021](021-huggingface-as-upstream-oci-as-trust-boundary.md) | HuggingFace as Canonical Upstream; OCI + cosign as Trust Boundary | §6.1 |
+| [022](022-trust-boundary-format-agnosticism.md) | Trust-Boundary Format Agnosticism — Verify Signed Claims, Don't Parse Files | §6.1, §7 |
 
 ## Decision Coverage Matrix
 


### PR DESCRIPTION
## Summary

Pull-side half of [OCI-B (#67)](https://github.com/tosin2013/aegis-node/issues/67), and the architectural ADR that explains why we *aren't* shipping a custom GGUF parser.

- Per [ADR-022](docs/adrs/022-trust-boundary-format-agnosticism.md), the runtime trust boundary verifies signed claims; it never parses model file formats.
- `aegis pull` now reads `dev.aegis-node.chat-template.sha256` from the cosign-covered manifest annotation (via `oras manifest fetch`) and persists it as a `chat_template.sha256.txt` sidecar for the F1 boot binding.
- Annotation policy is fail-closed: required for `application/vnd.aegis-node.model.gguf.v1` artifacts, optional for non-model artifacts (devbox + third-party).
- `models-publish.yml` installs ggml-org's official `gguf` Python package, computes `tokenizer.chat_template` SHA-256 via `GGUFReader`, and sets the annotation at push time.

The user pushed back on the originally-drafted custom GGUF parser ("we may have to build new ones all the time"). Research found every off-the-shelf alternative is wrong-shaped (`gguf` unmaintained; `gguf-rs` library/CLI mixed; `gguf-rs-lib` 7.8k LoC; `candle-core` 50+ deps incl. `onig`) and the GGUF parser CVE history reads as a checklist of length-cast bugs (CVE-2025-49847, CVE-2025-53630, CVE-2026-5760, CVE-2024-34359). ADR-022 records the principle so ONNX / Safetensors / vendor formats can follow the same pattern without re-litigating the layering.

## What this changes

- New: `docs/adrs/022-trust-boundary-format-agnosticism.md` (200 lines)
- `crates/cli/src/pull.rs`: + `run_oras_manifest_fetch`, `extract_chat_template_annotation`, three new typed error variants (`ManifestFetchFailed`, `MissingChatTemplateAnnotation`, `InvalidAnnotationValue`)
- `crates/cli/tests/pull.rs`: 8 fake-tools tests (was 6) covering annotation-present / missing / bad-hex / non-model paths
- `crates/cli/tests/pull_real_image.rs`: asserts annotation-derived sha matches Qwen template
- `.github/workflows/models-publish.yml`: chat-template extraction step + new annotation flag
- README ADR count 21 → 22 + `docs/adrs/README.md` index entry

## Re-publish + pin update

The currently-pinned Qwen digest `sha256:240ece32...` was published before this change and has no annotation. `models-publish.yml` will be dispatched against this branch to re-publish against HF revision `91cad51170dc346986eccefdc2dd33a9da36ead9`. The blob bytes don't change, so:

- `PINNED_BLOB_SHA = 6a1a2eb6...` ✅ (unchanged)
- `PINNED_CHAT_TEMPLATE_SHA = d5495a1e...` ✅ (unchanged — same upstream)
- `PINNED_REF / PINNED_MANIFEST_SHA` 🔄 (new digest from the re-publish; updated in a follow-up commit on this branch before merge)

Old digest stays accessible for replay; not the operator pin.

## Test plan

- [x] Local `cargo test -p aegis-cli --test pull` — all 8 fake-tools tests pass
- [x] Local `cargo fmt --all -- --check` clean
- [x] Local `cargo clippy -p aegis-cli --tests` clean
- [ ] Re-run `models-publish.yml` against `feat/oci-b-chat-template` to re-publish Qwen with annotation
- [ ] Update pinned manifest digest in `tests/pull_real_image.rs` (and ADR-020 / SUPPLY_CHAIN.md)
- [ ] CI `rust.yml` → `pull_qwen_model_round_trips_against_real_registry` passes against new digest with chat-template assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)