### PR TITLE
docs(adr-023): pin first published LiteRT-LM runtime artifact digest

### DIFF
--- a/docs/adrs/023-litertlm-as-second-inference-backend.md
+++ b/docs/adrs/023-litertlm-as-second-inference-backend.md
@@ -268,6 +268,32 @@ Linux x86_64 binaries used by the Aegis runtime. The same supply-chain
 machinery that publishes signed model artifacts publishes signed
 runtime artifacts.
 
+#### Published artifact (first pin)
+
+The [`litertlm-runtime-publish.yml`](../../.github/workflows/litertlm-runtime-publish.yml)
+workflow's first successful run ([run 25223166187](https://github.com/tosin2013/aegis-node/actions/runs/25223166187),
+post the LFS-checkout fix in PR #110) shipped:
+
+- **Reference:** `ghcr.io/tosin2013/aegis-node-runtime/litertlm-linux-amd64:latest`
+- **Manifest digest:** `sha256:75ac8138f882d0aac93541d1c354863910cdb712620712f97e3d761a8fe1090d`
+- **`.so` SHA-256:** `216451eb3726b3326dbadbdc08ec2eda44d45d3035167d8613f45e08eb80a012`
+- **`c/engine.h` SHA-256:** `cacee1d18aa9e2c22aeb8da2fc1576b25c03d7104e5319a0352c64a57bb691e9`
+- **Upstream:** `google-ai-edge/LiteRT-LM` tag `v0.10.2`, commit `476c0bd49429569b2a4685c4db7a657d531d4b6e`
+- **Bazel target:** `//c:engine_cpu_shared` (the Aegis overlay rule on top of `engine_cpu`'s `cc_library`)
+- **Bazel version:** 7.6.1
+- **glibc target:** 2.39 (ubuntu-latest at build time)
+- **Platform / kind:** linux/amd64 / cpu-only
+- **Signed by:** `litertlm-runtime-publish.yml` workflow via Sigstore keyless
+
+LiteRT-A's `litertlm-sys/build.rs` pins this digest. Verified
+end-to-end:
+
+```bash
+cosign verify ghcr.io/tosin2013/aegis-node-runtime/litertlm-linux-amd64@sha256:75ac8138f882d0aac93541d1c354863910cdb712620712f97e3d761a8fe1090d \
+  --certificate-identity-regexp '^https://github\.com/tosin2013/aegis-node/\.github/workflows/litertlm-runtime-publish\.yml@.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
 **New OCI artifact-type:**
 `application/vnd.aegis-node.litertlm-runtime.v1`. Same cosign keyless
 identity (the publish workflow's GitHub OIDC token), same `aegis pull`


### PR DESCRIPTION
## Summary

[`litertlm-runtime-publish.yml`](https://github.com/tosin2013/aegis-node/blob/main/.github/workflows/litertlm-runtime-publish.yml)'s first successful run ([run 25223166187](https://github.com/tosin2013/aegis-node/actions/runs/25223166187), post the LFS-checkout fix in #110) shipped the first signed LiteRT-LM Linux x86_64 runtime artifact. ADR-023's §Update now carries the pinned reference for LiteRT-A's `litertlm-sys/build.rs` to consume.

## Pinned reference

```
ghcr.io/tosin2013/aegis-node-runtime/litertlm-linux-amd64@sha256:75ac8138f882d0aac93541d1c354863910cdb712620712f97e3d761a8fe1090d
```

| Field | Value |
|---|---|
| `.so` SHA-256 | `216451eb3726b3326dbadbdc08ec2eda44d45d3035167d8613f45e08eb80a012` |
| `c/engine.h` SHA-256 | `cacee1d18aa9e2c22aeb8da2fc1576b25c03d7104e5319a0352c64a57bb691e9` |
| Upstream | `google-ai-edge/LiteRT-LM` tag `v0.10.2` (commit `476c0bd49429569b2a4685c4db7a657d531d4b6e`) |
| Bazel target | `//c:engine_cpu_shared` (Aegis overlay on top of `engine_cpu`) |
| Bazel version | 7.6.1 |
| glibc target | 2.39 (ubuntu-latest at build time) |
| Platform | linux/amd64, cpu-only |

End-to-end verification:

```bash
cosign verify ghcr.io/tosin2013/aegis-node-runtime/litertlm-linux-amd64@sha256:75ac8138f882d0aac93541d1c354863910cdb712620712f97e3d761a8fe1090d \
  --certificate-identity-regexp '^https://github\.com/tosin2013/aegis-node/\.github/workflows/litertlm-runtime-publish\.yml@.*$' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

→ ✅ signature valid; transparency-log entry verified.

## Test plan

- [x] `cosign verify` passes against the workflow's GitHub OIDC identity
- [x] `oras manifest fetch` returns the manifest with all 11 expected annotations (upstream commit/tag, Bazel target/version, glibc, runtime so/header SHAs, platform, kind)
- [x] No code changes — ADR pin only

🤖 Generated with [Claude Code](https://claude.com/claude-code)