### PR TITLE
fix(ci): pull Git LFS on LiteRT-LM upstream checkout (#107 followup)

### DIFF
--- a/.github/workflows/litertlm-runtime-publish.yml
+++ b/.github/workflows/litertlm-runtime-publish.yml
@@ -79,6 +79,15 @@ jobs:
           # We need to capture the resolved commit SHA for the OCI
           # annotation; fetch enough history to read it.
           fetch-depth: 1
+          # `prebuilt/<platform>/libGemmaModelConstraintProvider.so`
+          # (vendored binary used by the constrained-decoding feature
+          # — Gemma's tool-call grammar enforcer) is Git-LFS-tracked.
+          # Without LFS, the checkout writes a pointer file (~130
+          # bytes of text starting with `version https://git-lfs.../v1`)
+          # which lld then misreads as a linker version script,
+          # exploding the build with `unknown directive: version`.
+          # First-dispatch postmortem: run 25221781498.
+          lfs: true
 
       - name: Resolve upstream commit SHA
         id: upstream


### PR DESCRIPTION
## Summary

First dispatch of `litertlm-runtime-publish.yml` ([run 25221781498](https://github.com/tosin2013/aegis-node/actions/runs/25221781498)) failed at the linking step with:

```
ld.lld: error: bazel-out/.../libGemmaModelConstraintProvider.so:1: unknown directive: version
clang: error: linker command failed with exit code 1
```

## Root cause

`prebuilt/linux_x86_64/libGemmaModelConstraintProvider.so` (the vendored binary backing `runtime/components/constrained_decoding/gemma_model_constraint_provider_shared_lib` — Gemma's tool-call grammar enforcer) is **Git-LFS-tracked** in the upstream LiteRT-LM repo. `actions/checkout@v4` without `lfs: true` writes the ~130-byte LFS pointer file to disk instead of the actual ELF binary. Pointer files start with `version https://git-lfs.../v1`, which `lld` misreads as a linker version script — hence the cryptic "unknown directive: version" 30 minutes into the Bazel build.

## Fix

Add `lfs: true` to the upstream-checkout step. One-line change.

## Test plan

- Re-dispatch `litertlm-runtime-publish.yml` against `v0.10.2` after this merges. Expect: full Bazel build succeeds, `libaegis_litertlm_engine_cpu.so` lands at the expected path, the OCI artifact gets pushed + signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)