### PR TITLE
docs(adr-020): per-demo model selection table + Demo 7 (multimodal vision agent, #100)

### DIFF
--- a/docs/adrs/020-recorded-demo-program.md
+++ b/docs/adrs/020-recorded-demo-program.md
@@ -129,6 +129,33 @@ which caps the model size we can use without the recording feeling slow.
    close. The ADR is the long-lived artifact; the recordings ship in
    v0.9.x or early v1.0.0 alongside the marketing site refresh.
 
+8. **Model selection per demo** (amended 2026-05-01 alongside
+   [ADR-023](023-litertlm-as-second-inference-backend.md)). The
+   pinned-Qwen decision in item 4 above is no longer one-size-fits-
+   all once the LiteRT-LM second backend lands ([#98](https://github.com/tosin2013/aegis-node/issues/98)).
+   Each demo picks the model whose strengths match its narrative:
+
+   | # | Demo | Pinned model | Backend | Reason |
+   |---|---|---|---|---|
+   | 1 | MCP, sandboxed twice | Qwen2.5-1.5B-Q4_K_M | llama | (blocked on [#91](https://github.com/tosin2013/aegis-node/issues/91); choice revisited when unblocked) |
+   | 2 | Read-only research | **Gemma 4 E4B** | **litertlm** | Bigger model produces more useful "summarize" output; enterprise-clean origin matters for the canonical "agent reads docs" pitch |
+   | 3 | Code review + time-bounded write | **Gemma 4 E4B** | **litertlm** | Code understanding + agentic tool calls favor a 4B Western-origin model; F7 timer demo leans on credible review output |
+   | 4 | Customer-support + approval gate | **Gemma 4 E2B** | **litertlm** | Customer-support narrative reads better with realistic agent voice; E2B keeps the ~30-second budget |
+   | 5 | **Tampered model halts** | **Qwen2.5-1.5B-Q4_K_M** | **llama** | Mechanical F1 IdentityRebind demo. Model quality irrelevant; Qwen 1.5B is faster (3-second turn) and the existing GIF (PR [#93](https://github.com/tosin2013/aegis-node/pull/93)) works. Don't re-render. |
+   | 6 | Egress containment | Qwen2.5-1.5B-Q4_K_M | llama | F6 deny-by-default is mechanical; same reasoning as Demo 5 |
+   | **7** | **Multimodal vision agent** ([#100](https://github.com/tosin2013/aegis-node/issues/100)) | **Gemma 4 E4B (multimodal)** | **litertlm** | Genuinely new capability — agent reads a screenshot, F2 + F6 gate the side-effects. No competing runtime can show this. |
+
+   Mechanical demos (5, 6) stay on the original Qwen pin so re-renders are
+   cheap and `make demos` reproducibility is preserved through the LiteRT
+   transition. Demos that lean on agent reasoning quality (2, 3, 4) move
+   to Gemma 4 once the LiteRT-LM pipeline is live. Demo 7 is the program's
+   first multimodal scenario and depends on multipart `ChatMessage` +
+   `aegis run --image` plumbing tracked in [#100](https://github.com/tosin2013/aegis-node/issues/100).
+
+   The published OCI artifact pin in §"Pinned model" below stays
+   authoritative for Qwen-based demos; Gemma 4's pin lands in the
+   first PR that publishes the artifact ([LiteRT-C / #97](https://github.com/tosin2013/aegis-node/issues/97)).
+
 ## Why these decisions
 
 - **Why VHS specifically.** VHS is the de-facto standard for terminal


### PR DESCRIPTION
## Summary

Amends ADR-020 §"Decision" with a per-demo model-selection table and files [#100 (Demo 7)](https://github.com/tosin2013/aegis-node/issues/100) — the first multimodal scenario, which Gemma 4 unlocks and llama.cpp / Qwen 1.5B can't do at all.

## Per-demo picks (rationale: model fit, not blanket Qwen)

| # | Demo | Pinned model | Backend | Reason |
|---|---|---|---|---|
| 1 | MCP, sandboxed twice | Qwen 1.5B-Q4 | llama | (blocked on #91) |
| 2 | Read-only research | **Gemma 4 E4B** | **litertlm** | Bigger model = useful "summarize" output; enterprise-clean origin |
| 3 | Code review + time-bounded write | **Gemma 4 E4B** | **litertlm** | Code understanding + tool calls favor 4B Western model |
| 4 | Customer-support + approval gate | **Gemma 4 E2B** | **litertlm** | Realistic agent voice; E2B keeps the ~30s budget |
| 5 | Tampered model halts | Qwen 1.5B-Q4 | llama | Mechanical F1 demo; ship as-is (PR #93). |
| 6 | Egress containment | Qwen 1.5B-Q4 | llama | Mechanical F6 deny-by-default |
| **7** (new, #100) | **Multimodal vision agent** | **Gemma 4 E4B (multimodal)** | **litertlm** | Genuinely new — agent reads a screenshot, F2 + F6 gate side-effects |

Mechanical demos (5, 6) stay on Qwen so re-renders are cheap and the existing Demo 5 GIF doesn't need re-rendering. Demos that lean on agent reasoning quality (2, 3, 4) move to Gemma 4 once the LiteRT-LM pipeline is live (#95/96/97).

## Demo 7 (#100) outline

Agent receives a user message + a screenshot:

> *"Describe what you see in this screenshot. Don't share it externally."*

Three calls in one turn:

1. `filesystem__read` on the screenshot path → mediator allows; F4 Access entry.
2. Pure model reasoning about content (no tool call).
3. **Anti-pattern**: model attempts `network__connect` to upload the image bytes → mediator **denies** under deny-by-default network policy + F6 attestation captures the attempt.

The story: **multimodal in, security gates intact**.

Demo 7 depends on runtime work beyond LiteRT-A/B/C:
- Multipart `ChatMessage` shape (text + image parts; backwards-compat preserved by defaulting to a text-only path)
- `aegis run --image <path>` plumbing
- LlamaCppBackend rejects multimodal parts with a typed error; LiteRtLmBackend accepts them

Both tracked in #100's hard-requirements list.

## Files changed

- `docs/adrs/020-recorded-demo-program.md` — new §"Decision" item 8 with the per-demo table.

## Test plan

- [x] Schema check (no schema changes)
- [x] markdown renders correctly with the new table
- [x] Issue #100 filed with full requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)