### PR TITLE
feat(adr-024-a): allowed_tools union — string shorthand or object with pre_validate (#103)

### DIFF
--- a/crates/inference-engine/src/turn.rs
+++ b/crates/inference-engine/src/turn.rs
@@ -235,9 +235,13 @@ impl Session {
             });
         }
 
-        // MCP catalog entries.
+        // MCP catalog entries. Per ADR-024, allowed_tools is now a
+        // union — entries may be bare strings or objects with
+        // pre_validate clauses; the catalog only surfaces names so
+        // we ask each entry for its name regardless of shape.
         for server in &manifest.tools.mcp {
-            for tool_name in &server.allowed_tools {
+            for entry in &server.allowed_tools {
+                let tool_name = entry.name();
                 decls.push(ToolDecl {
                     name: format_mcp_name(&server.server_name, tool_name),
                     description: format!(

--- a/crates/policy/src/manifest.rs
+++ b/crates/policy/src/manifest.rs
@@ -162,7 +162,121 @@ pub struct ApiGrant {
 pub struct McpServerGrant {
     pub server_name: String,
     pub server_uri: String,
-    pub allowed_tools: Vec<String>,
+    pub allowed_tools: Vec<AllowedTool>,
+}
+
+/// One entry in [`McpServerGrant::allowed_tools`]. Two shapes are
+/// accepted (per ADR-024 §"Decision" item 1):
+///
+/// 1. **String shorthand** — `"read_text_file"` — interpreted as
+///    "no pre-validation; one-layer enforcement," preserving the
+///    pre-ADR-024 behavior.
+/// 2. **Object form** — `{ name, pre_validate }` — declares
+///    side-effect clauses the mediator runs against
+///    `tools.filesystem.*` / `tools.network.*` policy before
+///    dispatching to the MCP server.
+///
+/// Both shapes deserialize via `#[serde(untagged)]` — serde tries
+/// each variant in order and picks the first that matches. The
+/// JSON Schema `oneOf` in
+/// [`schemas/manifest/v1/manifest.schema.json`](../../../../schemas/manifest/v1/manifest.schema.json)
+/// pins the cross-language contract.
+///
+/// Helper accessors keep call sites that only need the name terse:
+///
+/// ```ignore
+/// for entry in &grant.allowed_tools {
+///     if entry.name() == requested {
+///         for clause in entry.pre_validate() { /* ... */ }
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AllowedTool {
+    /// Bare tool name — legacy/short-form. The mediator only enforces
+    /// the MCP allowlist for this entry; the underlying tool call's
+    /// side-effects are left to the MCP server's own discretion.
+    Name(String),
+    /// Object form with per-tool pre-validation clauses. The mediator
+    /// runs each clause against the corresponding `tools.filesystem.*`
+    /// / `tools.network.*` gate before dispatching to the MCP server.
+    WithPreValidate {
+        /// Tool name (matches the MCP server's tool catalog).
+        name: String,
+        /// Side-effect clauses the mediator pre-validates. Empty / absent
+        /// `pre_validate` is equivalent to the [`AllowedTool::Name`]
+        /// shorthand — one-layer MCP enforcement only.
+        #[serde(default)]
+        pre_validate: Vec<PreValidateClause>,
+    },
+}
+
+impl AllowedTool {
+    /// Tool name, regardless of which form the manifest uses.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            AllowedTool::Name(s) => s,
+            AllowedTool::WithPreValidate { name, .. } => name,
+        }
+    }
+
+    /// Pre-validation clauses declared for this tool. Empty for the
+    /// string-shorthand form — i.e., one-layer MCP enforcement only.
+    #[must_use]
+    pub fn pre_validate(&self) -> &[PreValidateClause] {
+        match self {
+            AllowedTool::Name(_) => &[],
+            AllowedTool::WithPreValidate { pre_validate, .. } => pre_validate,
+        }
+    }
+}
+
+/// One side-effect-shaped pre-validation clause for an [`AllowedTool`]
+/// object form. The mediator extracts the named argument from the MCP
+/// tool call's payload and runs the corresponding `policy.check_*`
+/// method before dispatching the call (per ADR-024 §"Decision" item 2).
+///
+/// Phase 1 covers `filesystem_{read,write,delete}` + `network_outbound`;
+/// `exec_run` is intentionally out of scope (exec via MCP is rare and
+/// the path-extraction shape differs).
+///
+/// Exactly one of [`Self::arg`] / [`Self::arg_array`] must be set —
+/// the JSON Schema enforces this via `oneOf` and the Rust deserializer
+/// surfaces a typed error if both or neither are present.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PreValidateClause {
+    /// Which side-effect family to gate against.
+    pub kind: PreValidateKind,
+    /// Name of the scalar argument carrying the path or URL the
+    /// mediator should extract and check. Mutually exclusive with
+    /// [`Self::arg_array`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arg: Option<String>,
+    /// Name of an array-of-strings argument; the mediator extracts
+    /// each element and runs the check on it. Mutually exclusive with
+    /// [`Self::arg`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arg_array: Option<String>,
+}
+
+/// Side-effect family a [`PreValidateClause`] gates against. Adding a
+/// new family requires a corresponding `policy.check_*` method, a JSON
+/// Schema enum bump, and parity in the Go union type.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PreValidateKind {
+    /// Path extracted from the named arg; checked via `policy.check_filesystem_read`.
+    FilesystemRead,
+    /// Path extracted from the named arg; checked via `policy.check_filesystem_write`.
+    FilesystemWrite,
+    /// Path extracted from the named arg; checked via `policy.check_filesystem_delete`.
+    FilesystemDelete,
+    /// Host + port parsed from the named arg (URL or host:port);
+    /// checked via `policy.check_network_outbound`.
+    NetworkOutbound,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/policy/src/policy.rs
+++ b/crates/policy/src/policy.rs
@@ -216,7 +216,12 @@ impl Policy {
                 ));
             }
         };
-        if !server.allowed_tools.iter().any(|t| t == tool_name) {
+        // ADR-024: allowed_tools is now a Vec<AllowedTool> union
+        // (string shorthand or object with pre_validate clauses).
+        // The MCP-allowlist check still only cares about the name —
+        // the per-tool pre_validate clauses are consumed by the
+        // mediator (ADR-024-B) after this allow/deny decision.
+        if !server.allowed_tools.iter().any(|t| t.name() == tool_name) {
             return Decision::deny(format!(
                 "mcp tool call {server_name:?}/{tool_name:?} not granted: tool not in allowed_tools",
             ));

--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -289,9 +289,86 @@ tools:
     assert_eq!(mcp.len(), 2);
     assert_eq!(mcp[0].server_name, "fs-helper");
     assert_eq!(mcp[0].server_uri, "stdio:/usr/local/bin/mcp-fs");
-    assert_eq!(mcp[0].allowed_tools, vec!["read_file", "list_dir"]);
+    // Both shorthand entries deserialize as AllowedTool::Name; the
+    // accessor lets call sites stay name-only when they don't care
+    // about pre_validate clauses (which are absent here).
+    let names: Vec<&str> = mcp[0].allowed_tools.iter().map(|t| t.name()).collect();
+    assert_eq!(names, vec!["read_file", "list_dir"]);
+    for entry in &mcp[0].allowed_tools {
+        assert!(entry.pre_validate().is_empty(), "shorthand should have no clauses");
+    }
     assert_eq!(mcp[1].server_name, "web-search");
     assert!(mcp[1].allowed_tools.is_empty());
+}
+
+/// Per ADR-024-A. The object form of an `allowed_tools` entry
+/// declares per-tool pre-validation clauses. Both shapes can coexist
+/// in the same array (one entry as a bare name, another as an
+/// object) — the union deserializes via `#[serde(untagged)]`.
+#[test]
+fn mcp_allowed_tools_accepts_pre_validate_object_form() {
+    use aegis_policy::manifest::{AllowedTool, PreValidateKind};
+
+    let yaml = br#"
+schemaVersion: "1"
+agent: { name: "x", version: "1.0.0" }
+identity: { spiffeId: "spiffe://td/agent/x/1" }
+tools:
+  mcp:
+    - server_name: "fs"
+      server_uri: "stdio:/usr/local/bin/mcp-fs"
+      allowed_tools:
+        - "list_directory"
+        - name: "read_text_file"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "read_multiple_files"
+          pre_validate:
+            - kind: filesystem_read
+              arg_array: paths
+        - name: "write_file"
+          pre_validate:
+            - kind: filesystem_write
+              arg: path
+"#;
+    let p = Policy::from_yaml_bytes(yaml).unwrap();
+    let entries = &p.manifest().tools.mcp[0].allowed_tools;
+    assert_eq!(entries.len(), 4);
+
+    // Mixed shapes coexist in the array.
+    match &entries[0] {
+        AllowedTool::Name(n) => assert_eq!(n, "list_directory"),
+        other => panic!("expected shorthand, got {other:?}"),
+    }
+    match &entries[1] {
+        AllowedTool::WithPreValidate { name, pre_validate } => {
+            assert_eq!(name, "read_text_file");
+            assert_eq!(pre_validate.len(), 1);
+            assert_eq!(pre_validate[0].kind, PreValidateKind::FilesystemRead);
+            assert_eq!(pre_validate[0].arg.as_deref(), Some("path"));
+            assert_eq!(pre_validate[0].arg_array, None);
+        }
+        other => panic!("expected object form, got {other:?}"),
+    }
+
+    // arg_array variant.
+    match &entries[2] {
+        AllowedTool::WithPreValidate { name, pre_validate } => {
+            assert_eq!(name, "read_multiple_files");
+            assert_eq!(pre_validate[0].kind, PreValidateKind::FilesystemRead);
+            assert_eq!(pre_validate[0].arg, None);
+            assert_eq!(pre_validate[0].arg_array.as_deref(), Some("paths"));
+        }
+        other => panic!("expected object form, got {other:?}"),
+    }
+
+    // The MCP allowlist check still uses the name — pre_validate
+    // clauses don't affect the allow/deny decision (per the
+    // ADR-024-B mediator pass which runs separately).
+    assert!(p.check_mcp_tool("fs", "read_text_file").is_allow());
+    assert!(p.check_mcp_tool("fs", "list_directory").is_allow());
+    assert!(p.check_mcp_tool("fs", "delete_file").is_deny());
 }
 
 /// Per ADR-018 / issue #43. Malformed entry (missing `server_uri`) is rejected.

--- a/crates/policy/tests/integration.rs
+++ b/crates/policy/tests/integration.rs
@@ -295,7 +295,10 @@ tools:
     let names: Vec<&str> = mcp[0].allowed_tools.iter().map(|t| t.name()).collect();
     assert_eq!(names, vec!["read_file", "list_dir"]);
     for entry in &mcp[0].allowed_tools {
-        assert!(entry.pre_validate().is_empty(), "shorthand should have no clauses");
+        assert!(
+            entry.pre_validate().is_empty(),
+            "shorthand should have no clauses"
+        );
     }
     assert_eq!(mcp[1].server_name, "web-search");
     assert!(mcp[1].allowed_tools.is_empty());

--- a/pkg/manifest/decide.go
+++ b/pkg/manifest/decide.go
@@ -147,8 +147,13 @@ func (m *Manifest) decideMCPTool(server, tool string) Decision {
 		if s.ServerName != server {
 			continue
 		}
+		// ADR-024: AllowedTools entries are now AllowedTool (union of
+		// string shorthand + object form with pre_validate clauses).
+		// The MCP-allowlist check still only cares about the name —
+		// the per-tool pre_validate clauses are consumed by the
+		// mediator (ADR-024-B) after this allow/deny decision.
 		for _, t := range s.AllowedTools {
-			if t == tool {
+			if t.Name == tool {
 				return allowDecision()
 			}
 		}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -179,8 +179,8 @@ func TestLoadAgentWithMCPExample(t *testing.T) {
 		"create_directory": true,
 	}
 	for _, tool := range server.AllowedTools {
-		if writers[tool] {
-			t.Errorf("agent-with-mcp must stay read-only; %q is a writer", tool)
+		if writers[tool.Name] {
+			t.Errorf("agent-with-mcp must stay read-only; %q is a writer", tool.Name)
 		}
 	}
 
@@ -230,7 +230,7 @@ tools:
 	if m.Tools.MCP[0].ServerName != "fs-helper" ||
 		m.Tools.MCP[0].ServerURI != "stdio:/usr/local/bin/mcp-fs" ||
 		len(m.Tools.MCP[0].AllowedTools) != 2 ||
-		m.Tools.MCP[0].AllowedTools[0] != "read_file" {
+		m.Tools.MCP[0].AllowedTools[0].Name != "read_file" {
 		t.Errorf("mcp[0]: %+v", m.Tools.MCP[0])
 	}
 	if m.Tools.MCP[1].ServerName != "web-search" ||

--- a/pkg/manifest/schema_v1.json
+++ b/pkg/manifest/schema_v1.json
@@ -196,11 +196,57 @@
         },
         "allowed_tools": {
           "type": "array",
-          "description": "Names of MCP tools from this server the agent may invoke. Closed-by-default; empty array means none.",
-          "items": { "type": "string", "minLength": 1 },
+          "description": "Names of MCP tools from this server the agent may invoke. Closed-by-default; empty array means none. Each entry is either a bare name (string, one-layer enforcement: only the MCP allowlist gates) OR an object with optional `pre_validate` clauses that ask the mediator to also check the tool's args against `tools.filesystem.*` / `tools.network.*` policy before dispatch (per ADR-024).",
+          "items": { "$ref": "#/definitions/allowedTool" },
           "uniqueItems": true
         }
       }
+    },
+    "allowedTool": {
+      "description": "One MCP tool entry — a bare name (legacy / one-layer) or an object with per-tool pre-validation clauses (per ADR-024).",
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        {
+          "type": "object",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "pre_validate": {
+              "type": "array",
+              "description": "Side-effect clauses the mediator runs against `tools.filesystem.*` / `tools.network.*` after the MCP allowlist check, before dispatching to the MCP server. An empty or absent `pre_validate` collapses to the legacy one-layer behavior.",
+              "items": { "$ref": "#/definitions/preValidateClause" },
+              "uniqueItems": true
+            }
+          }
+        }
+      ]
+    },
+    "preValidateClause": {
+      "description": "One side-effect-shaped check the mediator should run on a named tool argument before dispatch. Phase 1 (ADR-024) supports filesystem_{read,write,delete} and network_outbound; exec_run is out of scope.",
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["filesystem_read", "filesystem_write", "filesystem_delete", "network_outbound"]
+        },
+        "arg": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the scalar argument carrying the path or URL the mediator should extract and check. Mutually exclusive with `arg_array`."
+        },
+        "arg_array": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of an array-of-strings argument; the mediator extracts each element and runs the check on it. Mutually exclusive with `arg`."
+        }
+      },
+      "oneOf": [
+        { "required": ["arg"] },
+        { "required": ["arg_array"] }
+      ]
     },
     "execGrant": {
       "type": "object",

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -9,6 +9,13 @@
 // embedded at build time so the validator is self-contained.
 package manifest
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
 // Manifest mirrors the schema at schemas/manifest/v1/manifest.schema.json.
 // Field names use the schema's spelling (camelCase for keys named in the
 // JSON-LD ledger context, snake_case for fields the schema spells that way).
@@ -109,10 +116,167 @@ type APIGrant struct {
 // Closed-by-default: an MCP tool call against a server not listed here is
 // denied + emits a Violation per F2.
 type MCPServerGrant struct {
-	ServerName   string   `yaml:"server_name" json:"server_name"`
-	ServerURI    string   `yaml:"server_uri" json:"server_uri"`
-	AllowedTools []string `yaml:"allowed_tools" json:"allowed_tools"`
+	ServerName   string        `yaml:"server_name" json:"server_name"`
+	ServerURI    string        `yaml:"server_uri" json:"server_uri"`
+	AllowedTools []AllowedTool `yaml:"allowed_tools" json:"allowed_tools"`
 }
+
+// AllowedTool is one entry in MCPServerGrant.AllowedTools (per ADR-024-A).
+// Two shapes are accepted at parse time:
+//
+//  1. String shorthand — `"read_text_file"` — interpreted as
+//     "no pre-validation; one-layer enforcement," preserving the
+//     pre-ADR-024 behavior. Stored with Name set, PreValidate empty.
+//  2. Object form — `{ name, pre_validate }` — declares side-effect
+//     clauses the mediator runs against `tools.filesystem.*` /
+//     `tools.network.*` policy before dispatching to the MCP server.
+//
+// The Rust side uses `#[serde(untagged)]`; here we implement custom
+// UnmarshalYAML / UnmarshalJSON that try the string form first, then
+// fall back to the object form. MarshalJSON / MarshalYAML serialize
+// back into whichever shape preserves the original input (string when
+// PreValidate is empty, object otherwise) so round-trips are stable.
+type AllowedTool struct {
+	// Tool name (matches the MCP server's tool catalog).
+	Name string `json:"name" yaml:"name"`
+	// Side-effect clauses the mediator pre-validates before dispatch.
+	// Empty / absent collapses to the string-shorthand semantics.
+	PreValidate []PreValidateClause `json:"pre_validate,omitempty" yaml:"pre_validate,omitempty"`
+}
+
+// UnmarshalJSON accepts either a JSON string or a JSON object.
+func (a *AllowedTool) UnmarshalJSON(data []byte) error {
+	// Strip leading whitespace per JSON spec; the first non-space byte
+	// tells us which branch to take.
+	for _, b := range data {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '"':
+			// String shorthand.
+			var s string
+			if err := json.Unmarshal(data, &s); err != nil {
+				return fmt.Errorf("allowed_tools entry: %w", err)
+			}
+			a.Name = s
+			a.PreValidate = nil
+			return nil
+		case '{':
+			// Object form. Use a typed shadow to avoid recursing into
+			// AllowedTool.UnmarshalJSON.
+			type allowedToolObj struct {
+				Name        string              `json:"name"`
+				PreValidate []PreValidateClause `json:"pre_validate"`
+			}
+			var obj allowedToolObj
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return fmt.Errorf("allowed_tools entry: %w", err)
+			}
+			if obj.Name == "" {
+				return fmt.Errorf("allowed_tools entry: object form requires non-empty `name`")
+			}
+			a.Name = obj.Name
+			a.PreValidate = obj.PreValidate
+			return nil
+		default:
+			return fmt.Errorf("allowed_tools entry: expected string or object, got %q", string(b))
+		}
+	}
+	return fmt.Errorf("allowed_tools entry: empty value")
+}
+
+// MarshalJSON emits the shorthand string form when PreValidate is
+// empty; otherwise emits the object form. Round-trips are stable as
+// long as the input used the same shape.
+func (a AllowedTool) MarshalJSON() ([]byte, error) {
+	if len(a.PreValidate) == 0 {
+		return json.Marshal(a.Name)
+	}
+	type allowedToolObj struct {
+		Name        string              `json:"name"`
+		PreValidate []PreValidateClause `json:"pre_validate"`
+	}
+	return json.Marshal(allowedToolObj{Name: a.Name, PreValidate: a.PreValidate})
+}
+
+// UnmarshalYAML accepts either a YAML scalar (string) or a YAML
+// mapping (object). Mirrors UnmarshalJSON's behavior — the parsed
+// shape is the same regardless of which surface delivered it.
+func (a *AllowedTool) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		// String shorthand. Reject non-string scalars (numbers, bools,
+		// nulls) explicitly — those would be a manifest authoring error.
+		if value.Tag != "" && value.Tag != "!!str" {
+			return fmt.Errorf("allowed_tools entry: scalar must be a string, got tag %q", value.Tag)
+		}
+		a.Name = value.Value
+		a.PreValidate = nil
+		return nil
+	case yaml.MappingNode:
+		// Object form. Decode into a shadow type to avoid recursion.
+		type allowedToolObj struct {
+			Name        string              `yaml:"name"`
+			PreValidate []PreValidateClause `yaml:"pre_validate"`
+		}
+		var obj allowedToolObj
+		if err := value.Decode(&obj); err != nil {
+			return fmt.Errorf("allowed_tools entry: %w", err)
+		}
+		if obj.Name == "" {
+			return fmt.Errorf("allowed_tools entry: object form requires non-empty `name`")
+		}
+		a.Name = obj.Name
+		a.PreValidate = obj.PreValidate
+		return nil
+	default:
+		return fmt.Errorf("allowed_tools entry: expected scalar or mapping, got node kind %d", value.Kind)
+	}
+}
+
+// MarshalYAML emits the shorthand string form when PreValidate is
+// empty; otherwise emits the object form (parallel to MarshalJSON).
+func (a AllowedTool) MarshalYAML() (interface{}, error) {
+	if len(a.PreValidate) == 0 {
+		return a.Name, nil
+	}
+	type allowedToolObj struct {
+		Name        string              `yaml:"name"`
+		PreValidate []PreValidateClause `yaml:"pre_validate"`
+	}
+	return allowedToolObj{Name: a.Name, PreValidate: a.PreValidate}, nil
+}
+
+// PreValidateClause is one side-effect-shaped pre-validation clause
+// for an AllowedTool object form (per ADR-024 §"Decision" item 2).
+// Phase 1 covers filesystem_{read,write,delete} + network_outbound.
+//
+// Exactly one of Arg / ArgArray must be set; the JSON Schema enforces
+// this via `oneOf`. The Go validator surfaces a typed error if both
+// or neither are present (see validate/rules.go).
+type PreValidateClause struct {
+	// Side-effect family this clause gates against.
+	Kind PreValidateKind `yaml:"kind" json:"kind"`
+	// Name of the scalar argument carrying the path or URL the
+	// mediator should extract and check.
+	Arg string `yaml:"arg,omitempty" json:"arg,omitempty"`
+	// Name of an array-of-strings argument; the mediator extracts
+	// each element and runs the check on it.
+	ArgArray string `yaml:"arg_array,omitempty" json:"arg_array,omitempty"`
+}
+
+// PreValidateKind enumerates the side-effect families a
+// PreValidateClause can gate against. Adding a new kind requires
+// (a) a constant here, (b) the JSON Schema enum bump, (c) the
+// matching policy.check_* method on the Rust side.
+type PreValidateKind string
+
+const (
+	PreValidateFilesystemRead   PreValidateKind = "filesystem_read"
+	PreValidateFilesystemWrite  PreValidateKind = "filesystem_write"
+	PreValidateFilesystemDelete PreValidateKind = "filesystem_delete"
+	PreValidateNetworkOutbound  PreValidateKind = "network_outbound"
+)
 
 type WriteGrant struct {
 	Resource         string   `yaml:"resource" json:"resource"`

--- a/schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml
+++ b/schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml
@@ -2,17 +2,23 @@
 # Anthropic filesystem MCP server (@modelcontextprotocol/server-filesystem)
 # in read-only mode.
 #
-# Per ADR-018 (F2-MCP-D / issue #46). Demonstrates the layered enforcement
-# Aegis-Node provides for MCP tool calls:
+# Per ADR-018 (F2-MCP-D / issue #46) + ADR-024 (MCP arg pre-validation).
+# Demonstrates the two-layer enforcement Aegis-Node provides for MCP
+# tool calls:
 #
 #   1. tools.mcp[] gates the *call* — closed-by-default per server + tool.
-#   2. The MCP server's underlying side effects (e.g. read_text_file
-#      issuing a real fs read) flow through Session::mediate_filesystem_*
-#      and are authorized by tools.filesystem.read separately.
+#   2. Per ADR-024-A, allowed_tools entries may declare `pre_validate`
+#      clauses naming which arg the mediator should extract and check
+#      against tools.filesystem.* / tools.network.* policy *before*
+#      dispatching to the MCP server. This is the layer that catches
+#      e.g. read_text_file({path: "/etc/passwd"}) when /etc isn't in
+#      tools.filesystem.read — even though the MCP allowlist permits
+#      read_text_file.
 #
-# Both layers must permit the operation. The MCP allowlist is not a
-# replacement for the syscall gate; it's an additional check that names
-# the protocol-level intent.
+# The mediator that consumes `pre_validate` is ADR-024-B (forthcoming);
+# this example manifest lights up both shapes (string shorthand for
+# tools whose args don't carry side-effect-shaped paths, object form
+# for tools that do) so cross-language conformance covers the union.
 #
 # Real-world launch (out of band of the manifest):
 #
@@ -47,13 +53,42 @@ tools:
       # (write_file, edit_file, move_file, create_directory) are
       # deliberately omitted — closed-by-default keeps them denied
       # regardless of what the upstream server advertises.
+      #
+      # Tools whose args carry filesystem-shaped paths use the object
+      # form to declare a pre_validate clause; tools whose args don't
+      # (list_allowed_directories, get_file_info on a known path) stay
+      # on the string shorthand for terseness.
       allowed_tools:
-        - "read_text_file"
-        - "read_multiple_files"
-        - "list_directory"
-        - "list_directory_with_sizes"
-        - "directory_tree"
-        - "search_files"
-        - "get_file_info"
+        - name: "read_text_file"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "read_multiple_files"
+          pre_validate:
+            - kind: filesystem_read
+              arg_array: paths
+        - name: "list_directory"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "list_directory_with_sizes"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "directory_tree"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "search_files"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "get_file_info"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        # Bare-name shorthand: returns the configured allowed roots,
+        # no path argument to pre-validate. The MCP allowlist still
+        # gates the call.
         - "list_allowed_directories"
 write_grants: []

--- a/schemas/manifest/v1/manifest.schema.json
+++ b/schemas/manifest/v1/manifest.schema.json
@@ -196,11 +196,57 @@
         },
         "allowed_tools": {
           "type": "array",
-          "description": "Names of MCP tools from this server the agent may invoke. Closed-by-default; empty array means none.",
-          "items": { "type": "string", "minLength": 1 },
+          "description": "Names of MCP tools from this server the agent may invoke. Closed-by-default; empty array means none. Each entry is either a bare name (string, one-layer enforcement: only the MCP allowlist gates) OR an object with optional `pre_validate` clauses that ask the mediator to also check the tool's args against `tools.filesystem.*` / `tools.network.*` policy before dispatch (per ADR-024).",
+          "items": { "$ref": "#/definitions/allowedTool" },
           "uniqueItems": true
         }
       }
+    },
+    "allowedTool": {
+      "description": "One MCP tool entry — a bare name (legacy / one-layer) or an object with per-tool pre-validation clauses (per ADR-024).",
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        {
+          "type": "object",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "pre_validate": {
+              "type": "array",
+              "description": "Side-effect clauses the mediator runs against `tools.filesystem.*` / `tools.network.*` after the MCP allowlist check, before dispatching to the MCP server. An empty or absent `pre_validate` collapses to the legacy one-layer behavior.",
+              "items": { "$ref": "#/definitions/preValidateClause" },
+              "uniqueItems": true
+            }
+          }
+        }
+      ]
+    },
+    "preValidateClause": {
+      "description": "One side-effect-shaped check the mediator should run on a named tool argument before dispatch. Phase 1 (ADR-024) supports filesystem_{read,write,delete} and network_outbound; exec_run is out of scope.",
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["filesystem_read", "filesystem_write", "filesystem_delete", "network_outbound"]
+        },
+        "arg": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the scalar argument carrying the path or URL the mediator should extract and check. Mutually exclusive with `arg_array`."
+        },
+        "arg_array": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of an array-of-strings argument; the mediator extracts each element and runs the check on it. Mutually exclusive with `arg`."
+        }
+      },
+      "oneOf": [
+        { "required": ["arg"] },
+        { "required": ["arg_array"] }
+      ]
     },
     "execGrant": {
       "type": "object",

--- a/tests/conformance/cases.json
+++ b/tests/conformance/cases.json
@@ -286,6 +286,39 @@
         "mcp_tool": "search"
       },
       "expected": "deny"
+    },
+    {
+      "_doc": "ADR-024-A: an entry in object form (name + pre_validate clauses) is still allowed by tools.mcp[] — the MCP allowlist check uses the entry's name regardless of which shape the manifest used. The pre_validate clauses themselves are consumed by ADR-024-B's mediator pass.",
+      "name": "mcp_pre_validate_object_form_allows_by_name",
+      "manifest": "manifests/mcp-pre-validate.manifest.yaml",
+      "query": {
+        "kind": "mcp_tool_call",
+        "mcp_server": "fs",
+        "mcp_tool": "read_text_file"
+      },
+      "expected": "allow"
+    },
+    {
+      "_doc": "ADR-024-A: string shorthand and object form coexist in the same allowed_tools array. The shorthand entry list_allowed_directories deserializes as AllowedTool::Name and is allowed.",
+      "name": "mcp_pre_validate_string_shorthand_coexists",
+      "manifest": "manifests/mcp-pre-validate.manifest.yaml",
+      "query": {
+        "kind": "mcp_tool_call",
+        "mcp_server": "fs",
+        "mcp_tool": "list_allowed_directories"
+      },
+      "expected": "allow"
+    },
+    {
+      "_doc": "ADR-024-A: a tool name absent from allowed_tools is still denied even when sibling object-form entries declare pre_validate clauses. The schema-bump is additive — closed-by-default semantics are preserved.",
+      "name": "mcp_pre_validate_unlisted_tool_denied",
+      "manifest": "manifests/mcp-pre-validate.manifest.yaml",
+      "query": {
+        "kind": "mcp_tool_call",
+        "mcp_server": "fs",
+        "mcp_tool": "delete_file"
+      },
+      "expected": "deny"
     }
   ]
 }

--- a/tests/conformance/manifests/mcp-pre-validate.manifest.yaml
+++ b/tests/conformance/manifests/mcp-pre-validate.manifest.yaml
@@ -1,0 +1,62 @@
+# Conformance fixture for ADR-024-A: per-tool pre_validate clauses on
+# tools.mcp[].allowed_tools. Mixes both shapes (string shorthand +
+# object form) in the same array so cross-language deserializers
+# exercise the union.
+#
+# This fixture is paired with cases.json entries that assert:
+#   - the MCP allow/deny decision (still based on the tool name only)
+#     matches the legacy mcp-allowlist.manifest.yaml semantics;
+#   - the parsed manifest preserves both shapes (asserted by
+#     pkg/manifest's manifest_test.go and crates/policy's
+#     integration.rs).
+#
+# The mediator that consumes the pre_validate clauses lands in
+# ADR-024-B (#104); this PR is schema-only.
+schemaVersion: "1"
+agent:
+  name: "mcp-pre-validate-conformance"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/mcp-pre-validate-conformance/inst-001"
+tools:
+  filesystem:
+    read:
+      - "/data"
+    write:
+      - "/tmp"
+  network:
+    outbound:
+      allowlist:
+        - host: "api.example.com"
+          port: 443
+          protocol: https
+  mcp:
+    - server_name: "fs"
+      server_uri: "stdio:/usr/local/bin/mcp-fs"
+      allowed_tools:
+        # String shorthand — no pre-validation. Lives alongside
+        # object-form entries in the same array.
+        - "list_allowed_directories"
+        # Object form — single arg (scalar path).
+        - name: "read_text_file"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        # Object form — array-of-strings arg.
+        - name: "read_multiple_files"
+          pre_validate:
+            - kind: filesystem_read
+              arg_array: paths
+        # Object form — write-shaped clause.
+        - name: "write_file"
+          pre_validate:
+            - kind: filesystem_write
+              arg: path
+    - server_name: "net"
+      server_uri: "stdio:/usr/local/bin/mcp-net"
+      allowed_tools:
+        # network_outbound clause — host+port parsed from a URL arg.
+        - name: "fetch"
+          pre_validate:
+            - kind: network_outbound
+              arg: url


### PR DESCRIPTION
## Summary

ADR-024-A under [ADR-024](docs/adrs/024-mcp-args-prevalidation.md) / [#103](https://github.com/tosin2013/aegis-node/issues/103). Schema-only first step toward MCP arg pre-validation: extend `tools.mcp[].allowed_tools` from `Vec<String>` to a **string-or-object union** so manifests can declare per-tool side-effect mappings the mediator will check against `tools.filesystem.*` / `tools.network.*` policy before dispatching to the MCP server. The mediator pass that consumes `pre_validate` clauses lands in **ADR-024-B ([#104](https://github.com/tosin2013/aegis-node/issues/104))**.

## Schema shape

```yaml
tools:
  mcp:
    - server_name: "filesystem"
      server_uri: "stdio:/usr/local/bin/mcp-server-filesystem"
      allowed_tools:
        # Bare-name shorthand — no pre-validation; one-layer enforcement.
        - "list_allowed_directories"
        # Object form — declares the arg the mediator extracts.
        - name: "read_text_file"
          pre_validate:
            - kind: filesystem_read
              arg: path
        - name: "read_multiple_files"
          pre_validate:
            - kind: filesystem_read
              arg_array: paths
        - name: "write_file"
          pre_validate:
            - kind: filesystem_write
              arg: path
```

`kind` enum (Phase 1): `filesystem_read`, `filesystem_write`, `filesystem_delete`, `network_outbound`. `exec_run` is out of scope.

## Cross-language types

- **Rust** (`crates/policy/src/manifest.rs`): `Vec<AllowedTool>` where `AllowedTool` is `#[serde(untagged)]` over `Name(String) | WithPreValidate { name, pre_validate }`. New `PreValidateClause` + `PreValidateKind` types.
- **Go** (`pkg/manifest/types.go`): `[]AllowedTool` with custom `UnmarshalYAML` / `UnmarshalJSON` (string first, object fallback) and matching marshalers that emit the shorthand when `PreValidate` is empty so round-trips are stable.
- **JSON Schema**: `oneOf [string, object{name, pre_validate}]` at `#/definitions/allowedTool`; `pre_validate` items are `oneOf [{required: arg}, {required: arg_array}]` at `#/definitions/preValidateClause`.

## Acceptance against #103

- [x] `schemas/manifest/v1/manifest.schema.json` updated with the union type + `AllowedTool` + `PreValidateClause` definitions.
- [x] `pkg/manifest/types.go` — Go custom YAML/JSON unmarshaller for the union.
- [x] `crates/policy/src/manifest.rs` — Rust `#[serde(untagged)]` enum.
- [x] `pkg/manifest/schema_v1.json` re-synced (file-level diff against the canonical schema is zero).
- [x] `tests/conformance/cases.json` gains 3 fixtures for both shapes (`mcp_pre_validate_object_form_allows_by_name`, `mcp_pre_validate_string_shorthand_coexists`, `mcp_pre_validate_unlisted_tool_denied`) backed by `mcp-pre-validate.manifest.yaml`.
- [x] `schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml` updated to use `pre_validate` for the Anthropic filesystem MCP's path-shaped tools (`read_text_file`, `read_multiple_files`, `list_directory`, etc.).
- [x] `aegis validate` continues to accept all existing committed manifests.

## Backwards compatibility

The existing string-shorthand form still parses and behaves identically — `AllowedTool::Name(s)` deserializes from a JSON/YAML string, `.name()` returns it, and `check_mcp_tool` walks names regardless of which shape the manifest used. New `pre_validate` clauses are opt-in per ADR-024 §"Decision" item 3.

## Test plan

- [x] `cargo test -p aegis-policy --workspace` — 18 pass (was 17, +1 mixed-shape case)
- [x] `cargo test -p aegis-policy --test conformance` — green
- [x] `go test ./pkg/manifest/` — ok (incl. conformance fixture round-trip)
- [x] `go test ./pkg/validate/` — ok (every committed example still passes)
- [x] `cargo clippy --workspace --exclude aegis-litertlm-backend --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)