### PR TITLE
feat(llama-backend, inference-engine): Backend trait + Session::run_turn driver (LLM-B, ADR-014)

### DIFF
--- a/crates/inference-engine/Cargo.toml
+++ b/crates/inference-engine/Cargo.toml
@@ -18,6 +18,7 @@ aegis-ledger-writer = { path = "../ledger-writer" }
 aegis-mcp-client = { path = "../mcp-client" }
 aegis-policy = { path = "../policy" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 hex = "0.4"

--- a/crates/inference-engine/src/backend.rs
+++ b/crates/inference-engine/src/backend.rs
@@ -1,0 +1,251 @@
+//! `Backend` trait + chat-time types — the runtime's only
+//! abstraction over an inference engine.
+//!
+//! Per LLM-B / [issue #71](https://github.com/tosin2013/aegis-node/issues/71)
+//! and ADR-014 §"Decision item 3". Lives in `aegis-inference-engine`
+//! (not `aegis-llama-backend`) so the runtime build path doesn't drag
+//! llama.cpp's C++ surface into every workspace PR. Concrete impls
+//! (currently `LlamaCppBackend` in `crates/llama-backend`) take a dep
+//! on this crate; the runtime takes a dep on neither.
+//!
+//! ## Types
+//!
+//! - [`ChatMessage`] / [`ChatRole`] — one chat turn in role-content
+//!   shape.
+//! - [`ToolDecl`] — declaration of a tool the model may call. Names
+//!   are formatted as `"<server>__<tool>"` for MCP tools so the
+//!   driver can split on `__` to dispatch via
+//!   `Session::mediate_mcp_tool_call` (per ADR-018).
+//! - [`ToolCall`] — one tool call the model emitted.
+//! - [`InferRequest`] / [`InferResponse`] — the per-turn shape.
+//!
+//! ## Traits
+//!
+//! - [`Backend`] — loads a model from disk. `Send + Sync`; one per
+//!   process is the typical pattern.
+//! - [`LoadedModel`] — owns the loaded weights, runs one chat turn
+//!   per `infer` call. `Send + !Sync` — `infer` mutates KV-cache /
+//!   sampler state in place.
+//!
+//! ## Error type
+//!
+//! [`BackendError`] is opaque: a typed [`BackendErrorKind`] +
+//! detail string. Concrete impls map their internal errors to a
+//! kind on the way out so the runtime never has to depend on
+//! llama.cpp's own error types.
+
+use std::fmt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Roles modern instruct models recognize. Vendor-specific roles
+/// ("function", "developer", etc.) get represented as
+/// [`ChatRole::Tool`] or by tunneling into [`ChatMessage::content`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChatRole {
+    /// System prompt.
+    System,
+    /// User input.
+    User,
+    /// Model output.
+    Assistant,
+    /// Result of a tool call, returned to the model on the next turn.
+    Tool,
+}
+
+impl ChatRole {
+    /// Lowercase string the chat template expects.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ChatRole::System => "system",
+            ChatRole::User => "user",
+            ChatRole::Assistant => "assistant",
+            ChatRole::Tool => "tool",
+        }
+    }
+}
+
+/// A single chat turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatMessage {
+    /// Role of the message (system / user / assistant / tool).
+    pub role: ChatRole,
+    /// Free-text content. Tool calls are surfaced through
+    /// [`ToolCall`] in the response, not embedded here.
+    pub content: String,
+}
+
+/// Declaration of a tool the model may call. Surfaces directly into
+/// the OpenAI-compatible `tools` block of the chat template (which
+/// every modern instruct-with-tools GGUF understands).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolDecl {
+    /// Tool name. For MCP tools (per ADR-018) this is formatted as
+    /// `"<server_name>__<tool_name>"` so the driver can split on the
+    /// first `__` and dispatch through `mediate_mcp_tool_call`. The
+    /// double-underscore convention avoids collisions with dots that
+    /// commonly appear in tool names (e.g., `filesystem.read`).
+    pub name: String,
+    /// Free-text description for the model. Pulled from the manifest's
+    /// catalog; the security review reads it.
+    pub description: String,
+    /// JSON Schema for the tool's arguments. Opaque to this layer —
+    /// the manifest validator already normalized it.
+    pub arguments_schema: serde_json::Value,
+}
+
+/// One tool call the model emitted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCall {
+    /// Tool name from the catalog. See [`ToolDecl::name`] for the
+    /// `<server>__<tool>` format the driver expects for MCP dispatch.
+    pub name: String,
+    /// JSON-shaped arguments. The mediator interprets them per tool.
+    pub arguments: serde_json::Value,
+}
+
+/// Inputs to one inference turn.
+#[derive(Debug, Clone)]
+pub struct InferRequest {
+    /// Conversation so far, in chronological order.
+    pub messages: Vec<ChatMessage>,
+    /// Tool catalog the model may call this turn. Empty when no tools
+    /// are available — every modern instruct model handles that
+    /// gracefully.
+    pub tools: Vec<ToolDecl>,
+}
+
+/// Outputs of one inference turn.
+#[derive(Debug, Clone)]
+pub struct InferResponse {
+    /// The model's free-text reasoning (everything outside any
+    /// `<tool_call>` blocks, with leading/trailing whitespace
+    /// trimmed). Surfaces into F5 `ReasoningStep` ledger entries. May
+    /// be empty when the model goes straight to a tool call.
+    pub reasoning: String,
+    /// Parsed tool calls. The runtime dispatches each through the
+    /// appropriate `mediate_*` method.
+    pub tool_calls: Vec<ToolCall>,
+    /// Optional terminal assistant message — set when the model
+    /// produced text intended for the user (vs. only tool calls).
+    pub assistant_text: Option<String>,
+}
+
+/// Trait for anything that can load a model from disk and return a
+/// [`LoadedModel`] handle. `Send + Sync` because production runtimes
+/// share a single backend across threads.
+pub trait Backend: Send + Sync {
+    /// Load a GGUF (or other supported format) and return a stateful
+    /// model handle.
+    fn load(&self, model_path: &Path) -> Result<Box<dyn LoadedModel>, BackendError>;
+}
+
+/// One inference session against a loaded model. `Send` so the
+/// runtime can hand it off across thread boundaries; **not** `Sync`
+/// — `infer` mutates KV-cache state in place.
+pub trait LoadedModel: Send {
+    /// Run a single chat-turn inference. Mutates the model's per-call
+    /// sampler state but otherwise leaves the loaded weights alone.
+    fn infer(&mut self, request: InferRequest) -> Result<InferResponse, BackendError>;
+}
+
+/// Typed error from a [`Backend`] / [`LoadedModel`] call. The kind
+/// is the discriminant the runtime uses to pick a violation /
+/// violation reason; `detail` is a human-readable extension that
+/// flows into the ledger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendError {
+    /// Which gate refused.
+    pub kind: BackendErrorKind,
+    /// Free-text detail from the impl (FFI message, parser error,
+    /// etc.).
+    pub detail: String,
+}
+
+impl BackendError {
+    /// Build a new error from a kind + detail.
+    pub fn new(kind: BackendErrorKind, detail: impl Into<String>) -> Self {
+        Self {
+            kind,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.kind, self.detail)
+    }
+}
+
+impl std::error::Error for BackendError {}
+
+/// Categories of [`BackendError`]. Stable surface — concrete impls
+/// map their internal errors here on the way out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendErrorKind {
+    /// Model file unreadable / not found.
+    ModelFileUnreadable,
+    /// Model file present but rejected by the parser (not a valid
+    /// GGUF, version mismatch, ...).
+    ModelLoadFailed,
+    /// Could not allocate / initialize an inference context.
+    SessionInitFailed,
+    /// Tokenization of the prompt failed.
+    Tokenization,
+    /// `infer` returned an error from the FFI's decode step.
+    Inference,
+    /// Output contained invalid UTF-8.
+    InvalidUtf8,
+    /// Caller supplied an impossible configuration.
+    InvalidConfig,
+    /// Backend was already initialized in this process.
+    BackendAlreadyInitialized,
+    /// Backend init failed for a system-level reason.
+    BackendInitFailed,
+    /// Other / impl-specific. The detail string carries the specifics.
+    Other,
+}
+
+impl fmt::Display for BackendErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BackendErrorKind::ModelFileUnreadable => "model file unreadable",
+            BackendErrorKind::ModelLoadFailed => "model load failed",
+            BackendErrorKind::SessionInitFailed => "session init failed",
+            BackendErrorKind::Tokenization => "tokenization failed",
+            BackendErrorKind::Inference => "inference decode failed",
+            BackendErrorKind::InvalidUtf8 => "invalid UTF-8 in output",
+            BackendErrorKind::InvalidConfig => "invalid configuration",
+            BackendErrorKind::BackendAlreadyInitialized => "backend already initialized",
+            BackendErrorKind::BackendInitFailed => "backend init failed",
+            BackendErrorKind::Other => "backend error",
+        };
+        f.write_str(s)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_role_serializes_lowercase() {
+        let m = ChatMessage {
+            role: ChatRole::Assistant,
+            content: "hi".to_string(),
+        };
+        let s = serde_json::to_string(&m).unwrap();
+        assert!(s.contains(r#""role":"assistant""#), "{s}");
+    }
+
+    #[test]
+    fn backend_error_display_includes_kind_and_detail() {
+        let e = BackendError::new(BackendErrorKind::Tokenization, "bad bytes");
+        assert_eq!(e.to_string(), "tokenization failed: bad bytes");
+    }
+}

--- a/crates/inference-engine/src/error.rs
+++ b/crates/inference-engine/src/error.rs
@@ -32,6 +32,24 @@ pub enum Error {
     #[error("chat-template sidecar at {path:?}: {detail}")]
     ChatTemplateSidecar { path: String, detail: String },
 
+    /// `Session::run_turn` was called but no [`crate::backend::LoadedModel`]
+    /// is attached. Use [`crate::Session::with_loaded_model`] after boot.
+    #[error("no inference backend configured for session (call with_loaded_model first)")]
+    NoBackendConfigured,
+
+    /// The model returned an error from its `infer` call. The detail
+    /// carries the impl-specific reason; the kind discriminates so the
+    /// mediator can decide whether to halt or continue.
+    #[error("backend infer failed: {0}")]
+    BackendInfer(#[from] crate::backend::BackendError),
+
+    /// `run_turn` parsed a tool call whose name doesn't match the
+    /// expected `<server>__<tool>` shape (per ADR-018 LLM-B contract).
+    /// The model emitted something the runtime can't dispatch — record
+    /// the violation, don't try to interpret.
+    #[error("tool call name {name:?} is not in the expected <server>__<tool> shape")]
+    UnroutableToolCall { name: String },
+
     #[error("access-log: {0}")]
     AccessLog(#[from] aegis_access_log::Error),
 

--- a/crates/inference-engine/src/lib.rs
+++ b/crates/inference-engine/src/lib.rs
@@ -11,9 +11,16 @@
 //! that point.
 
 pub mod attestation;
+pub mod backend;
 pub mod error;
 mod mediator;
 mod session;
+mod turn;
 
+pub use backend::{
+    Backend, BackendError, BackendErrorKind, ChatMessage, ChatRole, InferRequest, InferResponse,
+    LoadedModel, ToolCall, ToolDecl,
+};
 pub use error::{Error, Result};
 pub use session::{BootConfig, NetworkConnectionDecision, NetworkConnectionMeta, Session};
+pub use turn::{ToolCallOutcome, ToolCallResult, TurnOutcome};

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -90,6 +90,10 @@ pub struct Session {
     /// session — the mediator returns `Error::Denied` rather than panic.
     /// Set via [`Session::with_mcp_client`] after boot.
     pub(crate) mcp_client: Option<Box<dyn McpClient>>,
+    /// LLM-B inference backend. None means `run_turn` is unavailable
+    /// (the legacy fixed-script `run` path keeps working). Set via
+    /// [`Session::with_loaded_model`] after boot. Per ADR-014.
+    pub(crate) loaded_model: Option<Box<dyn crate::backend::LoadedModel>>,
 }
 
 /// One observed network-connection attempt + the gate's decision.
@@ -229,6 +233,7 @@ impl Session {
             approval_channel: None,
             network_log: Vec::new(),
             mcp_client: None,
+            loaded_model: None,
         })
     }
 
@@ -246,6 +251,14 @@ impl Session {
     /// Violation citing "no MCP client configured").
     pub fn with_mcp_client(mut self, client: Box<dyn McpClient>) -> Self {
         self.mcp_client = Some(client);
+        self
+    }
+
+    /// Attach an LLM-B inference backend. Required to invoke
+    /// [`Self::run_turn`]; without it `run_turn` returns
+    /// [`Error::NoBackendConfigured`]. Per ADR-014 / LLM-B.
+    pub fn with_loaded_model(mut self, model: Box<dyn crate::backend::LoadedModel>) -> Self {
+        self.loaded_model = Some(model);
         self
     }
 

--- a/crates/inference-engine/src/turn.rs
+++ b/crates/inference-engine/src/turn.rs
@@ -1,0 +1,234 @@
+//! `Session::run_turn` driver — the LLM-B integration point.
+//!
+//! Per LLM-B / [issue #71](https://github.com/tosin2013/aegis-node/issues/71)
+//! and ADR-014. One call:
+//!
+//! 1. Build [`InferRequest`] from the user input + the manifest's MCP
+//!    tool catalog.
+//! 2. Call the attached [`LoadedModel::infer`] (the LLM-B trait).
+//! 3. Emit one F5 [`ReasoningStep`] ledger entry from the response —
+//!    the reasoning text plus `tool_selected` populated from the
+//!    parsed tool calls.
+//! 4. For each [`ToolCall`] the model emitted, route through the
+//!    appropriate `mediate_*` method on `Session`. LLM-B routes only
+//!    MCP tools (per the issue's E2E acceptance); filesystem / network
+//!    / exec dispatch land in a follow-up.
+//! 5. Return a [`TurnOutcome`] capturing assistant text + per-call
+//!    outcomes for the caller.
+//!
+//! The driver is intentionally narrow: the runtime contract stays
+//! "every side-effect routes through `mediate_*`," so once the model
+//! emits a tool call we lean on the existing per-tool-call mediator.
+//! No new policy gates here.
+
+use crate::backend::{InferRequest, ToolCall, ToolDecl};
+use crate::error::{Error, Result};
+use crate::session::Session;
+
+/// Outcome of one [`Session::run_turn`] call. Captures every
+/// observable side-effect the caller might want to act on (logs,
+/// retries, halt decisions). The ledger holds the canonical record;
+/// this struct is the in-process echo.
+#[derive(Debug, Clone)]
+pub struct TurnOutcome {
+    /// Assistant text the model produced — `Some` when the model
+    /// emitted free-text reasoning intended for the user, `None`
+    /// when it went straight to tool calls.
+    pub assistant_text: Option<String>,
+    /// Per-tool-call outcome, in emission order.
+    pub tool_calls: Vec<ToolCallOutcome>,
+}
+
+/// Outcome of one dispatched [`ToolCall`].
+#[derive(Debug, Clone)]
+pub struct ToolCallOutcome {
+    /// Tool name as the model emitted it (`<server>__<tool>` for MCP).
+    pub name: String,
+    /// Result of the dispatch.
+    pub result: ToolCallResult,
+}
+
+/// Three terminal states for one tool call.
+#[derive(Debug, Clone)]
+pub enum ToolCallResult {
+    /// Mediator allowed and the upstream tool returned `value`.
+    Success(serde_json::Value),
+    /// Mediator denied — `reason` is the policy / runtime reason that
+    /// already lives in the ledger as a Violation entry.
+    Denied(String),
+    /// Mediator demanded approval and the call short-circuited (the
+    /// approval channel either timed out, was rejected, or wasn't
+    /// configured). `reason` is the same reason in the ledger.
+    RequiresApproval(String),
+    /// The tool call wasn't routable — the model emitted a name that
+    /// doesn't fit the `<server>__<tool>` convention LLM-B expects.
+    Unroutable(String),
+}
+
+impl Session {
+    /// Run one chat turn end-to-end: build request → infer → emit
+    /// reasoning → dispatch tool calls → return outcome.
+    ///
+    /// Errors:
+    /// - [`Error::NoBackendConfigured`] when the session was booted
+    ///   without [`Self::with_loaded_model`].
+    /// - [`Error::BackendInfer`] when the inference itself fails.
+    /// - Any error from `mediate_*` propagates only if it would also
+    ///   propagate from the legacy fixed-script `run` path (e.g.,
+    ///   identity rebind violation). Per-call denials and approval
+    ///   refusals are captured into [`TurnOutcome`] rather than
+    ///   short-circuiting the turn — the agent saw the refusal, the
+    ///   ledger has the Violation, the next turn can adapt.
+    pub fn run_turn(&mut self, user_message: &str) -> Result<TurnOutcome> {
+        let tools = self.mcp_tool_catalog();
+        let messages = vec![crate::backend::ChatMessage {
+            role: crate::backend::ChatRole::User,
+            content: user_message.to_string(),
+        }];
+
+        let response = {
+            let model = self
+                .loaded_model
+                .as_mut()
+                .ok_or(Error::NoBackendConfigured)?;
+            model.infer(InferRequest { messages, tools })?
+        };
+
+        // Emit one F5 reasoning step capturing the model's stated
+        // chain — input + reasoning + tools considered + selected.
+        let tools_considered: Vec<String> = self
+            .policy()
+            .manifest()
+            .tools
+            .mcp
+            .iter()
+            .flat_map(|s| {
+                s.allowed_tools
+                    .iter()
+                    .map(move |t| format_mcp_name(&s.server_name, t))
+            })
+            .collect();
+        let tool_selected = response.tool_calls.first().map(|c| c.name.clone());
+        let step_uuid = self.record_reasoning_step(
+            user_message,
+            &response.reasoning,
+            tools_considered,
+            tool_selected,
+        )?;
+        let step_id = step_uuid.to_string();
+
+        // Dispatch each tool call. We capture per-call outcomes rather
+        // than short-circuit the loop on Denied/RequireApproval —
+        // those are normal runtime conditions, not turn-fatal errors.
+        let mut outcomes = Vec::with_capacity(response.tool_calls.len());
+        for call in response.tool_calls {
+            let outcome = self.dispatch_tool_call(call, Some(&step_id))?;
+            outcomes.push(outcome);
+        }
+
+        Ok(TurnOutcome {
+            assistant_text: response.assistant_text,
+            tool_calls: outcomes,
+        })
+    }
+
+    /// Build the LLM-B tool catalog from the manifest's MCP grants.
+    /// Names are formatted as `<server>__<tool>` so the model's
+    /// emission can be split unambiguously by [`split_mcp_name`].
+    fn mcp_tool_catalog(&self) -> Vec<ToolDecl> {
+        let mut decls = Vec::new();
+        for server in &self.policy().manifest().tools.mcp {
+            for tool_name in &server.allowed_tools {
+                decls.push(ToolDecl {
+                    name: format_mcp_name(&server.server_name, tool_name),
+                    description: format!(
+                        "MCP tool {tool_name} on server {} (URI: {})",
+                        server.server_name, server.server_uri
+                    ),
+                    // No schema in the manifest yet — pass an open
+                    // object so the model isn't constrained. The MCP
+                    // server returns its own schema at handshake time;
+                    // surfacing that into the catalog lands in a
+                    // follow-up alongside MCP discovery.
+                    arguments_schema: serde_json::json!({"type": "object"}),
+                });
+            }
+        }
+        decls
+    }
+
+    /// Route one [`ToolCall`] through the existing per-tool mediator.
+    /// LLM-B handles MCP tools only; filesystem / network / exec
+    /// dispatch lands in a follow-up that introduces a richer name
+    /// scheme.
+    fn dispatch_tool_call(
+        &mut self,
+        call: ToolCall,
+        reasoning_step_id: Option<&str>,
+    ) -> Result<ToolCallOutcome> {
+        let Some((server, tool)) = split_mcp_name(&call.name) else {
+            return Ok(ToolCallOutcome {
+                name: call.name.clone(),
+                result: ToolCallResult::Unroutable(format!(
+                    "tool name {:?} not in <server>__<tool> shape",
+                    call.name
+                )),
+            });
+        };
+        let result =
+            match self.mediate_mcp_tool_call(server, tool, call.arguments, reasoning_step_id) {
+                Ok(value) => ToolCallResult::Success(value),
+                Err(Error::Denied { reason }) => ToolCallResult::Denied(reason),
+                Err(Error::RequireApproval { reason }) => ToolCallResult::RequiresApproval(reason),
+                // Identity rebind / I/O / other errors propagate — they
+                // already wrote a Violation entry where applicable, and
+                // the mediator's contract is "halt the run."
+                Err(other) => return Err(other),
+            };
+        Ok(ToolCallOutcome {
+            name: call.name,
+            result,
+        })
+    }
+}
+
+/// Format an MCP tool's qualified name for the LLM catalog.
+pub(crate) fn format_mcp_name(server: &str, tool: &str) -> String {
+    format!("{server}__{tool}")
+}
+
+/// Inverse of [`format_mcp_name`]. Returns `None` when the name
+/// doesn't carry the `__` separator.
+pub(crate) fn split_mcp_name(name: &str) -> Option<(&str, &str)> {
+    let (server, tool) = name.split_once("__")?;
+    if server.is_empty() || tool.is_empty() {
+        return None;
+    }
+    Some((server, tool))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_round_trips_through_split() {
+        let qualified = format_mcp_name("filesystem", "read_file");
+        assert_eq!(qualified, "filesystem__read_file");
+        let (server, tool) = split_mcp_name(&qualified).unwrap();
+        assert_eq!(server, "filesystem");
+        assert_eq!(tool, "read_file");
+    }
+
+    #[test]
+    fn split_rejects_unqualified_name() {
+        assert_eq!(split_mcp_name("just_a_tool"), None);
+    }
+
+    #[test]
+    fn split_rejects_empty_components() {
+        assert_eq!(split_mcp_name("__tool"), None);
+        assert_eq!(split_mcp_name("server__"), None);
+    }
+}

--- a/crates/inference-engine/tests/run_turn.rs
+++ b/crates/inference-engine/tests/run_turn.rs
@@ -1,0 +1,295 @@
+//! Integration tests for `Session::run_turn` (LLM-B / issue #71).
+//!
+//! Uses a [`MockLoadedModel`] that returns a canned [`InferResponse`]
+//! so the test asserts the F5 reasoning emission + MCP tool dispatch
+//! flow without needing a real GGUF or libclang at build time.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use aegis_identity::LocalCa;
+use aegis_inference_engine::{
+    BackendError, BootConfig, InferRequest, InferResponse, LoadedModel, Session, ToolCall,
+    ToolCallResult,
+};
+use aegis_mcp_client::{McpClient, Result as McpResult};
+use serde_json::Value;
+
+const TRUST_DOMAIN: &str = "session-boot.local";
+
+/// Test double for [`LoadedModel`]. Records every `infer` call's
+/// request and returns the next canned response. Tests pre-load the
+/// queue with the responses they want.
+struct MockLoadedModel {
+    queue: Arc<Mutex<Vec<Result<InferResponse, BackendError>>>>,
+    captured: Arc<Mutex<Vec<InferRequest>>>,
+}
+
+impl MockLoadedModel {
+    fn new(responses: Vec<Result<InferResponse, BackendError>>) -> (Self, MockHandle) {
+        let queue = Arc::new(Mutex::new(responses));
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let handle = MockHandle {
+            captured: captured.clone(),
+        };
+        (Self { queue, captured }, handle)
+    }
+}
+
+impl LoadedModel for MockLoadedModel {
+    fn infer(&mut self, request: InferRequest) -> Result<InferResponse, BackendError> {
+        self.captured.lock().unwrap().push(request);
+        let mut q = self.queue.lock().unwrap();
+        q.remove(0)
+    }
+}
+
+#[derive(Clone)]
+struct MockHandle {
+    captured: Arc<Mutex<Vec<InferRequest>>>,
+}
+
+impl MockHandle {
+    fn captured_requests(&self) -> Vec<InferRequest> {
+        self.captured.lock().unwrap().clone()
+    }
+}
+
+/// Test double for [`McpClient`]. Returns a canned JSON value for
+/// every `call_tool` invocation and records the (server, tool, args)
+/// tuple so the test can assert dispatch happened correctly.
+struct MockMcpClient {
+    response: serde_json::Value,
+    calls: Arc<Mutex<Vec<(String, String, serde_json::Value)>>>,
+}
+
+impl McpClient for MockMcpClient {
+    fn call_tool(
+        &mut self,
+        server_uri: &str,
+        tool_name: &str,
+        args: serde_json::Value,
+    ) -> McpResult<serde_json::Value> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((server_uri.to_string(), tool_name.to_string(), args));
+        Ok(self.response.clone())
+    }
+}
+
+fn write_manifest_with_one_mcp_server(path: &Path) {
+    let yaml = r#"schemaVersion: "1"
+agent: { name: "run-turn-test", version: "1.0.0" }
+identity: { spiffeId: "spiffe://session-boot.local/agent/research/inst-001" }
+tools:
+  mcp:
+    - server_name: "weather-mcp"
+      server_uri: "stdio:///bin/weather-mcp"
+      allowed_tools: ["get"]
+"#;
+    std::fs::write(path, yaml).unwrap();
+}
+
+fn boot_session(dir: &Path, ca_dir: &Path) -> Session {
+    LocalCa::init(ca_dir, TRUST_DOMAIN).unwrap();
+
+    let manifest_path = dir.join("manifest.yaml");
+    let model_path = dir.join("model.gguf");
+    let ledger_path = dir.join("ledger.jsonl");
+    write_manifest_with_one_mcp_server(&manifest_path);
+    std::fs::write(&model_path, b"fake-model-bytes-for-test").unwrap();
+
+    let cfg = BootConfig {
+        session_id: "session-run-turn".to_string(),
+        manifest_path,
+        model_path,
+        config_path: None,
+        chat_template_sidecar: None,
+        identity_dir: ca_dir.to_path_buf(),
+        workload_name: "research".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path,
+    };
+    Session::boot(cfg).unwrap()
+}
+
+#[test]
+fn run_turn_without_loaded_model_returns_typed_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let mut session = boot_session(dir.path(), ca_dir.path());
+
+    let err = session.run_turn("hello").unwrap_err();
+    assert!(
+        matches!(err, aegis_inference_engine::Error::NoBackendConfigured),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn run_turn_emits_reasoning_then_dispatches_one_mcp_tool_call() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    // Canned response: one tool call with no preamble — model goes
+    // straight to the call.
+    let response = InferResponse {
+        reasoning: "Looking up the weather.".to_string(),
+        tool_calls: vec![ToolCall {
+            name: "weather-mcp__get".to_string(),
+            arguments: serde_json::json!({"city": "Paris"}),
+        }],
+        assistant_text: Some("Looking up the weather.".to_string()),
+    };
+    let (mock, mock_handle) = MockLoadedModel::new(vec![Ok(response)]);
+
+    let mcp_calls = Arc::new(Mutex::new(Vec::new()));
+    let mcp_client = MockMcpClient {
+        response: serde_json::json!({"temp_c": 18}),
+        calls: mcp_calls.clone(),
+    };
+
+    let mut session = session
+        .with_mcp_client(Box::new(mcp_client))
+        .with_loaded_model(Box::new(mock));
+
+    let outcome = session.run_turn("What's the weather in Paris?").unwrap();
+
+    // The driver dispatched the tool call through the MCP client.
+    assert_eq!(outcome.tool_calls.len(), 1);
+    assert_eq!(outcome.tool_calls[0].name, "weather-mcp__get");
+    match &outcome.tool_calls[0].result {
+        ToolCallResult::Success(v) => {
+            assert_eq!(v["temp_c"], 18);
+        }
+        other => panic!("expected Success, got {other:?}"),
+    }
+
+    // The MCP client saw the dispatch with the right (server-uri, tool, args).
+    let calls = mcp_calls.lock().unwrap().clone();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "stdio:///bin/weather-mcp");
+    assert_eq!(calls[0].1, "get");
+    assert_eq!(calls[0].2, serde_json::json!({"city": "Paris"}));
+
+    // The InferRequest the mock saw was built from the user message
+    // and the manifest's MCP catalog (one tool: weather-mcp__get).
+    let captured = mock_handle.captured_requests();
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].messages.len(), 1);
+    assert_eq!(
+        captured[0].messages[0].content,
+        "What's the weather in Paris?"
+    );
+    assert_eq!(captured[0].tools.len(), 1);
+    assert_eq!(captured[0].tools[0].name, "weather-mcp__get");
+
+    // The ledger captured exactly the F5+F4 pair the issue's
+    // acceptance criterion calls for: ReasoningStep then Access.
+    let _ = session.shutdown().unwrap();
+    let ledger = std::fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+    let lines: Vec<Value> = ledger
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    let entry_types: Vec<&str> = lines
+        .iter()
+        .map(|v| v["entryType"].as_str().unwrap())
+        .collect();
+    assert!(
+        entry_types.contains(&"reasoning_step"),
+        "missing reasoning_step in {entry_types:?}"
+    );
+    assert!(
+        entry_types.contains(&"access"),
+        "missing access entry in {entry_types:?}"
+    );
+    let pos_reasoning = entry_types
+        .iter()
+        .position(|t| *t == "reasoning_step")
+        .unwrap();
+    let pos_access = entry_types.iter().position(|t| *t == "access").unwrap();
+    assert!(
+        pos_reasoning < pos_access,
+        "reasoning_step should precede access in {entry_types:?}"
+    );
+
+    // The reasoning step's tool_selected should be the qualified name
+    // the model emitted — auditors trace through it.
+    let reasoning_entry = &lines[pos_reasoning];
+    assert_eq!(
+        reasoning_entry["toolSelected"].as_str(),
+        Some("weather-mcp__get")
+    );
+}
+
+#[test]
+fn run_turn_marks_unroutable_tool_call_without_propagating_error() {
+    // Model emits a tool name not in the <server>__<tool> shape.
+    // Driver records it as Unroutable; the turn still succeeds so
+    // the next turn can show the model the problem.
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    let response = InferResponse {
+        reasoning: String::new(),
+        tool_calls: vec![ToolCall {
+            name: "just_a_tool_with_no_server".to_string(),
+            arguments: serde_json::Value::Null,
+        }],
+        assistant_text: None,
+    };
+    let (mock, _h) = MockLoadedModel::new(vec![Ok(response)]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+
+    let outcome = session.run_turn("hi").unwrap();
+    assert_eq!(outcome.tool_calls.len(), 1);
+    assert!(
+        matches!(&outcome.tool_calls[0].result, ToolCallResult::Unroutable(_)),
+        "{:?}",
+        outcome.tool_calls[0].result
+    );
+}
+
+#[test]
+fn run_turn_records_denied_tool_call_without_short_circuiting() {
+    // Model picks a tool the manifest doesn't allow — policy denies,
+    // ledger gets a Violation, driver records Denied and returns
+    // normally.
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    let response = InferResponse {
+        reasoning: String::new(),
+        tool_calls: vec![ToolCall {
+            // weather-mcp__delete is not in allowed_tools.
+            name: "weather-mcp__delete".to_string(),
+            arguments: serde_json::Value::Null,
+        }],
+        assistant_text: None,
+    };
+    let (mock, _h) = MockLoadedModel::new(vec![Ok(response)]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+
+    let outcome = session.run_turn("delete it").unwrap();
+    assert_eq!(outcome.tool_calls.len(), 1);
+    match &outcome.tool_calls[0].result {
+        ToolCallResult::Denied(reason) => {
+            assert!(reason.contains("not in allowed_tools"), "{reason}");
+        }
+        other => panic!("expected Denied, got {other:?}"),
+    }
+
+    let _ = session.shutdown().unwrap();
+    let ledger = std::fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+    assert!(
+        ledger.contains("violation"),
+        "ledger should have a Violation entry: {ledger}"
+    );
+}

--- a/crates/llama-backend/Cargo.toml
+++ b/crates/llama-backend/Cargo.toml
@@ -17,6 +17,18 @@ workspace = true
 # bump is an explicit, reviewed change to this number.
 llama-cpp-2 = "=0.1.145"
 thiserror = "1"
+# The Backend / LoadedModel traits + chat-time types live in
+# `aegis-inference-engine` so the runtime build path stays clear of
+# llama.cpp. Per LLM-B / ADR-014.
+aegis-inference-engine = { path = "../inference-engine" }
+# `chat.rs` serializes tool catalogs as JSON for the OpenAI-compatible
+# chat template path and parses tool-call blocks from raw model output.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"
+# Real-model end-to-end test in `tests/run_turn_real_model.rs` boots a
+# full `aegis_inference_engine::Session` against a live GGUF — needs
+# the local-CA helper for SVID issuance.
+aegis-identity = { path = "../identity" }

--- a/crates/llama-backend/src/chat.rs
+++ b/crates/llama-backend/src/chat.rs
@@ -1,0 +1,394 @@
+//! `LlamaCppBackend` — the llama.cpp impl of [`aegis_inference_engine::Backend`].
+//!
+//! Per LLM-B / [issue #71](https://github.com/tosin2013/aegis-node/issues/71)
+//! and ADR-014 §"Decision item 3". The trait + chat-time types
+//! ([`InferRequest`], [`ToolCall`], etc.) live in
+//! `aegis-inference-engine` so the runtime trust boundary doesn't
+//! drag llama.cpp's C++ surface; this module is the only place that
+//! bridges the two.
+//!
+//! Scope:
+//! - Format incoming [`InferRequest`] messages + tools through the
+//!   GGUF's bundled chat template.
+//! - Run the prompt through [`Session::infer`] (LLM-A's wrapper).
+//! - Parse `<tool_call>{...}</tool_call>` JSON blocks out of the raw
+//!   output (the convention Qwen2.5 and most modern instruct models
+//!   emit).
+//!
+//! Out of scope here:
+//! - Determinism knobs — LLM-C ([#72](https://github.com/tosin2013/aegis-node/issues/72))
+//!   wires seed / temperature / top-p / top-k / repeat-penalty. Until
+//!   then, sampling is greedy at temperature 0.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use aegis_inference_engine::{
+    Backend as RuntimeBackend, BackendError, BackendErrorKind, InferRequest, InferResponse,
+    LoadedModel, ToolCall, ToolDecl,
+};
+use llama_cpp_2::model::LlamaChatMessage;
+use serde::Deserialize;
+
+use crate::{Backend as LlamaBackendHandle, LlamaError, Model, Session, SessionOptions};
+
+/// llama.cpp implementation of [`aegis_inference_engine::Backend`].
+/// Wraps an LLM-A [`crate::Backend`] (the FFI handle) and produces
+/// [`LlamaCppLoadedModel`]s on demand.
+pub struct LlamaCppBackend {
+    backend: Arc<LlamaBackendHandle>,
+    options: SessionOptions,
+}
+
+impl LlamaCppBackend {
+    /// Construct a new `LlamaCppBackend` around an already-initialized
+    /// [`crate::Backend`]. Callers create the FFI handle once per
+    /// process (see [`crate::Backend::init`]) and share it via `Arc`.
+    pub fn new(backend: Arc<LlamaBackendHandle>, options: SessionOptions) -> Self {
+        Self { backend, options }
+    }
+}
+
+impl std::fmt::Debug for LlamaCppBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlamaCppBackend")
+            .field("options", &self.options)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RuntimeBackend for LlamaCppBackend {
+    fn load(&self, model_path: &Path) -> Result<Box<dyn LoadedModel>, BackendError> {
+        let model = Model::load(self.backend.clone(), model_path).map_err(map_err)?;
+        Ok(Box::new(LlamaCppLoadedModel {
+            model,
+            options: self.options.clone(),
+        }))
+    }
+}
+
+/// llama.cpp implementation of [`LoadedModel`]. Owns the loaded
+/// weights; opens a fresh inference [`Session`] on each `infer` call
+/// so KV-cache state doesn't leak between turns.
+pub struct LlamaCppLoadedModel {
+    model: Model,
+    options: SessionOptions,
+}
+
+impl std::fmt::Debug for LlamaCppLoadedModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlamaCppLoadedModel")
+            .field("options", &self.options)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LoadedModel for LlamaCppLoadedModel {
+    fn infer(&mut self, request: InferRequest) -> Result<InferResponse, BackendError> {
+        // Resolve the GGUF's bundled chat template. Models without a
+        // template (rare in 2026 — most instruct GGUFs ship one) get
+        // a flat fallback that just concatenates roles + content.
+        let prompt = match self.model.inner_chat_template() {
+            Some(tmpl) => apply_chat_template(&self.model, &tmpl, &request)?,
+            None => fallback_flat_prompt(&request),
+        };
+
+        let mut session = Session::new(&self.model, self.options.clone()).map_err(map_err)?;
+        let raw = session.infer(&prompt).map_err(map_err)?;
+        Ok(parse_response(&raw))
+    }
+}
+
+/// Format `request.messages` + `request.tools` through the GGUF's chat
+/// template, asking the model to predict the assistant turn.
+fn apply_chat_template(
+    model: &Model,
+    tmpl: &llama_cpp_2::model::LlamaChatTemplate,
+    request: &InferRequest,
+) -> Result<String, BackendError> {
+    let messages: Vec<LlamaChatMessage> = request
+        .messages
+        .iter()
+        .map(|m| {
+            LlamaChatMessage::new(m.role.as_str().to_string(), m.content.clone()).map_err(|e| {
+                BackendError::new(BackendErrorKind::Tokenization, format!("chat message: {e}"))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if request.tools.is_empty() {
+        // Plain chat-template apply — tools-disabled path.
+        model
+            .inner
+            .apply_chat_template(tmpl, &messages, true)
+            .map_err(|e| {
+                BackendError::new(
+                    BackendErrorKind::Tokenization,
+                    format!("apply_chat_template: {e}"),
+                )
+            })
+    } else {
+        // OpenAI-compatible tools surface. We pass tools as JSON; the
+        // template rendering injects them per the model's convention
+        // (Qwen2.5 emits `<tools>...</tools>` in the system prompt and
+        // expects responses inside `<tool_call>...</tool_call>`).
+        let tools_json = serialize_tools(&request.tools)?;
+        model
+            .inner
+            .apply_chat_template_with_tools_oaicompat(
+                tmpl,
+                &messages,
+                Some(&tools_json),
+                None,
+                /* add_generation_prompt: */ true,
+            )
+            .map(|out| out.prompt)
+            .map_err(|e| {
+                BackendError::new(
+                    BackendErrorKind::Tokenization,
+                    format!("apply_chat_template_with_tools_oaicompat: {e}"),
+                )
+            })
+    }
+}
+
+fn serialize_tools(tools: &[ToolDecl]) -> Result<String, BackendError> {
+    // OpenAI tools shape:
+    //   [{"type":"function","function":{"name":..,"description":..,"parameters":..}}]
+    let arr: Vec<serde_json::Value> = tools
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.arguments_schema,
+                }
+            })
+        })
+        .collect();
+    serde_json::to_string(&arr).map_err(|e| {
+        BackendError::new(
+            BackendErrorKind::Tokenization,
+            format!("serialize tool catalog: {e}"),
+        )
+    })
+}
+
+/// Last-resort prompt format for a model without a chat template —
+/// roles inlined, no special tokens. Most modern GGUFs ship a
+/// template; this exists so a malformed model doesn't break the API.
+fn fallback_flat_prompt(request: &InferRequest) -> String {
+    let mut out = String::new();
+    for m in &request.messages {
+        out.push_str(m.role.as_str());
+        out.push_str(": ");
+        out.push_str(&m.content);
+        out.push('\n');
+    }
+    out.push_str("assistant: ");
+    out
+}
+
+/// Parse the model's raw output into reasoning / tool calls /
+/// assistant text. Tool calls are extracted from
+/// `<tool_call>{...}</tool_call>` JSON blocks (the convention Qwen2.5
+/// and most modern instruct-with-tools models emit). Anything outside
+/// those blocks is treated as the assistant's reasoning + final
+/// message.
+pub(crate) fn parse_response(raw: &str) -> InferResponse {
+    const OPEN: &str = "<tool_call>";
+    const CLOSE: &str = "</tool_call>";
+
+    let mut reasoning = String::new();
+    let mut tool_calls = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(start) = raw[cursor..].find(OPEN) {
+        let abs_start = cursor + start;
+        // Anything before the `<tool_call>` is reasoning.
+        reasoning.push_str(&raw[cursor..abs_start]);
+
+        let body_start = abs_start + OPEN.len();
+        let Some(close_rel) = raw[body_start..].find(CLOSE) else {
+            // Unterminated `<tool_call>` — treat the rest as plain
+            // text. The next turn's request can show the model the
+            // problem.
+            reasoning.push_str(&raw[abs_start..]);
+            cursor = raw.len();
+            break;
+        };
+        let body = &raw[body_start..body_start + close_rel];
+
+        if let Ok(parsed) = serde_json::from_str::<ToolCallBody>(body.trim()) {
+            tool_calls.push(ToolCall {
+                name: parsed.name,
+                arguments: parsed.arguments.unwrap_or(serde_json::Value::Null),
+            });
+        } else {
+            // Malformed JSON inside the block — preserve the raw
+            // content as reasoning so the auditor can see what the
+            // model emitted.
+            reasoning.push_str(&raw[abs_start..body_start + close_rel + CLOSE.len()]);
+        }
+
+        cursor = body_start + close_rel + CLOSE.len();
+    }
+    reasoning.push_str(&raw[cursor..]);
+
+    // Trim trailing whitespace from reasoning so the ledger entry is
+    // stable across runs (model often emits a final newline).
+    let reasoning_trimmed = reasoning.trim().to_string();
+
+    let assistant_text = if !reasoning_trimmed.is_empty() {
+        Some(reasoning_trimmed.clone())
+    } else {
+        None
+    };
+
+    InferResponse {
+        reasoning: reasoning_trimmed,
+        tool_calls,
+        assistant_text,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallBody {
+    name: String,
+    #[serde(default)]
+    arguments: Option<serde_json::Value>,
+}
+
+/// Map an LLM-A `LlamaError` to the runtime-facing `BackendError`.
+fn map_err(e: LlamaError) -> BackendError {
+    let (kind, detail) = match &e {
+        LlamaError::BackendAlreadyInitialized => {
+            (BackendErrorKind::BackendAlreadyInitialized, e.to_string())
+        }
+        LlamaError::BackendInitFailed(_) => (BackendErrorKind::BackendInitFailed, e.to_string()),
+        LlamaError::ModelFileUnreadable { .. } => {
+            (BackendErrorKind::ModelFileUnreadable, e.to_string())
+        }
+        LlamaError::ModelLoadFailed { .. } => (BackendErrorKind::ModelLoadFailed, e.to_string()),
+        LlamaError::SessionInitFailed(_) => (BackendErrorKind::SessionInitFailed, e.to_string()),
+        LlamaError::TokenizationFailed(_) => (BackendErrorKind::Tokenization, e.to_string()),
+        LlamaError::InferenceFailed(_) => (BackendErrorKind::Inference, e.to_string()),
+        LlamaError::InvalidUtf8(_) => (BackendErrorKind::InvalidUtf8, e.to_string()),
+        LlamaError::InvalidConfig(_) => (BackendErrorKind::InvalidConfig, e.to_string()),
+    };
+    BackendError::new(kind, detail)
+}
+
+// --- Internal Model accessors ---------------------------------------
+//
+// Bridges `Model` (private about its inner llama-cpp-2 types) and
+// the LLM-B impl which needs to read the chat template.
+
+impl Model {
+    /// Resolve the GGUF's bundled chat template, if any. `None` means
+    /// the model didn't ship a template; callers fall back to a flat
+    /// role-prefixed format. Best-effort: parser failures also return
+    /// `None` rather than escalate.
+    pub(crate) fn inner_chat_template(&self) -> Option<llama_cpp_2::model::LlamaChatTemplate> {
+        self.inner.chat_template(None).ok()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use aegis_inference_engine::{ChatMessage, ChatRole};
+
+    #[test]
+    fn parse_response_with_no_tool_call_is_pure_reasoning() {
+        let parsed = parse_response("Paris is the capital of France.");
+        assert_eq!(parsed.reasoning, "Paris is the capital of France.");
+        assert!(parsed.tool_calls.is_empty());
+        assert_eq!(
+            parsed.assistant_text.as_deref(),
+            Some("Paris is the capital of France.")
+        );
+    }
+
+    #[test]
+    fn parse_response_extracts_single_tool_call_block() {
+        let raw = r#"Looking up weather. <tool_call>{"name":"weather.get","arguments":{"city":"Paris"}}</tool_call>"#;
+        let parsed = parse_response(raw);
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].name, "weather.get");
+        assert_eq!(
+            parsed.tool_calls[0].arguments,
+            serde_json::json!({"city":"Paris"})
+        );
+        assert_eq!(parsed.reasoning, "Looking up weather.");
+    }
+
+    #[test]
+    fn parse_response_extracts_multiple_tool_calls() {
+        let raw = r#"<tool_call>{"name":"a","arguments":{}}</tool_call><tool_call>{"name":"b","arguments":{"x":1}}</tool_call>"#;
+        let parsed = parse_response(raw);
+        assert_eq!(parsed.tool_calls.len(), 2);
+        assert_eq!(parsed.tool_calls[0].name, "a");
+        assert_eq!(parsed.tool_calls[1].name, "b");
+        assert_eq!(parsed.reasoning, "");
+        assert_eq!(parsed.assistant_text, None);
+    }
+
+    #[test]
+    fn parse_response_keeps_malformed_tool_call_in_reasoning() {
+        let raw = "before <tool_call>not json</tool_call> after";
+        let parsed = parse_response(raw);
+        assert!(parsed.tool_calls.is_empty(), "{parsed:?}");
+        assert!(
+            parsed.reasoning.contains("not json"),
+            "{}",
+            parsed.reasoning
+        );
+    }
+
+    #[test]
+    fn parse_response_handles_unterminated_tool_call() {
+        let raw = r#"<tool_call>{"name":"a"#;
+        let parsed = parse_response(raw);
+        assert!(parsed.tool_calls.is_empty());
+        assert!(parsed.reasoning.contains("<tool_call>"));
+    }
+
+    #[test]
+    fn fallback_flat_prompt_includes_assistant_marker() {
+        let req = InferRequest {
+            messages: vec![ChatMessage {
+                role: ChatRole::User,
+                content: "hello".to_string(),
+            }],
+            tools: vec![],
+        };
+        let prompt = fallback_flat_prompt(&req);
+        assert!(prompt.contains("user: hello"), "{prompt}");
+        assert!(prompt.ends_with("assistant: "), "{prompt}");
+    }
+
+    #[test]
+    fn serialize_tools_matches_openai_function_shape() {
+        let tools = vec![ToolDecl {
+            name: "fs__read".to_string(),
+            description: "read a file".to_string(),
+            arguments_schema: serde_json::json!({
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"]
+            }),
+        }];
+        let s = serialize_tools(&tools).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v[0]["type"], "function");
+        assert_eq!(v[0]["function"]["name"], "fs__read");
+        assert_eq!(
+            v[0]["function"]["parameters"]["properties"]["path"]["type"],
+            "string"
+        );
+    }
+}

--- a/crates/llama-backend/src/lib.rs
+++ b/crates/llama-backend/src/lib.rs
@@ -48,6 +48,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use std::path::Path;
+use std::sync::Arc;
 
 use llama_cpp_2::context::params::LlamaContextParams;
 use llama_cpp_2::llama_backend::LlamaBackend;
@@ -56,6 +57,9 @@ use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::{AddBos, LlamaModel};
 use llama_cpp_2::sampling::LlamaSampler;
 use thiserror::Error;
+
+pub mod chat;
+pub use chat::{LlamaCppBackend, LlamaCppLoadedModel};
 
 /// All errors the wrapper surfaces. Each variant maps to one phase of
 /// `Model::load` / `Session::infer` so an operator can see exactly
@@ -165,30 +169,40 @@ impl Backend {
     }
 }
 
-/// A loaded GGUF model. Borrows `&Backend`, so the backend is
-/// statically guaranteed to outlive the model. On `Drop`, llama.cpp
-/// releases the model weights — that's `LlamaModel::Drop`'s job, which
-/// we just wrap.
-pub struct Model<'b> {
+/// A loaded GGUF model. Owns an `Arc<Backend>` so it has no lifetime
+/// parameter — required for `Box<dyn LoadedModel>` in the LLM-B trait
+/// (the dyn-trait object can't carry a Rust lifetime). The Arc is
+/// cheap to clone and ensures the backend stays alive as long as
+/// any model derived from it.
+///
+/// On `Drop`, llama.cpp releases the model weights — that's
+/// `LlamaModel::Drop`'s job, which we just wrap.
+pub struct Model {
     inner: LlamaModel,
-    /// The `Backend` reference that authorized this model load. Held
-    /// only for the lifetime tie; we never read it again.
-    _backend: &'b Backend,
+    /// Shared `Backend` ownership. The Arc is the only thing keeping
+    /// the backend alive when callers drop their original `Backend`
+    /// handle.
+    backend: Arc<Backend>,
 }
 
-impl std::fmt::Debug for Model<'_> {
+impl std::fmt::Debug for Model {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Model").finish_non_exhaustive()
     }
 }
 
-impl<'b> Model<'b> {
+impl Model {
     /// Load a GGUF model from disk.
+    ///
+    /// `backend` is taken by `Arc` so the resulting `Model` is
+    /// `'static` and can be moved into a `Box<dyn LoadedModel>`. Clone
+    /// the Arc cheaply if you need the backend handle to outlive any
+    /// individual model.
     ///
     /// Errors are mapped to typed variants so the caller (and the F1
     /// boot path) sees exactly which gate refused: the file system,
     /// the GGUF parser, or context allocation.
-    pub fn load(backend: &'b Backend, path: &Path) -> Result<Self, LlamaError> {
+    pub fn load(backend: Arc<Backend>, path: &Path) -> Result<Self, LlamaError> {
         if !path.exists() {
             return Err(LlamaError::ModelFileUnreadable {
                 path: path.display().to_string(),
@@ -203,14 +217,11 @@ impl<'b> Model<'b> {
 
         // SAFETY-INVARIANT (delegated to llama-cpp-2):
         // `LlamaModel::load_from_file` requires a valid `&LlamaBackend`
-        // (held alive by the lifetime tie above) and a valid file
-        // path. It returns `Err` for any FFI / IO problem; we never
-        // unwrap here.
+        // (held alive by the Arc field below) and a valid file path.
+        // It returns `Err` for any FFI / IO problem; we never unwrap
+        // here.
         match LlamaModel::load_from_file(&backend.inner, path, &params) {
-            Ok(inner) => Ok(Self {
-                inner,
-                _backend: backend,
-            }),
+            Ok(inner) => Ok(Self { inner, backend }),
             Err(e) => Err(LlamaError::ModelLoadFailed {
                 path: path.display().to_string(),
                 detail: e.to_string(),
@@ -251,8 +262,8 @@ impl Default for SessionOptions {
 
 /// A single-shot inference session. Holds a llama.cpp context bound to
 /// `&Model`; on `Drop`, the context is released by `LlamaContext::Drop`.
-pub struct Session<'m, 'b> {
-    model: &'m Model<'b>,
+pub struct Session<'m> {
+    model: &'m Model,
     /// Shadow of [`SessionOptions::max_tokens`] — kept on the session
     /// so each `infer` call is bounded the same way.
     max_tokens: u32,
@@ -263,9 +274,9 @@ pub struct Session<'m, 'b> {
     context: llama_cpp_2::context::LlamaContext<'m>,
 }
 
-impl<'m, 'b> Session<'m, 'b> {
+impl<'m> Session<'m> {
     /// Open a fresh inference context against `model`.
-    pub fn new(model: &'m Model<'b>, options: SessionOptions) -> Result<Self, LlamaError> {
+    pub fn new(model: &'m Model, options: SessionOptions) -> Result<Self, LlamaError> {
         if options.max_tokens == 0 {
             return Err(LlamaError::InvalidConfig("max_tokens must be > 0"));
         }
@@ -285,7 +296,7 @@ impl<'m, 'b> Session<'m, 'b> {
         // don't unwrap.
         let context = model
             .inner
-            .new_context(&model._backend.inner, params)
+            .new_context(&model.backend.inner, params)
             .map_err(|e| LlamaError::SessionInitFailed(e.to_string()))?;
 
         // Greedy sampler — `temperature=0`, no top-k / top-p. LLM-C

--- a/crates/llama-backend/tests/run_turn_real_model.rs
+++ b/crates/llama-backend/tests/run_turn_real_model.rs
@@ -1,0 +1,111 @@
+//! End-to-end real-model test: LlamaCppBackend + Session::run_turn
+//! against a real GGUF, gated by `AEGIS_LLAMA_TEST_MODEL`.
+//!
+//! Mirrors the LLM-A smoke test's gating: `#[ignore]` by default,
+//! reads the model path from the env var. Validates the full chain
+//! (boot → backend.load → run_turn → infer → reasoning emission) end
+//! to end on a real model — the path that matters for Phase 2 demo
+//! recordings.
+//!
+//! Local invocation:
+//!
+//! ```bash
+//! AEGIS_LLAMA_TEST_MODEL=~/.cache/aegis/models/<sha>/blob.bin \
+//!   cargo test -p aegis-llama-backend --test run_turn_real_model -- --ignored
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aegis_inference_engine::{Backend as RuntimeBackend, BootConfig, Session};
+use aegis_llama_backend::{Backend, LlamaCppBackend, SessionOptions};
+
+const ENV_KEY: &str = "AEGIS_LLAMA_TEST_MODEL";
+
+fn fixture_path() -> Option<PathBuf> {
+    std::env::var_os(ENV_KEY).map(PathBuf::from)
+}
+
+#[test]
+#[ignore = "loads a real GGUF + boots a Session; set AEGIS_LLAMA_TEST_MODEL=<path>"]
+fn llama_cpp_backend_round_trips_a_run_turn_call() {
+    use aegis_identity::LocalCa;
+
+    let path = match fixture_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("[skipped] {ENV_KEY} not set");
+            return;
+        }
+    };
+    if !path.exists() {
+        eprintln!("[skipped] {} does not exist", path.display());
+        return;
+    }
+
+    // Stand up the FFI backend + LLM-B wrapper.
+    let llama = Arc::new(Backend::init().expect("backend init"));
+    let cpp_backend = LlamaCppBackend::new(
+        llama.clone(),
+        SessionOptions {
+            n_ctx: 1024,
+            max_tokens: 32,
+        },
+    );
+    let model = cpp_backend.load(&path).expect("load");
+
+    // Boot a Session with the same fixture as a model digest source.
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    LocalCa::init(ca_dir.path(), "session-boot.local").unwrap();
+
+    let manifest_path = dir.path().join("manifest.yaml");
+    std::fs::write(
+        &manifest_path,
+        r#"schemaVersion: "1"
+agent: { name: "real-model-turn", version: "1.0.0" }
+identity: { spiffeId: "spiffe://session-boot.local/agent/research/inst-001" }
+tools: {}
+"#,
+    )
+    .unwrap();
+
+    let cfg = BootConfig {
+        session_id: "session-real-turn".to_string(),
+        manifest_path,
+        // The test deliberately uses the same GGUF as the digest
+        // source — the wrapper hashes it via sha256_file, doesn't
+        // actually load it for inference (the LlamaCppBackend does).
+        model_path: path.clone(),
+        config_path: None,
+        chat_template_sidecar: None,
+        identity_dir: ca_dir.path().to_path_buf(),
+        workload_name: "research".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path: dir.path().join("ledger.jsonl"),
+    };
+    let session = Session::boot(cfg).expect("boot");
+    let mut session = session.with_loaded_model(model);
+
+    let outcome = session
+        .run_turn("In one short word, what is the capital of France?")
+        .expect("run_turn");
+
+    // Most modern instruct models will produce text on this prompt.
+    // Tool calls are zero (tools={}); we just check the reasoning
+    // wasn't empty.
+    eprintln!("[real-model] outcome: {outcome:?}");
+    assert!(
+        outcome.assistant_text.is_some() || !outcome.tool_calls.is_empty(),
+        "real-model run_turn produced neither reasoning nor tool calls: {outcome:?}"
+    );
+
+    let _ = session.shutdown().expect("shutdown");
+    let ledger = std::fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+    assert!(
+        ledger.contains("reasoning_step"),
+        "ledger should carry an F5 ReasoningStep entry: {ledger}"
+    );
+}

--- a/crates/llama-backend/tests/smoke.rs
+++ b/crates/llama-backend/tests/smoke.rs
@@ -27,6 +27,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use aegis_llama_backend::{Backend, LlamaError, Model, Session, SessionOptions};
 
@@ -39,13 +40,13 @@ fn fixture_path() -> Option<PathBuf> {
 #[test]
 fn missing_model_file_returns_typed_error() {
     let backend = match Backend::init() {
-        Ok(b) => b,
+        Ok(b) => Arc::new(b),
         Err(e) => {
             eprintln!("[skipped] backend init failed: {e}");
             return;
         }
     };
-    let err = Model::load(&backend, std::path::Path::new("/no/such/path.gguf")).unwrap_err();
+    let err = Model::load(backend, std::path::Path::new("/no/such/path.gguf")).unwrap_err();
     assert!(
         matches!(err, LlamaError::ModelFileUnreadable { .. }),
         "got {err:?}"
@@ -67,8 +68,8 @@ fn smoke_load_and_infer_one_turn() {
         return;
     }
 
-    let backend = Backend::init().expect("backend init");
-    let model = Model::load(&backend, &path).expect("model load");
+    let backend = Arc::new(Backend::init().expect("backend init"));
+    let model = Model::load(backend, &path).expect("model load");
     let mut session = Session::new(
         &model,
         SessionOptions {


### PR DESCRIPTION
## Summary

Second sub-issue under the [llama.cpp umbrella (#69)](https://github.com/tosin2013/aegis-node/issues/69). Closes [LLM-B (#71)](https://github.com/tosin2013/aegis-node/issues/71).

Adds the abstraction layer the runtime sees and wires it through \`Session\`:

- **Trait + types** live in \`aegis-inference-engine::backend\` (not \`aegis-llama-backend\`). If inference-engine depended on llama-backend, \`rust.yml --exclude aegis-llama-backend\` would stop working — Cargo would build it transitively. The runtime owns the trait; the FFI crate provides the impl.
- **\`LlamaCppBackend\`** in \`aegis-llama-backend::chat\` formats messages via the GGUF's chat template (or OpenAI-compatible tools surface for tool-bearing turns) and parses \`<tool_call>{...}</tool_call>\` JSON blocks back into \`ToolCall\` values.
- **\`Session::run_turn(input)\`** drives one chat turn: build request → infer → emit F5 \`ReasoningStep\` → dispatch each \`ToolCall\` through the existing \`mediate_mcp_tool_call\` → return \`TurnOutcome\`.

## LLM-A refactor (precondition)

\`Model<'b>\` borrowed the \`Backend\` — incompatible with \`Box<dyn LoadedModel>\` (no lifetimes in trait objects). Refactored to \`Model\` owning \`Arc<Backend>\`. \`Session<'m>\` still borrows \`&Model\` (because \`LlamaContext<'m>\` does); a fresh \`Session\` is created per \`infer\` call so KV-cache state doesn't leak between turns.

## Test plan

- [x] **Headline integration test** asserts the ledger pair: \`reasoning_step\` precedes \`access\` for one MCP tool dispatch (issue #71's E2E acceptance criterion).
- [x] Unroutable tool name doesn't short-circuit; recorded as \`ToolCallResult::Unroutable\`.
- [x] Denied tool call records \`ToolCallResult::Denied\` and writes a Violation entry, doesn't propagate.
- [x] Six chat-parser unit tests for the \`<tool_call>\` block extraction edge cases.
- [x] Real-model E2E test (\`#[ignore]\`'d behind \`AEGIS_LLAMA_TEST_MODEL\`) boots a Session against a real GGUF and asserts the F5 entry shows up.
- [x] Local \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Local \`cargo fmt --all -- --check\` clean.

## Out of scope (deferred)

- **Determinism knobs** (\`seed\`, \`temperature\`, etc.) → [LLM-C (#72)](https://github.com/tosin2013/aegis-node/issues/72). Sampling stays greedy at temperature 0 here.
- **Filesystem / network / exec dispatch** from \`run_turn\` — only MCP tools route today. Different naming scheme + different policy paths; the follow-up will add dispatch alongside a richer name format.
- **Real-model CI fixture caching** — same gating as LLM-A's smoke test; lands in a separate PR once \`actions/cache\` plumbing for the Qwen blob is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)