### PR TITLE
feat(adr-024-b): mediator pre-validation pass for MCP tool args (#104)

### DIFF
--- a/crates/inference-engine/src/error.rs
+++ b/crates/inference-engine/src/error.rs
@@ -63,6 +63,24 @@ pub enum Error {
     #[error("access-log: {0}")]
     AccessLog(#[from] aegis_access_log::Error),
 
+    /// An ADR-024-A `pre_validate` clause names an arg that's missing
+    /// from the tool call's payload, or is the wrong shape (e.g. clause
+    /// declared `arg: path` but the payload has no `path` field, or
+    /// the field is not a string). Surfaced as a denial — the model's
+    /// tool call gets a Violation entry rather than crashing the
+    /// session or silently dispatching.
+    #[error("pre_validate clause for mcp tool {server:?}/{tool:?} arg {arg:?}: {reason}")]
+    McpPreValidateMalformedArg {
+        /// MCP server name from `tools.mcp[]`.
+        server: String,
+        /// Tool name from `allowed_tools`.
+        tool: String,
+        /// Arg name the clause referenced.
+        arg: String,
+        /// What's wrong (missing, not-a-string, not-an-array, etc.).
+        reason: String,
+    },
+
     #[error("denied: {reason}")]
     Denied { reason: String },
 

--- a/crates/inference-engine/src/mediator.rs
+++ b/crates/inference-engine/src/mediator.rs
@@ -30,7 +30,11 @@ use aegis_access_log::{
 };
 use aegis_approval_gate::{ApprovalOutcome, ApprovalRequest, DEFAULT_TIMEOUT};
 use aegis_ledger_writer::{Entry, EntryType};
-use aegis_policy::{check_identity_binding, Decision, NetworkProto};
+use aegis_policy::{
+    check_identity_binding,
+    manifest::{PreValidateClause, PreValidateKind},
+    Decision, NetworkProto,
+};
 use chrono::Utc;
 use serde_json::{Map, Value};
 use uuid::Uuid;
@@ -293,7 +297,7 @@ impl Session {
                 return Err(Error::RequireApproval { reason });
             }
         }
-        let server_uri = match self
+        let server_grant = match self
             .policy()
             .manifest()
             .tools
@@ -301,7 +305,7 @@ impl Session {
             .iter()
             .find(|s| s.server_name == server_name)
         {
-            Some(s) => s.server_uri.clone(),
+            Some(s) => s,
             None => {
                 let reason = format!(
                     "mcp tool call to server {server_name:?} not granted: server not in tools.mcp[]",
@@ -310,6 +314,33 @@ impl Session {
                 return Err(Error::Denied { reason });
             }
         };
+        let server_uri = server_grant.server_uri.clone();
+
+        // ADR-024-B: per-tool pre-validation. After the MCP allowlist
+        // check passes (above), look up this tool's `allowed_tools`
+        // entry. If it's an object form with `pre_validate` clauses,
+        // run each clause against the matching `policy.check_*` gate
+        // before dispatching to the MCP server. The shorthand-string
+        // form has no clauses → behavior is unchanged (one-layer
+        // enforcement). Denials surface as Violation entries with a
+        // distinguishable `mcp-prevalidate://server/tool?arg=value`
+        // resource_uri so an auditor can tell which layer refused.
+        let pre_validate_clauses: Vec<PreValidateClause> = server_grant
+            .allowed_tools
+            .iter()
+            .find(|t| t.name() == tool_name)
+            .map(|t| t.pre_validate().to_vec())
+            .unwrap_or_default();
+        if !pre_validate_clauses.is_empty() {
+            self.run_mcp_pre_validate(
+                server_name,
+                tool_name,
+                &args,
+                &pre_validate_clauses,
+                reasoning_step_id,
+            )?;
+        }
+
         let mut client = match self.mcp_client.take() {
             Some(c) => c,
             None => {
@@ -333,6 +364,82 @@ impl Session {
             reasoning_step_id,
         )?;
         Ok(value)
+    }
+
+    /// ADR-024-B: run the manifest-declared `pre_validate` clauses
+    /// for an MCP tool call between the allowlist check and the
+    /// dispatch to the MCP server.
+    ///
+    /// On the first denial: emit a Violation entry with a
+    /// `mcp-prevalidate://<server>/<tool>?<arg>=<value>` resource_uri
+    /// (so an auditor can distinguish "MCP allowlist denied" from
+    /// "filesystem gate denied via MCP pre-validation"), then return
+    /// [`Error::Denied`]. Subsequent clauses on the same call do not
+    /// run — the call is refused as a whole.
+    ///
+    /// On a malformed arg (clause names a field that's missing or
+    /// the wrong shape), return [`Error::McpPreValidateMalformedArg`].
+    /// The model's tool call gets denied — better than dispatching
+    /// against an undefined arg or crashing the session.
+    fn run_mcp_pre_validate(
+        &mut self,
+        server_name: &str,
+        tool_name: &str,
+        args: &Value,
+        clauses: &[PreValidateClause],
+        _reasoning_step_id: Option<&str>,
+    ) -> Result<()> {
+        for clause in clauses {
+            let values = extract_clause_values(args, server_name, tool_name, clause)?;
+            // Capture session_start before any &mut self call below
+            // so we don't conflict with the immutable policy() borrow.
+            let session_start = self.session_start();
+            for value in values {
+                let arg_name = clause
+                    .arg
+                    .as_deref()
+                    .or(clause.arg_array.as_deref())
+                    .unwrap_or("?");
+                let decision = match clause.kind {
+                    PreValidateKind::FilesystemRead => {
+                        self.policy().check_filesystem_read(Path::new(&value))
+                    }
+                    PreValidateKind::FilesystemWrite => {
+                        let now = Utc::now();
+                        self.policy()
+                            .check_filesystem_write(Path::new(&value), now, session_start)
+                    }
+                    PreValidateKind::FilesystemDelete => {
+                        let now = Utc::now();
+                        self.policy()
+                            .check_filesystem_delete(Path::new(&value), now, session_start)
+                    }
+                    PreValidateKind::NetworkOutbound => {
+                        let (host, port) =
+                            parse_pre_validate_url(&value, server_name, tool_name, arg_name)?;
+                        self.policy()
+                            .check_network_outbound(&host, port, NetworkProto::Tcp)
+                    }
+                };
+                match decision {
+                    Decision::Allow => continue,
+                    Decision::Deny { reason } => {
+                        let resource_uri = format!(
+                            "mcp-prevalidate://{server_name}/{tool_name}?{arg_name}={value}"
+                        );
+                        self.emit_deny(&resource_uri, "mcp_pre_validate", &reason)?;
+                        return Err(Error::Denied { reason });
+                    }
+                    Decision::RequireApproval { reason } => {
+                        // Phase 1 — approvals over MCP pre-validate
+                        // not yet wired (parity with the existing
+                        // mediate_mcp_tool_call branch).
+                        return Err(Error::RequireApproval { reason });
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Exec a program with full mediation. Returns the captured Output.
@@ -633,6 +740,181 @@ fn file_uri(path: &Path) -> String {
 
 fn mcp_uri(server_name: &str, tool_name: &str) -> String {
     format!("mcp://{server_name}/{tool_name}")
+}
+
+/// Extract the value(s) a [`PreValidateClause`] points at from the
+/// MCP tool-call payload (which is a free-form `serde_json::Value`).
+///
+/// - `arg: <key>` — `args[key]` must be a JSON string. Returns one
+///   element.
+/// - `arg_array: <key>` — `args[key]` must be a JSON array of
+///   strings. Returns one element per array entry.
+/// - Both unset / both set → schema bug (the JSON Schema's `oneOf`
+///   normally catches this; we fail closed if it slips through).
+///
+/// Errors map to [`Error::McpPreValidateMalformedArg`] — the model's
+/// tool call gets denied with a typed reason rather than crashing
+/// the session.
+fn extract_clause_values(
+    args: &Value,
+    server_name: &str,
+    tool_name: &str,
+    clause: &PreValidateClause,
+) -> Result<Vec<String>> {
+    let make_err = |arg: &str, reason: String| Error::McpPreValidateMalformedArg {
+        server: server_name.to_string(),
+        tool: tool_name.to_string(),
+        arg: arg.to_string(),
+        reason,
+    };
+
+    match (clause.arg.as_deref(), clause.arg_array.as_deref()) {
+        (Some(key), None) => {
+            let v = args.get(key).ok_or_else(|| {
+                make_err(
+                    key,
+                    "required by pre_validate clause but missing from tool args".to_string(),
+                )
+            })?;
+            let s = v
+                .as_str()
+                .ok_or_else(|| {
+                    make_err(
+                        key,
+                        format!("expected JSON string, got {}", json_type_name(v)),
+                    )
+                })?
+                .to_string();
+            Ok(vec![s])
+        }
+        (None, Some(key)) => {
+            let v = args.get(key).ok_or_else(|| {
+                make_err(
+                    key,
+                    "required by pre_validate clause but missing from tool args".to_string(),
+                )
+            })?;
+            let arr = v.as_array().ok_or_else(|| {
+                make_err(
+                    key,
+                    format!(
+                        "expected JSON array (arg_array clause), got {}",
+                        json_type_name(v)
+                    ),
+                )
+            })?;
+            let mut out = Vec::with_capacity(arr.len());
+            for (i, elem) in arr.iter().enumerate() {
+                let s = elem.as_str().ok_or_else(|| {
+                    make_err(
+                        key,
+                        format!(
+                            "array element {i} is {}, expected string",
+                            json_type_name(elem)
+                        ),
+                    )
+                })?;
+                out.push(s.to_string());
+            }
+            Ok(out)
+        }
+        (Some(_), Some(_)) => Err(make_err(
+            "<both>",
+            "pre_validate clause has both `arg` and `arg_array` set; schema oneOf is supposed to refuse this".to_string(),
+        )),
+        (None, None) => Err(make_err(
+            "<neither>",
+            "pre_validate clause has neither `arg` nor `arg_array`; schema oneOf is supposed to require one".to_string(),
+        )),
+    }
+}
+
+/// Friendly JSON type name for error messages.
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Parse a URL-shaped string into `(host, port)` for the
+/// `network_outbound` pre-validate clause. Phase 1 supports:
+///
+/// - Full URL (`https://api.example.com:8443/foo`) → host +
+///   explicit port if present, otherwise the scheme's default
+///   (80 / 443) for `http` / `https`.
+/// - Bare `host:port` (no scheme) — common when an MCP tool's
+///   `target` arg is a host:port pair.
+///
+/// Anything else is a malformed-arg error. We refuse rather than
+/// guessing — the manifest declared `kind: network_outbound`, so
+/// the caller should be passing something parseable.
+fn parse_pre_validate_url(
+    raw: &str,
+    server_name: &str,
+    tool_name: &str,
+    arg_name: &str,
+) -> Result<(String, u16)> {
+    let make_err = |reason: String| Error::McpPreValidateMalformedArg {
+        server: server_name.to_string(),
+        tool: tool_name.to_string(),
+        arg: arg_name.to_string(),
+        reason,
+    };
+
+    // Strip a leading scheme if present.
+    let (default_port, after_scheme) = if let Some(rest) = raw.strip_prefix("https://") {
+        (Some(443u16), rest)
+    } else if let Some(rest) = raw.strip_prefix("http://") {
+        (Some(80u16), rest)
+    } else if raw.contains("://") {
+        // Some other scheme — refuse rather than misinterpret.
+        return Err(make_err(format!(
+            "unsupported URL scheme in {raw:?} (Phase 1 supports http/https or bare host:port)"
+        )));
+    } else {
+        (None, raw)
+    };
+
+    // Split off path / query / fragment so they don't leak into the
+    // host parser.
+    let host_port = after_scheme
+        .split_once('/')
+        .map(|(hp, _)| hp)
+        .unwrap_or(after_scheme);
+    let host_port = host_port
+        .split_once('?')
+        .map(|(hp, _)| hp)
+        .unwrap_or(host_port);
+
+    if host_port.is_empty() {
+        return Err(make_err(format!("empty host in {raw:?}")));
+    }
+
+    if let Some((host, port_str)) = host_port.rsplit_once(':') {
+        let port: u16 = port_str.parse().map_err(|_| {
+            make_err(format!(
+                "port component {port_str:?} in {raw:?} is not a valid u16"
+            ))
+        })?;
+        if host.is_empty() {
+            return Err(make_err(format!("empty host before port in {raw:?}")));
+        }
+        Ok((host.to_string(), port))
+    } else {
+        // No `:port` — only valid for the http/https schemes where
+        // a default exists.
+        let port = default_port.ok_or_else(|| {
+            make_err(format!(
+                "no port in {raw:?} and no scheme to imply a default (try host:port)"
+            ))
+        })?;
+        Ok((host_port.to_string(), port))
+    }
 }
 
 fn network_uri(host: &str, port: u16, proto: NetworkProto) -> String {

--- a/crates/inference-engine/tests/mediator.rs
+++ b/crates/inference-engine/tests/mediator.rs
@@ -881,3 +881,259 @@ fn mcp_disallowed_tool_on_allowed_server_emits_violation() {
         "mcp://fs-helper/delete_everything"
     );
 }
+
+// ---------------------------------------------------------------------------
+// ADR-024-B: per-tool pre-validation pass.
+//
+// Manifest declares an `allowed_tools` entry in object form with a
+// `pre_validate` clause; the mediator extracts the named arg from the
+// tool-call payload and runs it through the corresponding policy gate
+// before dispatching to the MCP client.
+//
+// 5 paths covered (per LiteRT-024-B acceptance criteria):
+//   - allowed-by-pre-validate (path inside tools.filesystem.read)
+//   - denied-by-pre-validate (path NOT inside tools.filesystem.read)
+//   - denied-by-pre-validate-array (one element of arg_array denied)
+//   - no-pre-validate (string-shape allowed_tool keeps current behavior)
+//   - malformed-arg (clause names a missing field) → typed error
+
+const PRE_VALIDATE_FS_YAML: &str = r#"schemaVersion: "1"
+agent: { name: "m", version: "1.0.0" }
+identity: { spiffeId: "spiffe://mediator.local/agent/research/inst-1" }
+tools:
+  filesystem:
+    read: ["/data"]
+  mcp:
+    - server_name: "fs"
+      server_uri: "stdio:/bin/true"
+      allowed_tools:
+        - name: "read_text_file"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "read_multiple_files"
+          pre_validate:
+            - kind: filesystem_read
+              arg_array: paths
+        # Shorthand-string entry: no pre_validate clause, dispatch
+        # proceeds without the extra check (parity with pre-ADR-024
+        # behavior).
+        - "list_allowed_directories"
+"#;
+
+#[test]
+fn mcp_pre_validate_allows_when_path_in_filesystem_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "pv-allow", PRE_VALIDATE_FS_YAML);
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({"contents": "ok"}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    let result = s
+        .mediate_mcp_tool_call(
+            "fs",
+            "read_text_file",
+            json!({"path": "/data/note.txt"}),
+            None,
+        )
+        .unwrap();
+    assert_eq!(result, json!({"contents": "ok"}));
+    s.shutdown().unwrap();
+
+    // Client was reached → Access entry, no Violation.
+    let entries = read_lines(&ledger);
+    assert_eq!(calls.lock().unwrap().len(), 1, "client must be invoked");
+    assert_eq!(entries[1]["entryType"], "access");
+    assert_eq!(entries[1]["accessType"], "mcp_tool_call");
+    assert_eq!(entries[1]["resourceUri"], "mcp://fs/read_text_file");
+}
+
+#[test]
+fn mcp_pre_validate_denies_when_path_outside_filesystem_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "pv-deny", PRE_VALIDATE_FS_YAML);
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    let err = s
+        .mediate_mcp_tool_call("fs", "read_text_file", json!({"path": "/etc/passwd"}), None)
+        .unwrap_err();
+    assert!(matches!(err, Error::Denied { .. }), "got {err:?}");
+    s.shutdown().unwrap();
+
+    // Pre-validate caught it before dispatch → no client invocation,
+    // and the Violation's resource_uri uses the mcp-prevalidate://
+    // scheme so an auditor can tell which layer refused.
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "client must NOT be invoked when pre_validate denies"
+    );
+    let entries = read_lines(&ledger);
+    let violation = entries
+        .iter()
+        .find(|e| e["entryType"] == "violation")
+        .expect("violation entry");
+    assert_eq!(violation["accessType"], "mcp_pre_validate");
+    let uri = violation["resourceUri"].as_str().unwrap();
+    assert!(
+        uri.starts_with("mcp-prevalidate://fs/read_text_file?path="),
+        "expected mcp-prevalidate URI, got {uri}"
+    );
+    assert!(
+        uri.contains("/etc/passwd"),
+        "uri should carry the value: {uri}"
+    );
+}
+
+#[test]
+fn mcp_pre_validate_arg_array_denies_on_first_disallowed_element() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "pv-array", PRE_VALIDATE_FS_YAML);
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    // First path is allowed, second is not → whole call is denied.
+    let err = s
+        .mediate_mcp_tool_call(
+            "fs",
+            "read_multiple_files",
+            json!({"paths": ["/data/a.txt", "/etc/passwd"]}),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(err, Error::Denied { .. }), "got {err:?}");
+    s.shutdown().unwrap();
+
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "client must NOT be invoked when any array element is denied"
+    );
+    let entries = read_lines(&ledger);
+    let violation = entries
+        .iter()
+        .find(|e| e["entryType"] == "violation")
+        .expect("violation entry");
+    let uri = violation["resourceUri"].as_str().unwrap();
+    assert!(
+        uri.contains("paths=/etc/passwd"),
+        "uri should name the offending element: {uri}"
+    );
+}
+
+#[test]
+fn mcp_pre_validate_string_shorthand_keeps_one_layer_behavior() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let (s, ledger) = boot(
+        dir.path(),
+        ca_dir.path(),
+        "pv-shorthand",
+        PRE_VALIDATE_FS_YAML,
+    );
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({"directories": ["/data"]}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    // list_allowed_directories is the bare-name shorthand entry —
+    // no pre_validate clause, so the call dispatches without extra
+    // checking even though we pass an arg the policy would reject
+    // if it were checked.
+    let result = s
+        .mediate_mcp_tool_call(
+            "fs",
+            "list_allowed_directories",
+            json!({"unused_path": "/etc/passwd"}),
+            None,
+        )
+        .unwrap();
+    assert_eq!(result, json!({"directories": ["/data"]}));
+    s.shutdown().unwrap();
+
+    assert_eq!(
+        calls.lock().unwrap().len(),
+        1,
+        "string-shorthand entry must dispatch (one-layer enforcement only)"
+    );
+    let entries = read_lines(&ledger);
+    assert_eq!(entries[1]["entryType"], "access");
+    assert_eq!(entries[1]["accessType"], "mcp_tool_call");
+}
+
+#[test]
+fn mcp_pre_validate_missing_arg_returns_typed_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    init_ca(ca_dir.path());
+
+    let (s, ledger) = boot(
+        dir.path(),
+        ca_dir.path(),
+        "pv-malformed",
+        PRE_VALIDATE_FS_YAML,
+    );
+    let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = MockMcpClient {
+        response: json!({}),
+        calls: calls.clone(),
+    };
+    let mut s = s.with_mcp_client(Box::new(client));
+
+    // Clause says `arg: path` but the payload has no `path` field.
+    let err = s
+        .mediate_mcp_tool_call(
+            "fs",
+            "read_text_file",
+            json!({"oops": "/data/note.txt"}),
+            None,
+        )
+        .unwrap_err();
+    match err {
+        Error::McpPreValidateMalformedArg {
+            server, tool, arg, ..
+        } => {
+            assert_eq!(server, "fs");
+            assert_eq!(tool, "read_text_file");
+            assert_eq!(arg, "path");
+        }
+        other => panic!("wrong error variant: {other:?}"),
+    }
+    s.shutdown().unwrap();
+
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "client must NOT be invoked on malformed-arg error"
+    );
+    // Note: the malformed-arg path is currently surfaced as the
+    // typed error without emitting a Violation — symmetric with the
+    // existing `no mcp client configured` branch, which also
+    // short-circuits before any ledger entry. The default ledger
+    // sequence here is start + network_attestation + end (3
+    // entries; no violation/access for this call).
+    let entries = read_lines(&ledger);
+    assert_eq!(entries.len(), 3, "{entries:#?}");
+}


### PR DESCRIPTION
## Summary

ADR-024-B under [ADR-024](docs/adrs/024-mcp-args-prevalidation.md) / [#104](https://github.com/tosin2013/aegis-node/issues/104). Wires the per-tool `pre_validate` clauses from ADR-024-A (#103) through the runtime: the mediator now extracts the named arg from each MCP tool call's payload and runs it through the matching `policy.check_*` gate **before** dispatching to the MCP server.

## Insertion in `mediate_mcp_tool_call`

```text
rebind                                    (existing)
policy.check_mcp_tool                     (existing)
── if allowed_tool entry has pre_validate clauses:    ← NEW
     for each clause:
       extract arg/arg_array from request.arguments
       dispatch to policy.check_filesystem_*/check_network_outbound
       on Deny: emit Violation w/ mcp-prevalidate://server/tool?arg=value
                resource_uri, return Error::Denied
       on malformed arg: return Error::McpPreValidateMalformedArg
client.call_tool                          (existing)
emit Access                                (existing)
```

## Distinguishable Violation URI

A pre-validate denial emits a Violation with **`mcp-prevalidate://<server>/<tool>?<arg>=<value>`** so an auditor can tell "MCP allowlist denied" (`mcp://`) from "filesystem gate denied via MCP pre-validation" (`mcp-prevalidate://`) at a glance — the two-layer story per ADR-024 §"Decision" item 2.

| layer | resource_uri |
|---|---|
| MCP allowlist denied | `mcp://fs/write_file` |
| filesystem gate denied via MCP pre-validation | `mcp-prevalidate://fs/write_file?path=/etc/passwd` |

## URL parsing for `network_outbound` clauses

`parse_pre_validate_url` handles `https://host:port/path` (default 443), `http://host:port/path` (default 80), and bare `host:port`. Other schemes / malformed values surface as `Error::McpPreValidateMalformedArg`.

## New error variant

```rust
Error::McpPreValidateMalformedArg {
    server: String,
    tool: String,
    arg: String,
    reason: String,
}
```

Surfaces clause/arg-shape mismatches — missing field, wrong JSON type, schema-bug-shouldn't-happen "both arg + arg_array set" cases — as a typed denial. The model's tool call gets refused without crashing the session or silently dispatching against an undefined arg.

## Acceptance against #104

- [x] Mediator pre-validation pass implemented per the schema in #103.
- [x] 5 new unit tests in `crates/inference-engine/tests/mediator.rs`:
  - `mcp_pre_validate_allows_when_path_in_filesystem_read`
  - `mcp_pre_validate_denies_when_path_outside_filesystem_read` (asserts the `mcp-prevalidate://` resource_uri shape)
  - `mcp_pre_validate_arg_array_denies_on_first_disallowed_element`
  - `mcp_pre_validate_string_shorthand_keeps_one_layer_behavior`
  - `mcp_pre_validate_missing_arg_returns_typed_error`
- [x] Existing MCP-routing tests continue to pass — string-shape entries flow through identically.

## Test plan

- [x] `cargo test -p aegis-inference-engine --test mediator` — 23 pass (was 18; +5 new)
- [x] `cargo clippy --workspace --exclude aegis-litertlm-backend --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] All other workspace tests still green

## Out of scope

- The Demo 1 recording — **ADR-024-C ([#105](https://github.com/tosin2013/aegis-node/issues/105))**, the next sub-issue.
- Sandbox-style enforcement (Linux namespaces / seccomp) for malicious-MCP threat models — future ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)