### PR TITLE
feat(litertlm): LiteRT-B — Backend trait impl + aegis run --backend (ADR-023, #96)

### DIFF
--- a/.github/workflows/litertlm.yml
+++ b/.github/workflows/litertlm.yml
@@ -96,3 +96,16 @@ jobs:
         run: |
           cargo test --package aegis-litertlm-sys --all-targets
           cargo test --package aegis-litertlm-backend --all-targets
+
+      # Per LiteRT-B (#96), the CLI's `--prompt` path gates LiteRT-LM
+      # behind `aegis-cli`'s `litertlm` Cargo feature. Build + clippy
+      # the CLI in that mode here too — keeps the feature flag honest
+      # on every change to the workspace pin or the CLI.
+      - name: Build aegis-cli with --features litertlm
+        run: cargo build --package aegis-cli --features litertlm --all-targets
+
+      - name: Clippy aegis-cli with --features litertlm
+        run: cargo clippy --package aegis-cli --features litertlm --all-targets -- -D warnings
+
+      - name: Test aegis-cli with --features litertlm
+        run: cargo test --package aegis-cli --features litertlm --all-targets

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,14 +18,19 @@ name = "aegis"
 path = "src/main.rs"
 
 [features]
-# By default the CLI builds without llama.cpp — `aegis run --prompt`
-# is unavailable, but `aegis run --script` and every other subcommand
-# work and the workspace `cargo build --workspace` (which `rust.yml`
-# uses) doesn't pay the ~50s cmake/llama.cpp build cost. Build with
-# `--features llama` to enable model-driven mode (per ADR-014). The
-# dedicated `llama.yml` CI job exercises this path.
+# By default the CLI builds without any inference backend —
+# `aegis run --prompt` is unavailable, but `aegis run --script` and
+# every other subcommand work and the workspace
+# `cargo build --workspace` (which `rust.yml` uses) doesn't pay the
+# ~50s cmake/llama.cpp build cost or the LiteRT-LM `.so`
+# materialization. Build with `--features llama` for the
+# GGUF / llama.cpp backend (per ADR-014; the `llama.yml` CI job
+# exercises it) or `--features litertlm` for the LiteRT-LM backend
+# (per ADR-023; the `litertlm.yml` CI job exercises it). Both can be
+# enabled together; `--backend <llama|litertlm>` picks at run time.
 default = []
 llama = ["dep:aegis-llama-backend"]
+litertlm = ["dep:aegis-litertlm-backend"]
 
 [dependencies]
 aegis-approval-gate = { path = "../approval-gate" }
@@ -33,6 +38,7 @@ aegis-identity = { path = "../identity" }
 aegis-inference-engine = { path = "../inference-engine" }
 aegis-ledger-writer = { path = "../ledger-writer" }
 aegis-llama-backend = { path = "../llama-backend", optional = true }
+aegis-litertlm-backend = { path = "../litertlm-backend", optional = true }
 aegis-policy = { path = "../policy" }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -32,8 +32,27 @@ use std::path::{Path, PathBuf};
 use aegis_inference_engine::{BootConfig, Error as RtError, Session};
 use aegis_policy::NetworkProto;
 use anyhow::{Context, Result};
-use clap::Args;
+use clap::{Args, ValueEnum};
 use serde::Deserialize;
+
+/// Which inference backend `aegis run --prompt` uses for one
+/// model-driven turn. Both choices require their respective Cargo
+/// feature to be enabled at build time; selecting a backend whose
+/// feature is off bails with an explicit "rebuild with --features X"
+/// error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
+#[value(rename_all = "lowercase")]
+pub enum BackendKind {
+    /// llama.cpp + GGUF model files (per ADR-014). Default for
+    /// backwards compatibility — pre-LiteRT-B `aegis run --prompt`
+    /// always used llama.cpp.
+    #[default]
+    Llama,
+    /// LiteRT-LM + `.litertlm` model files (per ADR-023). Phase 1
+    /// is CPU + greedy only; `temperature > 0.0` is refused at
+    /// session boot.
+    Litertlm,
+}
 
 #[derive(Debug, Args)]
 pub struct RunArgs {
@@ -86,14 +105,26 @@ pub struct RunArgs {
     pub script: Option<PathBuf>,
 
     /// User message to feed the LLM-B backend for one model-driven
-    /// turn. Requires the CLI to have been built with the `llama`
-    /// feature (per ADR-014, LLM-B). Mutually exclusive with
-    /// `--script`. The manifest's `inference.determinism` block (if
-    /// any) flows through to the sampler chain — pinning seed +
-    /// temperature 0.0 yields byte-identical output, which is what
-    /// the recorded demo program (ADR-020) depends on.
+    /// turn. Mutually exclusive with `--script`. The manifest's
+    /// `inference.determinism` block (if any) flows through to the
+    /// chosen backend's sampler — pinning seed + temperature 0.0
+    /// yields byte-identical output, which is what the recorded
+    /// demo program (ADR-020) depends on.
+    ///
+    /// Pair with `--backend` to pick the inference backend. The
+    /// CLI must have been built with the matching Cargo feature
+    /// (`llama` for the default `--backend llama`; `litertlm` for
+    /// `--backend litertlm`).
     #[arg(long, conflicts_with = "script")]
     pub prompt: Option<String>,
+
+    /// Inference backend used for `--prompt`. Default: `llama`
+    /// (preserves pre-LiteRT-B behavior). `litertlm` is the
+    /// LiteRT-LM backend per ADR-023; Phase 1 is CPU + greedy only,
+    /// so the manifest's `inference.determinism.temperature` must
+    /// be `0.0` (`omitted` is also fine — defaults to `0.0`).
+    #[arg(long, value_enum, default_value_t = BackendKind::default())]
+    pub backend: BackendKind,
 }
 
 /// Result of an `aegis run` invocation. Used by tests to assert
@@ -239,45 +270,21 @@ fn run_script(session: &mut Session, script_path: &Path) -> Result<(bool, Option
 }
 
 /// Drive a session via one model-driven turn (LLM-B `Session::run_turn`).
-/// Requires the `llama` Cargo feature; the no-`llama` build returns a
-/// typed error so the missing-feature case is loud, not silent.
-#[cfg(feature = "llama")]
+/// Dispatches on `args.backend` to either the llama.cpp wrapper
+/// (ADR-014) or the LiteRT-LM wrapper (ADR-023). Each is gated on
+/// its respective Cargo feature; choosing a backend whose feature
+/// is off bails with an explicit "rebuild with --features X" error.
 fn run_prompt(
     session: &mut Session,
     args: &RunArgs,
     prompt: &str,
 ) -> Result<(bool, Option<String>)> {
-    use aegis_inference_engine::{Backend as _, ToolCallResult};
-    use aegis_llama_backend::{
-        Backend as LlamaBackend, DeterminismKnobs, LlamaCppBackend, SessionOptions,
+    use aegis_inference_engine::ToolCallResult;
+
+    let loaded = match args.backend {
+        BackendKind::Llama => load_llama_backend(session, &args.model)?,
+        BackendKind::Litertlm => load_litertlm_backend(session, &args.model)?,
     };
-    use std::sync::Arc;
-
-    // Construct LLM-A backend + LLM-B LlamaCppBackend wrapper. The
-    // FFI is process-global (per ADR-014); we hold it for the duration
-    // of this command and let it drop on exit.
-    let llama_backend = Arc::new(LlamaBackend::init().context("llama backend init")?);
-
-    // Resolve `inference.determinism` from the manifest. The Policy
-    // already parsed it; pull it back out via the public accessor.
-    let determinism = session
-        .policy()
-        .manifest()
-        .inference
-        .as_ref()
-        .and_then(|i| i.determinism.as_ref())
-        .map(DeterminismKnobs::from)
-        .unwrap_or_default();
-
-    let options = SessionOptions {
-        determinism,
-        ..SessionOptions::default()
-    };
-
-    let cpp_backend = LlamaCppBackend::new(llama_backend, options);
-    let loaded = cpp_backend
-        .load(&args.model)
-        .with_context(|| format!("loading model {}", args.model.display()))?;
 
     // Plug the loaded model into the session for the duration of the
     // turn. `set_loaded_model` is the &mut-self counterpart of
@@ -320,15 +327,98 @@ fn run_prompt(
     Ok((false, None))
 }
 
+#[cfg(feature = "llama")]
+fn load_llama_backend(
+    session: &Session,
+    model_path: &Path,
+) -> Result<Box<dyn aegis_inference_engine::LoadedModel>> {
+    use aegis_inference_engine::Backend as _;
+    use aegis_llama_backend::{
+        Backend as LlamaBackend, DeterminismKnobs, LlamaCppBackend, SessionOptions,
+    };
+    use std::sync::Arc;
+
+    // Construct LLM-A backend + LLM-B LlamaCppBackend wrapper. The
+    // FFI is process-global (per ADR-014); we hold it for the duration
+    // of this command and let it drop on exit.
+    let llama_backend = Arc::new(LlamaBackend::init().context("llama backend init")?);
+
+    // Resolve `inference.determinism` from the manifest. The Policy
+    // already parsed it; pull it back out via the public accessor.
+    let determinism = session
+        .policy()
+        .manifest()
+        .inference
+        .as_ref()
+        .and_then(|i| i.determinism.as_ref())
+        .map(DeterminismKnobs::from)
+        .unwrap_or_default();
+
+    let options = SessionOptions {
+        determinism,
+        ..SessionOptions::default()
+    };
+
+    let cpp_backend = LlamaCppBackend::new(llama_backend, options);
+    cpp_backend
+        .load(model_path)
+        .with_context(|| format!("loading model {}", model_path.display()))
+}
+
 #[cfg(not(feature = "llama"))]
-fn run_prompt(
-    _session: &mut Session,
-    _args: &RunArgs,
-    _prompt: &str,
-) -> Result<(bool, Option<String>)> {
+fn load_llama_backend(
+    _session: &Session,
+    _model_path: &Path,
+) -> Result<Box<dyn aegis_inference_engine::LoadedModel>> {
     anyhow::bail!(
-        "aegis run --prompt requires the 'llama' feature; rebuild with \
+        "aegis run --backend llama requires the 'llama' Cargo feature; rebuild with \
          `cargo install --path crates/cli --features llama` (per ADR-014)"
+    );
+}
+
+#[cfg(feature = "litertlm")]
+fn load_litertlm_backend(
+    session: &Session,
+    model_path: &Path,
+) -> Result<Box<dyn aegis_inference_engine::LoadedModel>> {
+    use aegis_inference_engine::Backend as _;
+    use aegis_litertlm_backend::{DeterminismKnobs, LiteRtLmBackend, SessionOptions};
+
+    // Resolve `inference.determinism` from the manifest, same shape
+    // as the llama path. The two backends share the manifest schema
+    // (per ADR-023 §"Determinism + replay") so the conversion is a
+    // straight `From` impl.
+    let determinism = session
+        .policy()
+        .manifest()
+        .inference
+        .as_ref()
+        .and_then(|i| i.determinism.as_ref())
+        .map(DeterminismKnobs::from)
+        .unwrap_or_default();
+
+    let options = SessionOptions {
+        determinism,
+        ..SessionOptions::default()
+    };
+
+    // LiteRT-LM doesn't require a process-global init step (unlike
+    // llama.cpp); the backend wrapper is constructed and loaded in
+    // one go.
+    let backend = LiteRtLmBackend::new(options);
+    backend
+        .load(model_path)
+        .with_context(|| format!("loading model {}", model_path.display()))
+}
+
+#[cfg(not(feature = "litertlm"))]
+fn load_litertlm_backend(
+    _session: &Session,
+    _model_path: &Path,
+) -> Result<Box<dyn aegis_inference_engine::LoadedModel>> {
+    anyhow::bail!(
+        "aegis run --backend litertlm requires the 'litertlm' Cargo feature; rebuild with \
+         `cargo install --path crates/cli --features litertlm` (per ADR-023)"
     );
 }
 

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -43,6 +43,7 @@ fn args_for(
         session_id: Some(session_id.to_string()),
         script: Some(script),
         prompt: None,
+        backend: aegis_cli::run::BackendKind::Llama,
     }
 }
 
@@ -290,6 +291,7 @@ tools: {}
         session_id: Some("session-missing".to_string()),
         script: Some(work.path().join("does-not-exist.json")),
         prompt: None,
+        backend: aegis_cli::run::BackendKind::Llama,
     };
     let err = execute(args).unwrap_err();
     let msg = format!("{err}");
@@ -330,6 +332,7 @@ tools: {}
         session_id: Some("session-neither".to_string()),
         script: None,
         prompt: None,
+        backend: aegis_cli::run::BackendKind::Llama,
     };
     let err = execute(args).unwrap_err();
     let msg = format!("{err}");
@@ -373,11 +376,54 @@ tools: {}
         session_id: Some("session-no-feature".to_string()),
         script: None,
         prompt: Some("hello".to_string()),
+        backend: aegis_cli::run::BackendKind::Llama,
     };
     let err = execute(args).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
-        msg.contains("'llama' feature"),
+        msg.contains("'llama' Cargo feature"),
+        "expected feature-flag hint, got: {msg}"
+    );
+}
+
+// Parallel test for the litertlm backend: `--backend litertlm`
+// without the `litertlm` feature errors with the matching hint.
+// Per LiteRT-B (#96) acceptance criterion: the missing-feature case
+// must be loud, not silent.
+#[cfg(not(feature = "litertlm"))]
+#[test]
+fn execute_with_litertlm_backend_without_litertlm_feature_errors_cleanly() {
+    let work = tempfile::tempdir().unwrap();
+    let ca = tempfile::tempdir().unwrap();
+    write(
+        &work.path().join("manifest.yaml"),
+        r#"schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://aegis-node.local/agent/x/1" }
+tools: {}
+"#,
+    );
+    write(&work.path().join("model.litertlm"), "x");
+    aegis_identity::LocalCa::init(ca.path(), "aegis-node.local").unwrap();
+
+    let args = RunArgs {
+        manifest: work.path().join("manifest.yaml"),
+        model: work.path().join("model.litertlm"),
+        config: None,
+        chat_template_sidecar: None,
+        identity_dir: Some(ca.path().to_path_buf()),
+        workload: "research".to_string(),
+        instance: "inst-1".to_string(),
+        ledger: Some(work.path().join("ledger.jsonl")),
+        session_id: Some("session-no-litertlm".to_string()),
+        script: None,
+        prompt: Some("hello".to_string()),
+        backend: aegis_cli::run::BackendKind::Litertlm,
+    };
+    let err = execute(args).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("'litertlm' Cargo feature"),
         "expected feature-flag hint, got: {msg}"
     );
 }

--- a/crates/cli/tests/runtime.rs
+++ b/crates/cli/tests/runtime.rs
@@ -115,6 +115,7 @@ fn runtime_conformance_golden() {
         session_id: Some(SESSION_ID.to_string()),
         script: Some(script_path),
         prompt: None,
+        backend: aegis_cli::run::BackendKind::Llama,
     };
 
     let outcome = execute(args).expect("aegis run");

--- a/crates/litertlm-backend/Cargo.toml
+++ b/crates/litertlm-backend/Cargo.toml
@@ -19,6 +19,17 @@ thiserror = "1"
 # manifest's `inference.determinism` block flows through unchanged
 # across both backends. Per LiteRT-A.
 aegis-policy = { path = "../policy" }
+# Backend / LoadedModel traits + chat-time types live in
+# aegis-inference-engine; chat.rs implements them per LiteRT-B.
+aegis-inference-engine = { path = "../inference-engine" }
+# chat.rs serializes the tool catalog as JSON for the flat-prompt
+# path. Mirrors the llama-backend's serde_json usage.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"
+# Real-model end-to-end test in tests/run_turn_real_model.rs boots a
+# full aegis_inference_engine::Session against a live .litertlm —
+# needs the local-CA helper for SVID issuance.
+aegis-identity = { path = "../identity" }

--- a/crates/litertlm-backend/src/chat.rs
+++ b/crates/litertlm-backend/src/chat.rs
@@ -1,0 +1,452 @@
+//! `LiteRtLmBackend` — the LiteRT-LM impl of [`aegis_inference_engine::Backend`].
+//!
+//! Per LiteRT-B / [issue #96](https://github.com/tosin2013/aegis-node/issues/96)
+//! and [ADR-023](../../docs/adrs/023-litertlm-as-second-inference-backend.md)
+//! §"Implementation plan" item 2. The trait + chat-time types
+//! ([`InferRequest`], [`ToolCall`], etc.) live in
+//! `aegis-inference-engine` so the runtime trust boundary doesn't
+//! drag LiteRT-LM's C++ surface; this module is the only place that
+//! bridges the two.
+//!
+//! Scope:
+//!
+//! - Format incoming [`InferRequest`] messages + tools into a flat
+//!   prompt (Phase 1 — see "Conversation API future" below for the
+//!   production-quality path).
+//! - Run the prompt through [`Session::infer`] (LiteRT-A's wrapper).
+//! - Parse `<tool_call>{...}</tool_call>` JSON blocks out of the raw
+//!   output. Same convention modern instruct models emit; reused
+//!   from the llama-backend so audit reasoning doesn't fork.
+//!
+//! Determinism (per ADR-023 §"Determinism + replay") is wired
+//! through [`SessionOptions::determinism`] — the manifest's
+//! `inference.determinism` block translates to those knobs and the
+//! sampler param chain in [`crate::Session::new`] honors them.
+//! `temperature > 0.0` is **refused at boot** with
+//! [`BackendErrorKind::InvalidConfig`] until upstream's
+//! `LiteRT-LM #2080` / `#2081` GPU sampler-determinism fix lands;
+//! Phase 1 is CPU + greedy only.
+//!
+//! ## Conversation API future
+//!
+//! Upstream offers a higher-level Conversation API
+//! (`litert_lm_conversation_send_message` with structured
+//! tools_json + messages_json + constrained-decoding) that yields
+//! pre-parsed tool calls. The flat-prompt path here is a placeholder:
+//! it works for any text-in/text-out instruct model but doesn't
+//! exploit Gemma 4's grammar-constrained tool-call decoder. Once
+//! LiteRT-C ships a real Gemma 4 fixture and we have a runnable
+//! smoke test, swap [`infer`] over to the Conversation API in a
+//! follow-up — see the issue tracker.
+
+use std::path::Path;
+
+use aegis_inference_engine::{
+    Backend as RuntimeBackend, BackendError, BackendErrorKind, InferRequest, InferResponse,
+    LoadedModel, ToolCall, ToolDecl,
+};
+
+use crate::{Engine, LiteRtError, Session, SessionOptions};
+
+/// LiteRT-LM implementation of [`aegis_inference_engine::Backend`].
+/// Wraps the LiteRT-A safe-wrapper crate and produces
+/// [`LiteRtLmLoadedModel`]s on demand.
+///
+/// `Backend::load` enforces the Phase 1 determinism gate
+/// (`temperature == 0.0` → greedy only) before calling into the FFI.
+/// Failing fast at boot — rather than at the first inference turn —
+/// matches the `temperature > 0.0` "errors at boot" criterion in the
+/// LiteRT-B acceptance list.
+#[derive(Debug, Clone)]
+pub struct LiteRtLmBackend {
+    options: SessionOptions,
+}
+
+impl LiteRtLmBackend {
+    /// Construct a new backend handle. The `options.determinism`
+    /// block is validated lazily on each [`load`] — keeping `new`
+    /// total simplifies CLI wiring (the manifest's determinism
+    /// knobs aren't fully resolved until session boot).
+    #[must_use]
+    pub fn new(options: SessionOptions) -> Self {
+        Self { options }
+    }
+}
+
+impl RuntimeBackend for LiteRtLmBackend {
+    fn load(&self, model_path: &Path) -> Result<Box<dyn LoadedModel>, BackendError> {
+        // Phase 1 determinism gate. CPU + greedy only — anything
+        // that would activate the seed-aware random sampler is
+        // refused until upstream's GPU sampler-determinism fix
+        // lands (LiteRT-LM #2080 / PR #2081).
+        check_phase1_determinism(&self.options)?;
+
+        let engine = Engine::load(model_path).map_err(map_err)?;
+        Ok(Box::new(LiteRtLmLoadedModel {
+            engine,
+            options: self.options.clone(),
+        }))
+    }
+}
+
+/// LiteRT-LM implementation of [`LoadedModel`]. Owns the loaded
+/// engine; opens a fresh inference [`Session`] on each `infer` call
+/// so per-turn sampler state doesn't leak between turns.
+pub struct LiteRtLmLoadedModel {
+    engine: Engine,
+    options: SessionOptions,
+}
+
+impl std::fmt::Debug for LiteRtLmLoadedModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiteRtLmLoadedModel")
+            .field("options", &self.options)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LoadedModel for LiteRtLmLoadedModel {
+    fn infer(&mut self, request: InferRequest) -> Result<InferResponse, BackendError> {
+        let prompt = format_chat_prompt(&request)?;
+
+        let mut session = Session::new(&self.engine, self.options.clone()).map_err(map_err)?;
+        let raw = session.infer(&prompt).map_err(map_err)?;
+        Ok(parse_response(&raw))
+    }
+}
+
+/// Refuse a [`SessionOptions`] that would activate the seed-aware
+/// random sampler. Phase 1 is CPU + greedy only — see
+/// [ADR-023](../../docs/adrs/023-litertlm-as-second-inference-backend.md)
+/// §"Determinism + replay" and the LiteRT-B acceptance criterion.
+///
+/// The boot-time refusal is the same posture llama-backend uses for
+/// invalid configurations (typed error, never a runtime surprise).
+fn check_phase1_determinism(options: &SessionOptions) -> Result<(), BackendError> {
+    let temp = options.determinism.temperature.unwrap_or(0.0);
+    if temp > 0.0 {
+        return Err(BackendError::new(
+            BackendErrorKind::InvalidConfig,
+            format!(
+                "litertlm backend Phase 1 (per ADR-023) requires temperature=0.0 (greedy); got temperature={temp}. \
+                 Probabilistic sampling is gated on upstream LiteRT-LM #2080 (CPU sampler determinism) \
+                 and PR #2081 (GPU sampler determinism); both must land before warm-temperature \
+                 sampling is unblocked. Set inference.determinism.temperature: 0.0 in the manifest."
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Format `request.messages` + `request.tools` into a flat prompt
+/// the model can consume. Phase 1 placeholder — the production path
+/// uses upstream's Conversation API (see module docstring).
+///
+/// Format mirrors a generic instruct-model layout:
+///
+/// ```text
+/// <available_tools>
+/// [tool catalog as JSON]
+/// </available_tools>
+///
+/// system: <system prompt>
+/// user: <user message>
+/// tool: <tool result>
+/// ...
+/// assistant:
+/// ```
+///
+/// Modern instruct models trained on tool-call data understand this
+/// shape well enough for Phase 1 demonstrations. The Gemma 4 family
+/// in particular emits structured `<tool_call>{...}</tool_call>`
+/// blocks the [`parse_response`] helper below extracts.
+fn format_chat_prompt(request: &InferRequest) -> Result<String, BackendError> {
+    let mut out = String::new();
+
+    if !request.tools.is_empty() {
+        let tools_json = serialize_tools(&request.tools)?;
+        out.push_str("<available_tools>\n");
+        out.push_str(&tools_json);
+        out.push_str("\n</available_tools>\n\n");
+    }
+
+    for m in &request.messages {
+        out.push_str(m.role.as_str());
+        out.push_str(": ");
+        out.push_str(&m.content);
+        out.push('\n');
+    }
+    out.push_str("assistant: ");
+    Ok(out)
+}
+
+/// Serialize a tool catalog into the OpenAI-compatible tools JSON
+/// shape (mirroring llama-backend's serializer so audit reasoning
+/// stays unified).
+fn serialize_tools(tools: &[ToolDecl]) -> Result<String, BackendError> {
+    let arr: Vec<serde_json::Value> = tools
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.arguments_schema,
+                }
+            })
+        })
+        .collect();
+    serde_json::to_string(&arr).map_err(|e| {
+        BackendError::new(
+            BackendErrorKind::Tokenization,
+            format!("serialize tool catalog: {e}"),
+        )
+    })
+}
+
+/// Parse the model's raw output into reasoning / tool calls /
+/// assistant text. Tool calls are extracted from
+/// `<tool_call>{...}</tool_call>` JSON blocks (the convention modern
+/// instruct-with-tools models emit). Anything outside those blocks
+/// is treated as the assistant's reasoning + final message.
+///
+/// Same shape as the llama-backend parser (intentionally) — once we
+/// switch to the Conversation API the parser becomes redundant
+/// (constrained decoding upstream produces structured tool_calls
+/// directly), but the flat-prompt path needs it now.
+pub(crate) fn parse_response(raw: &str) -> InferResponse {
+    const OPEN: &str = "<tool_call>";
+    const CLOSE: &str = "</tool_call>";
+
+    let mut reasoning = String::new();
+    let mut tool_calls = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(start) = raw[cursor..].find(OPEN) {
+        let abs_start = cursor + start;
+        reasoning.push_str(&raw[cursor..abs_start]);
+
+        let body_start = abs_start + OPEN.len();
+        let Some(close_rel) = raw[body_start..].find(CLOSE) else {
+            // Unterminated `<tool_call>` — treat the rest as plain
+            // text. The next turn's request can show the model the
+            // problem.
+            reasoning.push_str(&raw[abs_start..]);
+            cursor = raw.len();
+            break;
+        };
+        let body_end = body_start + close_rel;
+        let body = raw[body_start..body_end].trim();
+
+        if let Some(call) = parse_tool_call_body(body) {
+            tool_calls.push(call);
+        } else {
+            // Malformed JSON — keep the original block in reasoning
+            // verbatim so downstream debugging can see what the model
+            // emitted.
+            reasoning.push_str(&raw[abs_start..body_end + CLOSE.len()]);
+        }
+
+        cursor = body_end + CLOSE.len();
+    }
+    // Trailing text after the last `</tool_call>` is reasoning.
+    reasoning.push_str(&raw[cursor..]);
+
+    let reasoning = reasoning.trim().to_string();
+    let assistant_text = if reasoning.is_empty() {
+        None
+    } else {
+        Some(reasoning.clone())
+    };
+    InferResponse {
+        reasoning,
+        tool_calls,
+        assistant_text,
+    }
+}
+
+/// Parse a `<tool_call>...</tool_call>` body into a [`ToolCall`].
+/// Strict serde_json: the Conversation API's structured output (and
+/// constrained-decoded Gemma 4 output) is well-formed JSON. If a
+/// future model emits the doubled-brace Qwen quirk, surface that as
+/// a separate fallback then; today's pin doesn't need it.
+fn parse_tool_call_body(body: &str) -> Option<ToolCall> {
+    #[derive(serde::Deserialize)]
+    struct Wire {
+        name: String,
+        #[serde(default)]
+        arguments: serde_json::Value,
+    }
+    let wire: Wire = serde_json::from_str(body).ok()?;
+    Some(ToolCall {
+        name: wire.name,
+        arguments: wire.arguments,
+    })
+}
+
+/// Map a [`LiteRtError`] into the runtime-facing
+/// [`BackendError`] discriminant.
+fn map_err(e: LiteRtError) -> BackendError {
+    let (kind, detail) = match &e {
+        LiteRtError::ModelFileUnreadable { detail, .. } => {
+            (BackendErrorKind::ModelFileUnreadable, detail.clone())
+        }
+        LiteRtError::EngineCreationFailed { .. } => {
+            (BackendErrorKind::ModelLoadFailed, e.to_string())
+        }
+        LiteRtError::EngineSettingsAllocFailed | LiteRtError::SessionConfigAllocFailed => {
+            (BackendErrorKind::SessionInitFailed, e.to_string())
+        }
+        LiteRtError::SessionInitFailed => (BackendErrorKind::SessionInitFailed, e.to_string()),
+        LiteRtError::InferenceFailed | LiteRtError::NoCandidates => {
+            (BackendErrorKind::Inference, e.to_string())
+        }
+        LiteRtError::InvalidUtf8(_) => (BackendErrorKind::InvalidUtf8, e.to_string()),
+        LiteRtError::InteriorNul(_) => (BackendErrorKind::InvalidConfig, e.to_string()),
+        LiteRtError::InvalidConfig(s) => (BackendErrorKind::InvalidConfig, (*s).to_string()),
+    };
+    BackendError::new(kind, detail)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use aegis_inference_engine::{ChatMessage, ChatRole};
+
+    #[test]
+    fn parse_response_extracts_single_tool_call() {
+        let raw = r#"Let me think.<tool_call>{"name":"filesystem__read","arguments":{"path":"/etc/passwd"}}</tool_call>"#;
+        let resp = parse_response(raw);
+        assert_eq!(resp.tool_calls.len(), 1);
+        assert_eq!(resp.tool_calls[0].name, "filesystem__read");
+        assert_eq!(resp.tool_calls[0].arguments["path"], "/etc/passwd");
+        assert_eq!(resp.reasoning, "Let me think.");
+    }
+
+    #[test]
+    fn parse_response_handles_pure_text_response() {
+        let raw = "The capital of France is Paris.";
+        let resp = parse_response(raw);
+        assert_eq!(resp.tool_calls.len(), 0);
+        assert_eq!(resp.reasoning, "The capital of France is Paris.");
+        assert_eq!(
+            resp.assistant_text.as_deref(),
+            Some("The capital of France is Paris.")
+        );
+    }
+
+    #[test]
+    fn parse_response_handles_multiple_tool_calls() {
+        let raw = r#"<tool_call>{"name":"a","arguments":{"x":1}}</tool_call>middle<tool_call>{"name":"b","arguments":{"y":2}}</tool_call>"#;
+        let resp = parse_response(raw);
+        assert_eq!(resp.tool_calls.len(), 2);
+        assert_eq!(resp.tool_calls[0].name, "a");
+        assert_eq!(resp.tool_calls[1].name, "b");
+        assert_eq!(resp.reasoning, "middle");
+    }
+
+    #[test]
+    fn parse_response_unterminated_tool_call_falls_back_to_reasoning() {
+        let raw = r#"text <tool_call>{"name":"oops"}"#;
+        let resp = parse_response(raw);
+        assert_eq!(resp.tool_calls.len(), 0);
+        assert!(resp.reasoning.contains("<tool_call>"));
+    }
+
+    #[test]
+    fn parse_response_malformed_json_kept_as_reasoning() {
+        let raw = r#"<tool_call>not json</tool_call>"#;
+        let resp = parse_response(raw);
+        assert_eq!(resp.tool_calls.len(), 0);
+        assert!(resp.reasoning.contains("not json"));
+    }
+
+    #[test]
+    fn check_phase1_determinism_accepts_temp_zero() {
+        let mut opts = SessionOptions::default();
+        opts.determinism.temperature = Some(0.0);
+        opts.determinism.seed = Some(42);
+        check_phase1_determinism(&opts).expect("temp=0 must be accepted");
+    }
+
+    #[test]
+    fn check_phase1_determinism_accepts_temp_unset() {
+        let opts = SessionOptions::default();
+        check_phase1_determinism(&opts).expect("unset temp must be accepted (defaults to 0.0)");
+    }
+
+    #[test]
+    fn check_phase1_determinism_refuses_warm_temperature() {
+        let mut opts = SessionOptions::default();
+        opts.determinism.temperature = Some(0.7);
+        let err = check_phase1_determinism(&opts).expect_err("temp>0 must be refused");
+        assert_eq!(err.kind, BackendErrorKind::InvalidConfig);
+        assert!(err.detail.contains("temperature=0.7"));
+        assert!(err.detail.contains("#2080") && err.detail.contains("#2081"));
+    }
+
+    #[test]
+    fn format_chat_prompt_includes_messages_and_tool_catalog() {
+        let request = InferRequest {
+            messages: vec![
+                ChatMessage {
+                    role: ChatRole::System,
+                    content: "You are helpful.".to_string(),
+                },
+                ChatMessage {
+                    role: ChatRole::User,
+                    content: "Read /etc/passwd".to_string(),
+                },
+            ],
+            tools: vec![ToolDecl {
+                name: "filesystem__read".to_string(),
+                description: "Read a file".to_string(),
+                arguments_schema: serde_json::json!({"type": "object"}),
+            }],
+        };
+        let prompt = format_chat_prompt(&request).unwrap();
+        assert!(prompt.contains("<available_tools>"));
+        assert!(prompt.contains("filesystem__read"));
+        assert!(prompt.contains("system: You are helpful."));
+        assert!(prompt.contains("user: Read /etc/passwd"));
+        assert!(prompt.ends_with("assistant: "));
+    }
+
+    #[test]
+    fn format_chat_prompt_skips_tool_block_when_no_tools() {
+        let request = InferRequest {
+            messages: vec![ChatMessage {
+                role: ChatRole::User,
+                content: "Hi".to_string(),
+            }],
+            tools: vec![],
+        };
+        let prompt = format_chat_prompt(&request).unwrap();
+        assert!(!prompt.contains("<available_tools>"));
+        assert!(prompt.contains("user: Hi"));
+    }
+
+    #[test]
+    fn map_err_invalid_config_passes_through() {
+        let mapped = map_err(LiteRtError::InvalidConfig("max_tokens must be > 0"));
+        assert_eq!(mapped.kind, BackendErrorKind::InvalidConfig);
+    }
+
+    #[test]
+    fn map_err_inference_failure_maps_to_inference_kind() {
+        let mapped = map_err(LiteRtError::InferenceFailed);
+        assert_eq!(mapped.kind, BackendErrorKind::Inference);
+    }
+
+    #[test]
+    fn loadedmodel_send_bound_satisfied() {
+        // Compile-time check: LoadedModel must be Send so the
+        // runtime can hand it across thread boundaries. If Engine
+        // ever loses its `unsafe impl Send`, this test stops
+        // compiling.
+        fn require_send<T: Send>() {}
+        require_send::<LiteRtLmLoadedModel>();
+    }
+}

--- a/crates/litertlm-backend/src/lib.rs
+++ b/crates/litertlm-backend/src/lib.rs
@@ -48,6 +48,9 @@ use std::ffi::{CStr, CString};
 use std::path::Path;
 use std::ptr::NonNull;
 
+pub mod chat;
+pub use chat::{LiteRtLmBackend, LiteRtLmLoadedModel};
+
 use aegis_litertlm_sys as sys;
 use thiserror::Error;
 
@@ -270,19 +273,26 @@ fn build_sampler_params(knobs: &DeterminismKnobs) -> sys::LiteRtLmSamplerParams 
 /// coexist in the same process (the C ABI does not require a
 /// process-global init step).
 ///
-/// `Engine` is intentionally `!Send + !Sync`. The LiteRT-LM C ABI's
-/// engine handle is owned by the calling thread that created it;
-/// upstream documentation does not promise thread-safety on the
-/// engine pointer. We enforce that at compile time via the
-/// `_not_thread_safe` `PhantomData<*const ()>` field — flipping it
-/// to a `Send`-bearing marker requires re-reading this comment.
+/// `Engine` is `Send` but `!Sync`. The LiteRT-LM C ABI's engine
+/// handle can move between threads (upstream's Python and JNI
+/// bindings rely on this) but concurrent calls on the same handle
+/// are not documented as safe. The `Backend` trait in
+/// `aegis-inference-engine` requires `LoadedModel: Send`, so the
+/// LiteRtLmBackend impl in `chat.rs` needs `Engine: Send`.
 pub struct Engine {
     /// Owned engine handle. Non-null for the entire lifetime of the
     /// `Engine` — released by `Drop`.
     handle: NonNull<sys::LiteRtLmEngine>,
-    /// Marker that disables the `Send + Sync` auto-traits.
-    _not_thread_safe: std::marker::PhantomData<*const ()>,
 }
+
+// SAFETY-INVARIANT: the LiteRT-LM C ABI's engine handle is a thread-
+// movable opaque pointer — upstream's Python and JNI bindings move
+// the handle across threads as a matter of course. Concurrent calls
+// against the same handle are NOT documented as safe; we therefore
+// withhold `Sync` (the absence of an `unsafe impl Sync for Engine`
+// below). `infer` takes `&mut self` on the wrapping `LoadedModel` so
+// the borrow checker enforces single-threaded use.
+unsafe impl Send for Engine {}
 
 impl std::fmt::Debug for Engine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -350,10 +360,7 @@ impl Engine {
             path: path.display().to_string(),
         })?;
 
-        Ok(Self {
-            handle,
-            _not_thread_safe: std::marker::PhantomData,
-        })
+        Ok(Self { handle })
     }
 }
 


### PR DESCRIPTION
## Summary

LiteRT-B under [ADR-023](docs/adrs/023-litertlm-as-second-inference-backend.md) / [#96](https://github.com/tosin2013/aegis-node/issues/96). Closes the trait-impl + CLI-wiring half of the LiteRT-LM umbrella.

| | what |
|---|---|
| `crates/litertlm-backend/src/chat.rs` | `LiteRtLmBackend` + `LiteRtLmLoadedModel` implementing `aegis_inference_engine::Backend` + `LoadedModel` |
| `crates/cli/src/run.rs` | new `--backend <llama\|litertlm>` flag, default `llama` |
| `crates/cli/Cargo.toml` | new `litertlm` feature paralleling `llama` |
| `.github/workflows/litertlm.yml` | adds CLI `--features litertlm` build + clippy + test steps |

## Backend impl shape

Phase 1 takes the **flat-prompt path**: format messages + tool catalog as a generic instruct-template prompt, run through the existing `Session::infer`, parse `<tool_call>{...}</tool_call>` blocks (mirror of llama-backend's parser). Production path uses LiteRT-LM's Conversation API for upstream-constrained-decoded structured tool calls — flagged for follow-up once **LiteRT-C ([#97](https://github.com/tosin2013/aegis-node/issues/97))** ships a Gemma 4 fixture we can validate against.

```rust
match args.backend {
    BackendKind::Llama    => load_llama_backend(session, &args.model)?,
    BackendKind::Litertlm => load_litertlm_backend(session, &args.model)?,
}
// ... session.set_loaded_model(loaded); session.run_turn(prompt) ...
```

## Determinism gate (per acceptance criterion)

`temperature > 0.0` is **refused at session boot** with `BackendErrorKind::InvalidConfig` referencing upstream `LiteRT-LM #2080` + `#2081`:

```
litertlm backend Phase 1 (per ADR-023) requires temperature=0.0 (greedy);
got temperature=0.7. Probabilistic sampling is gated on upstream
LiteRT-LM #2080 (CPU sampler determinism) and PR #2081 (GPU sampler
determinism); both must land before warm-temperature sampling is
unblocked. Set inference.determinism.temperature: 0.0 in the manifest.
```

## Send/Sync posture change

`Engine` promoted from `!Send + !Sync` (PhantomData marker) → **`Send + !Sync`** (explicit `unsafe impl Send`). The C ABI's engine handle is thread-movable — upstream's Python and JNI bindings rely on this — but concurrent calls remain forbidden via the absent `Sync` impl + `LoadedModel::infer`'s `&mut self` bound. A compile-time `loadedmodel_send_bound_satisfied` test pins the constraint so a future regression to `!Send` doesn't sneak in.

## Acceptance against #96

- [x] `LiteRtLmBackend` implements `aegis_inference_engine::Backend`.
- [x] `LiteRtLmLoadedModel` implements `aegis_inference_engine::LoadedModel`. (Phase 1 returns reasoning + parsed tool_calls via the flat-prompt path; structured-from-JSON Conversation API path is filed for follow-up.)
- [x] `--backend` flag works for both `llama` and `litertlm`. Default `llama` preserves pre-LiteRT-B behavior.
- [x] Reserved-name boot check from #92 still applies.
- [x] `temperature > 0.0` against the litertlm backend errors at session boot with a typed error referencing upstream #2080/#2081.
- [ ] Mock-free integration test against a real Gemma 4 model — gated on **LiteRT-C** shipping the publish; placeholder smoke test is `#[ignore]`d behind `AEGIS_LITERTLM_TEST_MODEL`.

## Test plan

- [x] `cargo fmt -- --check` clean across default / `--features llama` / `--features litertlm` / both
- [x] `cargo clippy --all-targets -- -D warnings` clean across all 4 feature combinations
- [x] `cargo test -p aegis-cli --all-targets` (default features) — 9 tests pass including the new `execute_with_litertlm_backend_without_litertlm_feature_errors_cleanly`
- [x] `cargo test -p aegis-litertlm-backend --all-targets` (lib unit tests in chat.rs cover parse_response edge cases, determinism gate, prompt formatting, map_err, LoadedModel: Send compile-time check)
- [ ] Real-model end-to-end run against Gemma 4 — gated on LiteRT-C; smoke test is in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)