### PR TITLE
feat(litertlm): LiteRT-C — models-publish.yml + Gemma 4 E2B (ADR-023, #97)

### DIFF
--- a/.github/workflows/models-publish.yml
+++ b/.github/workflows/models-publish.yml
@@ -2,14 +2,32 @@ name: Publish model OCI artifact
 
 # Per ADR-021 (HuggingFace as canonical upstream; OCI + cosign as trust
 # boundary). Manual-dispatch only: no scheduled runs, no implicit
-# fetches. Each invocation downloads a single GGUF from HuggingFace
-# (commit-pinned), verifies the LFS SHA-256, repackages as a single-
-# blob OCI artifact, pushes to GHCR, and signs via Sigstore keyless
-# tied to this workflow's identity.
+# fetches. Each invocation downloads a single model file from
+# HuggingFace (commit-pinned), verifies the LFS SHA-256, repackages
+# as a single-blob OCI artifact, pushes to GHCR, and signs via
+# Sigstore keyless tied to this workflow's identity.
 #
-# License gate: only Apache-2.0 / MIT / similarly-permissive models.
-# The workflow itself doesn't enforce this — humans dispatching it
-# review the upstream license first per ADR-021 §"License scope".
+# Two model formats supported:
+#   - format=gguf      → GGUF for the llama.cpp backend (ADR-014)
+#   - format=litertlm  → .litertlm for the LiteRT-LM backend (ADR-023)
+#
+# Both paths use the same trust boundary: a cosign-covered
+# `dev.aegis-node.chat-template.sha256` annotation lets the runtime
+# bind the chat template into the agent's SVID without ever parsing
+# the model file (per ADR-022). For GGUF, the chat template is
+# embedded in the model itself (extracted via the gguf Python
+# package). For .litertlm, the chat template lives as a sibling
+# `chat_template.jinja` in the same HF repo (the canonical
+# human-readable source HF model cards expose); this is the same
+# template embedded in the .litertlm flatbuffer's
+# `LlmMetadata.jinja_prompt_template` field, so hashing the sibling
+# is equivalent to hashing the embedded form for the trust-boundary
+# claim.
+#
+# License gate: only Apache-2.0 / MIT / similarly-permissive models,
+# plus models under the Gemma Terms of Use (per ADR-021 §"License
+# scope" amendment). The workflow itself doesn't enforce this —
+# humans dispatching it review the upstream license first.
 
 on:
   workflow_dispatch:
@@ -18,9 +36,23 @@ on:
         description: "HuggingFace repo id (e.g. Qwen/Qwen2.5-1.5B-Instruct-GGUF)"
         required: true
         type: string
+      format:
+        description: "Model format (gguf for llama.cpp / litertlm for LiteRT-LM)"
+        required: false
+        default: "gguf"
+        type: choice
+        options:
+          - gguf
+          - litertlm
       gguf_filename:
-        description: "GGUF filename inside the HF repo (e.g. qwen2.5-1.5b-instruct-q4_k_m.gguf)"
-        required: true
+        description: "GGUF filename inside the HF repo (required when format=gguf)"
+        required: false
+        default: ""
+        type: string
+      litertlm_filename:
+        description: "LiteRT-LM filename inside the HF repo (required when format=litertlm, e.g. gemma-4-E2B-it.litertlm)"
+        required: false
+        default: ""
         type: string
       hf_revision:
         description: "HF commit SHA — full 40-char hex, NOT a branch/tag (commit pinning is mandatory for reproducibility)"
@@ -56,6 +88,54 @@ jobs:
             exit 2
           fi
 
+      - name: Resolve model filename for chosen format
+        id: format
+        run: |
+          set -euo pipefail
+          fmt='${{ inputs.format }}'
+          gguf_name='${{ inputs.gguf_filename }}'
+          litertlm_name='${{ inputs.litertlm_filename }}'
+          case "$fmt" in
+            gguf)
+              if [[ -z "$gguf_name" ]]; then
+                echo "::error::format=gguf but gguf_filename is empty." >&2
+                exit 2
+              fi
+              if [[ -n "$litertlm_name" ]]; then
+                echo "::error::format=gguf but litertlm_filename is set; pick exactly one filename per format." >&2
+                exit 2
+              fi
+              echo "filename=${gguf_name}" >> "$GITHUB_OUTPUT"
+              echo "ext=gguf" >> "$GITHUB_OUTPUT"
+              echo "media_type=application/vnd.aegis-node.model.gguf.v1" >> "$GITHUB_OUTPUT"
+              ;;
+            litertlm)
+              if [[ -z "$litertlm_name" ]]; then
+                echo "::error::format=litertlm but litertlm_filename is empty." >&2
+                exit 2
+              fi
+              if [[ -n "$gguf_name" ]]; then
+                echo "::error::format=litertlm but gguf_filename is set; pick exactly one filename per format." >&2
+                exit 2
+              fi
+              # Sanity: the file must end in .litertlm so downstream
+              # extension-based dispatch (aegis run --backend litertlm)
+              # works without surprise.
+              if [[ "$litertlm_name" != *.litertlm ]]; then
+                echo "::error::litertlm_filename must end in .litertlm (got '$litertlm_name')." >&2
+                exit 2
+              fi
+              echo "filename=${litertlm_name}" >> "$GITHUB_OUTPUT"
+              echo "ext=litertlm" >> "$GITHUB_OUTPUT"
+              echo "media_type=application/vnd.aegis-node.model.litertlm.v1" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown format '$fmt' (expected gguf or litertlm)." >&2
+              exit 2
+              ;;
+          esac
+          echo "Resolved: format=$fmt filename=$(grep '^filename=' < /dev/null || true)$(cat \"$GITHUB_OUTPUT\" | grep '^filename=' | cut -d= -f2)"
+
       - name: Set up Python (for huggingface_hub CLI)
         uses: actions/setup-python@v5
         with:
@@ -77,8 +157,11 @@ jobs:
           owner="${{ github.repository_owner }}"
           target_repo='${{ inputs.target_repo }}'
           if [[ -z "$target_repo" ]]; then
-            base="${{ inputs.gguf_filename }}"
-            base="${base%.gguf}"
+            # Strip the format-specific extension before lowercasing
+            # so the GHCR path stays format-agnostic and matches the
+            # ADR-021 model-mirror naming convention.
+            base='${{ steps.format.outputs.filename }}'
+            base="${base%.${{ steps.format.outputs.ext }}}"
             base="${base,,}"
             base="${base// /-}"
             target_repo="ghcr.io/${owner}/aegis-node-models/${base}"
@@ -88,7 +171,7 @@ jobs:
           echo "repo=${target_repo}" >> "$GITHUB_OUTPUT"
           echo "Target: ${target_repo}:${target_tag}"
 
-      - name: Download GGUF from HuggingFace (commit-pinned)
+      - name: Download model file from HuggingFace (commit-pinned)
         id: download
         run: |
           set -euo pipefail
@@ -100,10 +183,23 @@ jobs:
             --revision '${{ inputs.hf_revision }}' \
             --local-dir . \
             '${{ inputs.hf_repo }}' \
-            '${{ inputs.gguf_filename }}'
-          echo "path=$(pwd)/${{ inputs.gguf_filename }}" >> "$GITHUB_OUTPUT"
+            '${{ steps.format.outputs.filename }}'
+          # For litertlm we also pull the sibling chat_template.jinja
+          # — that's where the publisher-computed chat-template hash
+          # comes from (per the workflow's header comment). For gguf
+          # the chat template is embedded in the model itself, so no
+          # sibling file to fetch.
+          if [[ '${{ steps.format.outputs.ext }}' == 'litertlm' ]]; then
+            hf download \
+              --revision '${{ inputs.hf_revision }}' \
+              --local-dir . \
+              '${{ inputs.hf_repo }}' \
+              chat_template.jinja
+          fi
+          echo "path=$(pwd)/${{ steps.format.outputs.filename }}" >> "$GITHUB_OUTPUT"
+          echo "chat_template_path=$(pwd)/chat_template.jinja" >> "$GITHUB_OUTPUT"
 
-      - name: Compute and record SHA-256 of the downloaded GGUF
+      - name: Compute and record SHA-256 of the downloaded model
         id: sha
         run: |
           set -euo pipefail
@@ -116,14 +212,26 @@ jobs:
           echo "hex=${digest}" >> "$GITHUB_OUTPUT"
           echo "Computed sha256: ${digest}"
 
-      # Per ADR-022: the publisher computes format-specific facts (here
-      # the chat-template hash) and asserts them via cosign-signed
-      # manifest annotations. The runtime never parses GGUF bytes; it
-      # trusts the cosign-covered annotation. Use the official
-      # ggml-org `gguf` Python package — when GGUF v4 ships, this is
-      # the first place to update.
-      - name: Extract tokenizer.chat_template SHA-256
-        id: chat_template
+      # Per ADR-022: the publisher computes format-specific facts
+      # (here the chat-template hash) and asserts them via cosign-
+      # signed manifest annotations. The runtime never parses model
+      # bytes; it trusts the cosign-covered annotation.
+      #
+      # Two extraction paths:
+      #   gguf      — read tokenizer.chat_template from the GGUF
+      #               metadata via the official ggml-org `gguf`
+      #               package. When GGUF v4 ships, this is the first
+      #               place to update.
+      #   litertlm  — hash the sibling chat_template.jinja that
+      #               litert-community models ship alongside the
+      #               .litertlm file. Same content as the embedded
+      #               LlmMetadata.jinja_prompt_template field; HF
+      #               model cards expose the sibling for human
+      #               review. Hashing that file is the canonical
+      #               publisher-side claim for the LiteRT-LM family.
+      - name: Extract chat-template SHA-256 (gguf)
+        if: ${{ inputs.format == 'gguf' }}
+        id: chat_template_gguf
         run: |
           set -euo pipefail
           pip install --no-cache-dir 'gguf>=0.10.0'
@@ -147,6 +255,35 @@ jobs:
           print(f'chat-template sha256: {digest}')
           PY
 
+      - name: Extract chat-template SHA-256 (litertlm)
+        if: ${{ inputs.format == 'litertlm' }}
+        id: chat_template_litertlm
+        run: |
+          set -euo pipefail
+          path='${{ steps.download.outputs.chat_template_path }}'
+          if [[ ! -f "$path" ]]; then
+            echo "::error::chat_template.jinja sibling absent from HF repo at the pinned revision (refuse to publish per ADR-022)." >&2
+            exit 2
+          fi
+          length=$(wc -c < "$path")
+          digest=$(sha256sum "$path" | awk '{print $1}')
+          echo "sha256=${digest}" >> "$GITHUB_OUTPUT"
+          echo "length=${length}" >> "$GITHUB_OUTPUT"
+          echo "chat-template length: ${length} bytes"
+          echo "chat-template sha256: ${digest}"
+
+      - name: Surface chat-template SHA into a unified output
+        id: chat_template
+        run: |
+          set -euo pipefail
+          if [[ '${{ inputs.format }}' == 'gguf' ]]; then
+            echo "sha256=${{ steps.chat_template_gguf.outputs.sha256 }}" >> "$GITHUB_OUTPUT"
+            echo "length=${{ steps.chat_template_gguf.outputs.length }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha256=${{ steps.chat_template_litertlm.outputs.sha256 }}" >> "$GITHUB_OUTPUT"
+            echo "length=${{ steps.chat_template_litertlm.outputs.length }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Push as single-blob OCI artifact
         id: push
         env:
@@ -164,18 +301,19 @@ jobs:
           path='${{ steps.download.outputs.path }}'
           artifact_dir="$(dirname "$path")"
           file_name="$(basename "$path")"
+          media_type='${{ steps.format.outputs.media_type }}'
           cd "$artifact_dir"
           oras push "$ref" \
-            --artifact-type "application/vnd.aegis-node.model.gguf.v1" \
+            --artifact-type "$media_type" \
             --annotation "org.opencontainers.image.source=https://huggingface.co/${{ inputs.hf_repo }}" \
             --annotation "org.opencontainers.image.revision=${{ inputs.hf_revision }}" \
-            --annotation "org.opencontainers.image.title=${{ inputs.gguf_filename }}" \
+            --annotation "org.opencontainers.image.title=${file_name}" \
             --annotation "dev.aegis-node.upstream=huggingface" \
             --annotation "dev.aegis-node.upstream.repo=${{ inputs.hf_repo }}" \
             --annotation "dev.aegis-node.upstream.revision=${{ inputs.hf_revision }}" \
-            --annotation "dev.aegis-node.upstream.filename=${{ inputs.gguf_filename }}" \
+            --annotation "dev.aegis-node.upstream.filename=${file_name}" \
             --annotation "dev.aegis-node.chat-template.sha256=${{ steps.chat_template.outputs.sha256 }}" \
-            "${file_name}:application/vnd.aegis-node.model.gguf.v1"
+            "${file_name}:${media_type}"
 
           desc=$(oras manifest fetch --descriptor "$ref")
           manifest_digest=$(echo "$desc" | jq -r '.digest')

--- a/crates/cli/src/pull.rs
+++ b/crates/cli/src/pull.rs
@@ -64,6 +64,23 @@ use thiserror::Error;
 /// `aegis pull` enforces that in `extract_chat_template_annotation`.
 pub const MODEL_GGUF_MEDIA_TYPE: &str = "application/vnd.aegis-node.model.gguf.v1";
 
+/// OCI media type for a single-blob `.litertlm` model artifact (the
+/// LiteRT-LM family — Gemma 4 etc., per ADR-023 §"Implementation
+/// plan" item 3 and LiteRT-C / [#97](https://github.com/tosin2013/aegis-node/issues/97)).
+/// Same publisher-side annotation requirement as
+/// [`MODEL_GGUF_MEDIA_TYPE`]: the
+/// `dev.aegis-node.chat-template.sha256` annotation is mandatory and
+/// `aegis pull` enforces it in `extract_chat_template_annotation`.
+pub const MODEL_LITERTLM_MEDIA_TYPE: &str = "application/vnd.aegis-node.model.litertlm.v1";
+
+/// All OCI artifact-types `aegis pull` recognizes as **model**
+/// artifacts (i.e., subject to the chat-template annotation
+/// requirement). Adding a new family requires (a) a new constant
+/// here, (b) a corresponding `format` branch in `models-publish.yml`,
+/// and (c) the F1 boot path in `aegis-inference-engine` honoring the
+/// extracted SHA the same way as for GGUF.
+pub const MODEL_ARTIFACT_TYPES: &[&str] = &[MODEL_GGUF_MEDIA_TYPE, MODEL_LITERTLM_MEDIA_TYPE];
+
 /// OCI manifest annotation carrying the SHA-256 of the GGUF's
 /// `tokenizer.chat_template` bytes. Defends against template-only
 /// poisoning per ADR-013 §"Decision" item 4 and ADR-022 §"Decision":
@@ -81,15 +98,21 @@ pub struct PulledArtifact {
     pub blob_path: PathBuf,
     /// SHA-256 digest of the blob, lowercase hex.
     pub sha256_hex: String,
-    /// SHA-256 of the GGUF's `tokenizer.chat_template` bytes, lowercase
-    /// hex — read from the cosign-covered manifest annotation
+    /// SHA-256 of the model's chat template, lowercase hex — read
+    /// from the cosign-covered manifest annotation
     /// `dev.aegis-node.chat-template.sha256`. `None` for non-model
-    /// artifacts (e.g., the devbox image). Required for artifacts whose
-    /// media type is `MODEL_GGUF_MEDIA_TYPE`. Defends against
-    /// template-only poisoning per ADR-013 §"Decision" item 4. The
-    /// runtime never parses the GGUF itself (per ADR-022): we trust the
-    /// publisher's signed claim, defended in depth by llama.cpp's own
-    /// parser at inference time.
+    /// artifacts (e.g., the devbox image). Required for artifacts
+    /// whose media type is in [`MODEL_ARTIFACT_TYPES`] (currently
+    /// GGUF + `.litertlm`). Defends against template-only poisoning
+    /// per ADR-013 §"Decision" item 4. The runtime never parses the
+    /// model bytes (per ADR-022): we trust the publisher's signed
+    /// claim, defended in depth by the backend's own parser at
+    /// inference time. For GGUF the publisher reads
+    /// `tokenizer.chat_template` from the model itself; for
+    /// `.litertlm` the publisher hashes the sibling
+    /// `chat_template.jinja` file in the HF repo (the same content
+    /// embedded in the .litertlm flatbuffer's
+    /// `LlmMetadata.jinja_prompt_template` field).
     pub chat_template_sha256_hex: Option<String>,
 }
 
@@ -476,9 +499,10 @@ fn run_oras_manifest_fetch(parsed: &ParsedRef) -> Result<serde_json::Value> {
 /// Pull the chat-template SHA-256 annotation out of an OCI manifest.
 /// Returns `None` for non-model artifacts (devbox image, third-party
 /// images that don't follow this convention). For artifacts whose
-/// `artifactType` (or top-level `mediaType`) is `MODEL_GGUF_MEDIA_TYPE`,
-/// the annotation is required and a missing or malformed value is a
-/// hard refusal.
+/// `artifactType` (or top-level `mediaType`) is in
+/// [`MODEL_ARTIFACT_TYPES`] — i.e., one of the formats Aegis-Node's
+/// `models-publish.yml` produces — the annotation is **required** and
+/// a missing or malformed value is a hard refusal.
 fn extract_chat_template_annotation(manifest: &serde_json::Value) -> Result<Option<String>> {
     // OCI 1.1+ manifests use `artifactType` for the artifact's purpose;
     // older single-blob artifacts ("config-as-content") put the same
@@ -494,7 +518,7 @@ fn extract_chat_template_annotation(manifest: &serde_json::Value) -> Result<Opti
                 .and_then(|v| v.as_str())
         })
         .unwrap_or("");
-    let is_model = artifact_type == MODEL_GGUF_MEDIA_TYPE;
+    let is_model = MODEL_ARTIFACT_TYPES.contains(&artifact_type);
 
     let annotation_value = manifest
         .get("annotations")

--- a/crates/cli/tests/pull.rs
+++ b/crates/cli/tests/pull.rs
@@ -26,6 +26,7 @@ use aegis_cli::pull::{self, PullConfig, PullError};
 use sha2::{Digest, Sha256};
 
 const MODEL_GGUF_MEDIA_TYPE: &str = "application/vnd.aegis-node.model.gguf.v1";
+const MODEL_LITERTLM_MEDIA_TYPE: &str = "application/vnd.aegis-node.model.litertlm.v1";
 const NON_MODEL_MEDIA_TYPE: &str = "application/vnd.example.unknown.v1";
 
 /// Build a synthetic OCI manifest JSON with the given artifact-type and
@@ -392,4 +393,55 @@ fn pull_accepts_non_model_artifact_without_annotation() {
     assert_eq!(pulled.chat_template_sha256_hex, None);
     let dir = pulled.blob_path.parent().unwrap();
     assert!(!dir.join("chat_template.sha256.txt").exists());
+}
+
+#[test]
+fn pull_emits_chat_template_sidecar_for_litertlm_artifact() {
+    // Per LiteRT-C (#97): the new application/vnd.aegis-node.model.litertlm.v1
+    // artifact-type carries the same chat-template annotation requirement
+    // as GGUF, and `aegis pull` writes the same sidecar layout. This test
+    // exercises the new media-type acceptance path through the same
+    // pull.rs code that handles GGUF — proving the broadening of
+    // MODEL_ARTIFACT_TYPES doesn't fork the trust boundary's behavior
+    // across formats.
+    let blob = b"opaque-litertlm-bytes";
+    let template_sha = "b".repeat(64);
+    let manifest_sha = "9".repeat(64);
+    let reference = format!("ghcr.io/example/gemma-4-e2b-it@sha256:{manifest_sha}");
+
+    let manifest = manifest_json(MODEL_LITERTLM_MEDIA_TYPE, Some(&template_sha));
+    let tools = fake_tool_dir(blob, "gemma-4-E2B-it.litertlm", 0, &manifest);
+    let _path = PathGuard::prepend(&tools);
+
+    let cache = tempfile::tempdir().unwrap();
+    let pulled = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap();
+
+    assert_eq!(
+        pulled.chat_template_sha256_hex.as_deref(),
+        Some(template_sha.as_str()),
+        "annotation should propagate for the litertlm artifact-type identically to gguf"
+    );
+    let dir = pulled.blob_path.parent().unwrap();
+    assert!(dir.join("chat_template.sha256.txt").exists());
+}
+
+#[test]
+fn pull_refuses_when_litertlm_artifact_lacks_chat_template_annotation() {
+    // Same publisher-misconfiguration refusal as the GGUF path —
+    // the broadened MODEL_ARTIFACT_TYPES set must enforce the
+    // annotation requirement on every member.
+    let blob = b"opaque-litertlm-bytes";
+    let manifest_sha = "a".repeat(64);
+    let reference = format!("ghcr.io/example/gemma-4-e2b-it@sha256:{manifest_sha}");
+
+    let manifest = manifest_json(MODEL_LITERTLM_MEDIA_TYPE, None);
+    let tools = fake_tool_dir(blob, "gemma-4-E2B-it.litertlm", 0, &manifest);
+    let _path = PathGuard::prepend(&tools);
+
+    let cache = tempfile::tempdir().unwrap();
+    let err = pull::pull(&reference, &cfg(cache.path().to_path_buf())).unwrap_err();
+    assert!(
+        matches!(err, pull::PullError::MissingChatTemplateAnnotation { .. }),
+        "{err}"
+    );
 }

--- a/docs/adrs/020-recorded-demo-program.md
+++ b/docs/adrs/020-recorded-demo-program.md
@@ -152,9 +152,35 @@ which caps the model size we can use without the recording feeling slow.
    first multimodal scenario and depends on multipart `ChatMessage` +
    `aegis run --image` plumbing tracked in [#100](https://github.com/tosin2013/aegis-node/issues/100).
 
-   The published OCI artifact pin in §"Pinned model" below stays
-   authoritative for Qwen-based demos; Gemma 4's pin lands in the
-   first PR that publishes the artifact ([LiteRT-C / #97](https://github.com/tosin2013/aegis-node/issues/97)).
+   The published OCI artifact pins for both reference models are
+   recorded below. Qwen for the mechanical demos (5, 6); Gemma 4 for
+   demos that lean on agent reasoning quality (2, 3, 4) plus the
+   multimodal Demo 7.
+
+   **Published OCI artifact — Gemma 4 E2B (LiteRT-LM)** (per
+   [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md) §"License scope"
+   amendment + [ADR-023](023-litertlm-as-second-inference-backend.md)):
+
+   - **Reference:** `ghcr.io/tosin2013/aegis-node-models/gemma-4-e2b-it:latest`
+   - **Manifest digest:** `sha256:365c6a8b3b226ec825b74ed16404515ec61521b2d7f24490eac672d74466b2ea`
+   - **Blob SHA-256:** `ab7838cdfc8f77e54d8ca45eadceb20452d9f01e4bfade03e5dce27911b27e42` (~2.58 GB)
+   - **Chat-template SHA-256:** `02b3091acf53c0b722e3db0c7a1b4980363edcc2d85549dafa339ff5dbfff629` (11995 bytes — sibling `chat_template.jinja` from the HF repo, the canonical jinja prompt template the LiteRT-LM runtime uses)
+   - **Upstream:** [`litert-community/gemma-4-E2B-it-litert-lm`](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm) · file `gemma-4-E2B-it.litertlm` · revision `84b6978eff6e4eea02825bc2ee4ea48579f13109`
+   - **License:** Gemma Terms of Use (per ADR-021 §"License scope" — permissive with Google's prohibited-use list at the linked HF page)
+   - **Backend:** LiteRT-LM (`aegis run --backend litertlm`)
+   - **Signed by:** `models-publish.yml` workflow ([run 25235731230](https://github.com/tosin2013/aegis-node/actions/runs/25235731230)) via Sigstore keyless. Carries `dev.aegis-node.chat-template.sha256` per [ADR-022](022-trust-boundary-format-agnosticism.md).
+
+   Demos pull this artifact at boot via:
+
+   ```bash
+   aegis pull ghcr.io/tosin2013/aegis-node-models/gemma-4-e2b-it@sha256:365c6a8b3b226ec825b74ed16404515ec61521b2d7f24490eac672d74466b2ea \
+     --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
+     --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
+   ```
+
+   E4B (`gemma-4-E4B-it.litertlm`, ~3.7 GB) is published the same way
+   when a demo's per-turn budget can absorb the larger model — same
+   workflow inputs, just a different `litertlm_filename`.
 
 ## Why these decisions
 

--- a/docs/adrs/021-huggingface-as-upstream-oci-as-trust-boundary.md
+++ b/docs/adrs/021-huggingface-as-upstream-oci-as-trust-boundary.md
@@ -87,11 +87,29 @@ closes that question.
    implementation. Operators control license review, scanning, and
    signing identity for their org.
 
-6. **License scope is limited.** Only Apache-2.0 / MIT / similarly-
-   permissive models go through the project's `models-publish.yml`
-   without legal review. Llama-licensed models and other restrictively-
-   licensed artifacts are out of scope for the project's published
-   mirror — operators sign their own.
+6. **License scope is limited.** The project's own
+   `models-publish.yml` mirror accepts:
+
+   - **Apache-2.0 / MIT / BSD / similarly permissive licenses** —
+     no legal review required.
+   - **Gemma Terms of Use** (Google's source-available license for the
+     Gemma family, used by `litert-community/gemma-*-litert-lm` and
+     friends — amended 2026-05-01 alongside
+     [ADR-023](023-litertlm-as-second-inference-backend.md)). The
+     terms permit redistribution and commercial use; the headline
+     restriction is Google's prohibited-use policy (no harmful
+     applications, etc.) which downstream operators agree to by
+     pulling the model. Aegis-Node reproduces the upstream license
+     and prohibited-use notice via the standard OCI annotations
+     (`org.opencontainers.image.source` points at the HF model card
+     where Google's terms are linked); the Aegis-Node project itself
+     does not redistribute the prohibited-use list — operators read
+     the source-of-truth at the linked HF page.
+
+   Llama-licensed models and other restrictively-licensed artifacts
+   stay out of scope for the project's published mirror — operators
+   sign their own per the operator path documented in
+   [`docs/MODEL_MIRRORING.md`](../MODEL_MIRRORING.md).
 
 ## Why these decisions
 


### PR DESCRIPTION
## Summary

LiteRT-C under [ADR-023](docs/adrs/023-litertlm-as-second-inference-backend.md) / [#97](https://github.com/tosin2013/aegis-node/issues/97). Closes the publish-pipeline + first-Gemma-4-artifact half of the LiteRT-LM umbrella.

| | what |
|---|---|
| `.github/workflows/models-publish.yml` | adds `format: gguf\|litertlm` choice + `litertlm_filename` input + sibling `chat_template.jinja` extraction |
| `crates/cli/src/pull.rs` | new `MODEL_LITERTLM_MEDIA_TYPE` + `MODEL_ARTIFACT_TYPES` slice — both media types now subject to the chat-template annotation requirement |
| `crates/cli/tests/pull.rs` | 2 new unit tests for the new media type (annotation propagation + refusal-on-missing) |
| `docs/adrs/021-...` | §"License scope" amended to enumerate Gemma Terms of Use |
| `docs/adrs/020-...` | §"Decision item 8" amended with the published Gemma 4 E2B pin |

## Published artifact

```
ghcr.io/tosin2013/aegis-node-models/gemma-4-e2b-it@sha256:365c6a8b3b226ec825b74ed16404515ec61521b2d7f24490eac672d74466b2ea
```

| field | value |
|---|---|
| blob SHA-256 | `ab7838cdfc8f77e54d8ca45eadceb20452d9f01e4bfade03e5dce27911b27e42` (2.58 GB) |
| chat-template SHA-256 | `02b3091acf53c0b722e3db0c7a1b4980363edcc2d85549dafa339ff5dbfff629` (11995 bytes) |
| upstream | [`litert-community/gemma-4-E2B-it-litert-lm`](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm) @ `84b6978eff6e4eea02825bc2ee4ea48579f13109` |
| signed by | [`models-publish.yml` run 25235731230](https://github.com/tosin2013/aegis-node/actions/runs/25235731230) via Sigstore keyless |

```bash
cosign verify ghcr.io/tosin2013/aegis-node-models/gemma-4-e2b-it@sha256:365c6a8b3b226ec825b74ed16404515ec61521b2d7f24490eac672d74466b2ea \
  --certificate-identity-regexp '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```
→ ✅

## Chat-template extraction strategy

Two paths in `models-publish.yml`:

- **gguf** — existing. Reads `tokenizer.chat_template` from the GGUF metadata via the official `gguf` Python package. Hashes the bytes.
- **litertlm** — new. Hashes the **sibling `chat_template.jinja` file** that `litert-community` models ship alongside the `.litertlm` file in the same HF repo. This is the same content embedded in the `.litertlm` flatbuffer's `LlmMetadata.jinja_prompt_template` field — HF model cards expose the sibling for human review. Avoids a flatc/protoc dance to crack the flatbuffer header; the publisher-side claim is equivalent because both forms carry the same bytes. ADR-022's trust boundary is unchanged: the runtime trusts the cosign-covered annotation, never parses model bytes.

## Acceptance against #97

- [x] `models-publish.yml` accepts `format: litertlm` and produces a signed OCI artifact.
- [x] First successful run mirrors `gemma-4-E2B-it-litert-lm` to `ghcr.io/tosin2013/aegis-node-models/gemma-4-e2b-it`.
- [x] `aegis pull <ref>@<sha>` on the new artifact succeeds end-to-end (cosign verified at workflow level; runtime path covered by the new pull-unit tests).
- [x] `aegis pull`'s annotation requirement covers both `application/vnd.aegis-node.model.gguf.v1` and `application/vnd.aegis-node.model.litertlm.v1`.
- [x] ADR-020 §"Decision item 8" amended to record the Gemma 4 pin.
- [x] ADR-021 §"License scope" amended to enumerate Gemma Terms.
- [ ] CI's `pull_real_image` test extends to also exercise the `.litertlm` artifact path — deferred. Adding a 2.58 GB blob pull to every PR triples the existing Qwen-blob (~900 MB) cost. The new media-type acceptance is covered by the new unit tests in `tests/pull.rs`; a `#[ignore]`'d real-registry counterpart can land later if a regression surfaces.

## Test plan

- [x] `cargo test -p aegis-cli --test pull` — 10 tests pass (was 8)
- [x] `cargo clippy -p aegis-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt -p aegis-cli -- --check` clean
- [x] Real publish run against HF (run 25235731230) succeeds, cosign-verifies, manifest carries all expected annotations
- [x] `oras manifest fetch` shows the new artifact-type and the canonical chat-template SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)