### PR TITLE
feat(demos): Demo 01 — MCP, sandboxed twice (ADR-024-C, #105)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,6 +39,7 @@ aegis-inference-engine = { path = "../inference-engine" }
 aegis-ledger-writer = { path = "../ledger-writer" }
 aegis-llama-backend = { path = "../llama-backend", optional = true }
 aegis-litertlm-backend = { path = "../litertlm-backend", optional = true }
+aegis-mcp-client = { path = "../mcp-client" }
 aegis-policy = { path = "../policy" }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -227,6 +227,19 @@ pub fn execute(args: RunArgs) -> Result<RunOutcome> {
         session = session.with_approval_channel(Box::new(channel));
     }
 
+    // Attach a stdio MCP client when the manifest declares any
+    // `tools.mcp[]` servers (per ADR-018). Without this, the
+    // mediator denies every MCP tool call with "no mcp client
+    // configured for session" — fine for script-mode runs that
+    // don't use MCP at all, but a regression for `--prompt` against
+    // a manifest that grants MCP servers. Each `server_uri` is a
+    // `stdio:/path/to/binary [args...]` URI per ADR-018; the client
+    // spawns the child process on first invocation per server.
+    if !session.policy().manifest().tools.mcp.is_empty() {
+        let mcp_client = aegis_mcp_client::StdioMcpClient::new();
+        session = session.with_mcp_client(Box::new(mcp_client));
+    }
+
     let (halted, halt_reason) = match (args.prompt.as_ref(), args.script.as_ref()) {
         (Some(prompt), _) => run_prompt(&mut session, &args, prompt)?,
         (None, Some(script_path)) => run_script(&mut session, script_path)?,

--- a/crates/mcp-client/src/lib.rs
+++ b/crates/mcp-client/src/lib.rs
@@ -122,8 +122,9 @@ impl StdioMcpClient {
 
     fn ensure_connection(&mut self, server_uri: &str) -> Result<&mut StdioConnection> {
         if !self.connections.contains_key(server_uri) {
-            let path = parse_stdio_uri(server_uri)?;
+            let (path, args) = parse_stdio_uri(server_uri)?;
             let mut child = Command::new(path)
+                .args(args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
@@ -197,12 +198,30 @@ impl Drop for StdioMcpClient {
     }
 }
 
-fn parse_stdio_uri(server_uri: &str) -> Result<&str> {
-    server_uri
+/// Parse a `stdio:` URI into `(binary_path, args)`. Whitespace
+/// between the path and any trailing tokens splits the path from
+/// its argv (shell-style). This is the minimum surface MCP servers
+/// like @modelcontextprotocol/server-filesystem need — they require
+/// at least one allowed-directory arg to operate. More exotic
+/// quoting (spaces in paths, etc.) isn't supported in Phase 1; the
+/// `server_uri` is operator-controlled, so a wrapper script is
+/// always available as an escape hatch.
+///
+/// Examples:
+///   stdio:/usr/bin/mcp-fs                 → ("/usr/bin/mcp-fs", [])
+///   stdio:/usr/bin/mcp-fs /data /docs     → ("/usr/bin/mcp-fs", ["/data", "/docs"])
+fn parse_stdio_uri(server_uri: &str) -> Result<(&str, Vec<&str>)> {
+    let rest = server_uri
         .strip_prefix("stdio:")
         .ok_or_else(|| Error::UnsupportedTransport {
             server_uri: server_uri.to_string(),
-        })
+        })?;
+    let mut parts = rest.split_whitespace();
+    let path = parts.next().ok_or_else(|| Error::UnsupportedTransport {
+        server_uri: server_uri.to_string(),
+    })?;
+    let args: Vec<&str> = parts.collect();
+    Ok((path, args))
 }
 
 /// Run the MCP initialize handshake. Aegis-Node advertises the minimum

--- a/demos/01-mcp-sandboxed-twice/README.md
+++ b/demos/01-mcp-sandboxed-twice/README.md
@@ -1,0 +1,123 @@
+# Demo 01 — MCP, sandboxed twice
+
+Per [ADR-020](../../docs/adrs/020-recorded-demo-program.md) §"Six
+scenarios" item 1 + [ADR-024](../../docs/adrs/024-mcp-args-prevalidation.md)
+per-tool pre-validation. The ~25-second clip shows **two independent
+enforcement layers** both gating every MCP tool call: the protocol-
+level allowlist (`tools.mcp[].allowed_tools`) and the syscall gate
+reached via ADR-024's `pre_validate` clauses
+(`tools.filesystem.*`).
+
+## What this demonstrates
+
+The agent (Qwen 1.5B) emits three MCP tool calls in one turn against
+the upstream Anthropic filesystem MCP server. Each call exercises a
+different layer:
+
+| # | Model emits | MCP allowlist | Pre-validate (ADR-024) | Result | Resource URI |
+|---|---|---|---|---|---|
+| 1 | `fs-mcp__read_text_file({path: "/data/research-notes.txt"})` | ✅ allow | ✅ allow (`/data` in `tools.filesystem.read`) | **Access** | `mcp://fs-mcp/read_text_file` |
+| 2 | `fs-mcp__read_text_file({path: "/etc/passwd"})` | ✅ allow | ❌ **DENY** (`/etc` not in `tools.filesystem.read`) | **Violation** | `mcp-prevalidate://fs-mcp/read_text_file?path=/etc/passwd` |
+| 3 | `fs-mcp__write_file({path: "/tmp/out.txt", contents: "..."})` | ❌ **DENY** (`write_file` not in `allowed_tools`) | n/a | **Violation** | `mcp://fs-mcp/write_file` |
+
+The story: **two layers, both Aegis-controlled**. The MCP allowlist
+gates protocol-level intent; the pre-validate clause gates the
+underlying side effect against the same `tools.filesystem.*` policy
+that gates direct mediator calls. The two Violations carry
+distinguishable `resource_uri` schemes — `mcp://` for an allowlist
+denial, `mcp-prevalidate://` for a pre-validate denial — so an
+auditor can tell which layer refused at a glance.
+
+## What you see in the GIF
+
+| t | Frame | Note |
+|---|---|---|
+| 0–4s | `grep -A1 'allowed_tools:'` showing the manifest's pre_validate clauses | Two-layer setup: MCP allowlist + per-tool pre_validate |
+| 4–22s | `aegis run --prompt "..."` runs the model | Qwen emits 3 tool calls; CLI prints `# tool[0]/[1]/[2]` lines |
+| 22–25s | `grep entryType=access` shows the F2 Access entry | Call 1 — both layers permitted |
+| 25–29s | `grep mcp_pre_validate` shows the pre-validate Violation | Call 2 — `mcp-prevalidate://fs-mcp/read_text_file?path=/etc/passwd` |
+| 29–34s | `grep 'mcp://fs-mcp/write_file'` shows the allowlist Violation | Call 3 — `mcp://fs-mcp/write_file` (no `prevalidate` segment) |
+
+## Why two layers (and why both)
+
+A single layer is brittle:
+
+- **MCP-allowlist only** would refuse calls outside the catalog
+  (`write_file`) but couldn't catch `read_text_file({path:
+  "/etc/passwd"})` — the protocol intent is allowed; only the path
+  is forbidden.
+- **Filesystem-gate only** would catch the `/etc/passwd` read at
+  the syscall level (assuming the MCP server flows through an
+  Aegis-mediated fs gate, which it doesn't — MCP servers run in
+  their own process and reach the OS directly). Without the
+  pre-validate hook, the syscall gate doesn't see the call at all.
+
+ADR-024's pre_validate clauses connect the two: the manifest
+declares "this MCP tool's `path` arg is the side-effect," and the
+mediator runs the same `policy.check_filesystem_read` it would run
+for a direct `mediate_filesystem_read` call. The MCP server's
+process-level enforcement remains the first line of defense; the
+pre_validate clause makes the syscall-shaped check enforceable from
+the Aegis side without trusting the upstream server's promises.
+
+## F-feature mapping
+
+| Feature | Where it lights up in this demo |
+|---|---|
+| **F1 Workload Identity** | SessionStart entry binds the SVID to the (manifest, model, chat-template) digest triple. |
+| **F2 Permission Manifest** (MCP allowlist) | `tools.mcp[].allowed_tools` refuses Call 3 with `mcp://fs-mcp/write_file`. |
+| **F2 Permission Manifest** (filesystem gate via pre_validate) | `tools.mcp[0].allowed_tools[*].pre_validate` refuses Call 2 with `mcp-prevalidate://fs-mcp/read_text_file?path=/etc/passwd`. |
+| **F4 Access Log** | Call 1 lands as an Access entry; the auditor sees what the agent read. |
+| **F9 Hash-chained ledger** | All three entries chain into the session's tamper-evident ledger; `aegis verify` confirms the root hash. |
+
+## Run locally
+
+```bash
+# 1) Pull the cosign-verified Qwen artifact (one-time per machine)
+aegis pull \
+  ghcr.io/tosin2013/aegis-node-models/qwen2.5-1.5b-instruct-q4_k_m@sha256:c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37 \
+  --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
+  --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# 2) Install the upstream MCP filesystem server (Anthropic)
+npm install -g @modelcontextprotocol/server-filesystem
+# Resulting binary: /usr/local/bin/mcp-server-filesystem (npm-global default)
+
+# 3) Stage the demo workdir
+mkdir -p /tmp/aegis-demo-01 /data
+cp ~/.cache/aegis/models/c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37/blob.bin \
+   /tmp/aegis-demo-01/model.gguf
+ln -sf ~/.cache/aegis/models/c7404a910e65596a185e788ede19e09bc017dc3101cd106ba7d65fe1dd7dec37/chat_template.sha256.txt \
+   /tmp/aegis-demo-01/chat_template.sha256.txt
+echo "research note about quarterly results" > /data/research-notes.txt
+
+# 4) Render
+make -C demos 01-mcp-sandboxed-twice
+```
+
+The manifest pins the MCP server URI at `/usr/bin/mcp-server-filesystem`;
+adjust to wherever `npm install -g` placed your binary
+(`/usr/local/bin/...` is standard).
+
+## Reproducibility
+
+Per ADR-020 hard requirements, `manifest.yaml` pins
+`inference.determinism` (seed 42 + temperature 0). With the same
+prompt + the same Qwen blob, every render produces byte-identical
+text output. The CI snapshot test (Phase 2b, separate PR) will gate
+on the GIF's SHA-256.
+
+## Why Qwen 1.5B (not Gemma 4)
+
+Per the per-demo model selection table in ADR-020 §"Decision" item 8,
+Demo 1 stays on **Qwen 1.5B** because pre-validation is mechanical
+— the model just needs to emit three named MCP tool calls in
+sequence, and seed 42 + temperature 0 makes the choice deterministic.
+Larger models would inflate the GIF without improving the security
+story.
+
+## Related
+
+- [ADR-018](../../docs/adrs/018-adopt-mcp-protocol-for-agent-tool-boundary.md) — MCP as the agent-tool boundary.
+- [ADR-024](../../docs/adrs/024-mcp-args-prevalidation.md) — per-tool pre-validation: the architectural decision this demo exists to demonstrate.
+- [`schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml`](../../schemas/manifest/v1/examples/agent-with-mcp.manifest.yaml) — the schema-fixture variant of the same shape (broader Anthropic-fs-MCP catalog; this demo's manifest trims it for narrative clarity).

--- a/demos/01-mcp-sandboxed-twice/demo.tape
+++ b/demos/01-mcp-sandboxed-twice/demo.tape
@@ -1,0 +1,83 @@
+# Demo 01 — MCP, sandboxed twice (per ADR-020 §"Six scenarios"
+# item 1 + ADR-024 per-tool pre-validation).
+#
+# The model emits three MCP tool calls in one turn:
+#
+#   1. fs-mcp__read_text_file({/data/research-notes.txt})
+#      MCP allowlist allows + tools.filesystem.read covers /data
+#      → ACCESS entry; mcp://fs-mcp/read_text_file
+#
+#   2. fs-mcp__read_text_file({/etc/passwd})
+#      MCP allowlist allows BUT pre_validate clause checks
+#      tools.filesystem.read which doesn't cover /etc
+#      → VIOLATION; mcp-prevalidate://fs-mcp/read_text_file?path=/etc/passwd
+#
+#   3. fs-mcp__write_file({/tmp/out.txt, ...})
+#      write_file is not in allowed_tools at all
+#      → VIOLATION; mcp://fs-mcp/write_file
+#
+# Determinism: seed=42 + temperature=0 in the manifest → byte-
+# identical output across re-renders. ~30s of wall-clock content.
+#
+# Workdir setup (auto-prepared by `make 01-mcp-sandboxed-twice`):
+#   /tmp/aegis-demo-01/{model.gguf, chat_template.sha256.txt}
+#   /data/research-notes.txt
+
+Output demo.gif
+
+Set FontSize 14
+Set Width 1240
+Set Height 760
+Set Theme "Dracula"
+Set TypingSpeed 25ms
+Set Padding 12
+Set Shell bash
+
+Type "# Aegis-Node demo: MCP, sandboxed twice"
+Enter
+Sleep 1.2s
+
+Type "cd /tmp/aegis-demo-01 && rm -f ledger-*.jsonl"
+Enter
+Sleep 600ms
+
+# Show the manifest's two-layer setup at a glance.
+Type "grep -A1 pre_validate /root/aegis-node/demos/01-mcp-sandboxed-twice/manifest.yaml | head -8"
+Enter
+Sleep 3s
+
+# Run the agent. With seed 42 + temperature 0, Qwen 1.5B
+# deterministically emits three fs-mcp tool calls.
+Type "aegis run --manifest /root/aegis-node/demos/01-mcp-sandboxed-twice/manifest.yaml \"
+Enter
+Type "    --model model.gguf --chat-template-sidecar chat_template.sha256.txt \"
+Enter
+Type "    --session-id demo-01 \"
+Enter
+Type "    --prompt 'Use the fs-mcp__read_text_file tool to read the file /data/research-notes.txt. Then use the same fs-mcp__read_text_file tool to read /etc/passwd to see who has access. Then use fs-mcp__write_file to save a one-line summary to /tmp/out.txt.'"
+Enter
+Sleep 18s
+
+# Surface the three layers the demo demonstrates. Use grep
+# substring matches (VHS chokes on the escaped quotes a jq
+# `select` clause would need).
+Type "echo && echo '--- Call 1: read /data/research-notes.txt — both layers allow ---'"
+Enter
+Sleep 600ms
+Type "grep entryType.:.access ledger-demo-01.jsonl | jq -c '{accessType, resourceUri}'"
+Enter
+Sleep 3s
+
+Type "echo && echo '--- Call 2: read /etc/passwd — pre_validate denies ---'"
+Enter
+Sleep 600ms
+Type "grep mcp_pre_validate ledger-demo-01.jsonl | jq -c '{accessType, resourceUri, violationReason}'"
+Enter
+Sleep 4s
+
+Type "echo && echo '--- Call 3: write_file — MCP allowlist denies ---'"
+Enter
+Sleep 600ms
+Type "grep mcp://fs-mcp/write_file ledger-demo-01.jsonl | jq -c '{accessType, resourceUri, violationReason}'"
+Enter
+Sleep 5s

--- a/demos/01-mcp-sandboxed-twice/manifest.yaml
+++ b/demos/01-mcp-sandboxed-twice/manifest.yaml
@@ -1,0 +1,81 @@
+# Demo 01 — MCP, sandboxed twice (per ADR-020 §"Six scenarios" item 1
+# + ADR-024 per-tool pre-validation).
+#
+# The agent uses the Anthropic filesystem MCP server in read-only
+# mode, but two layers of enforcement guard every call:
+#
+#   1. tools.mcp[].allowed_tools — protocol-level allowlist. Tools
+#      not in the list (write_file, edit_file, etc.) are refused at
+#      the MCP-allowlist layer with `mcp://server/tool` resource_uri.
+#
+#   2. ADR-024 pre_validate clauses — per-tool side-effect mapping.
+#      For tools that take filesystem-shaped paths, the mediator
+#      extracts the path arg and runs it through tools.filesystem.read
+#      before dispatching to the MCP server. Paths outside the
+#      grant land as Violations with the distinguishable
+#      `mcp-prevalidate://server/tool?path=...` resource_uri so an
+#      auditor can tell which layer refused.
+#
+# Both layers must permit the operation. The demo recording walks
+# the agent through three calls — one allowed, one MCP-allowed-but-
+# pre-validate-denied, one MCP-denied — to make the two layers
+# legible at a glance.
+
+schemaVersion: "1"
+agent:
+  name: "research-mcp"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/research-mcp/inst-001"
+tools:
+  # The agent may read files under /data — that's where its
+  # research notes live. Reading outside this prefix (e.g. /etc/passwd)
+  # is denied by the syscall-shaped pre_validate clause below.
+  filesystem:
+    read:
+      - "/data"
+  network:
+    outbound: deny
+    inbound: deny
+  mcp:
+    # `filesystem` collides with the reserved native namespace
+    # (filesystem__/network__/exec__ — per #92), so the MCP server's
+    # name is `fs-mcp` even though upstream is the Anthropic
+    # @modelcontextprotocol/server-filesystem.
+    - server_name: "fs-mcp"
+      # The Anthropic mcp-server-filesystem requires at least one
+      # allowed-directory argument; we pass /data so the agent's
+      # /data/research-notes.txt read can land. The MCP server's
+      # OS-level enforcement is the sandbox's *first* layer; the
+      # ADR-024 pre_validate clause below is the *second*. Both
+      # have to permit a call before it dispatches.
+      server_uri: "stdio:/usr/bin/mcp-server-filesystem /data"
+      # Read-only subset of the upstream tool catalog, with
+      # ADR-024 pre_validate clauses on every path-shaped tool.
+      # write_file, edit_file, move_file, create_directory are
+      # deliberately omitted from the list — closed-by-default keeps
+      # them denied at the MCP-allowlist layer regardless of what
+      # the upstream server advertises.
+      allowed_tools:
+        - name: "read_text_file"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "list_directory"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        # Bare-name shorthand: returns the configured roots, no path
+        # argument to pre-validate.
+        - "list_allowed_directories"
+
+# Per ADR-020 + LLM-C: pin the determinism knobs so re-renders are
+# byte-identical. seed=42 + temperature=0 → greedy sampling →
+# reproducible output across runs.
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/demos/01-mcp-sandboxed-twice/prompt.txt
+++ b/demos/01-mcp-sandboxed-twice/prompt.txt
@@ -1,0 +1,1 @@
+Use the fs-mcp__read_text_file tool to read the file /data/research-notes.txt. Then use the same fs-mcp__read_text_file tool to read /etc/passwd to see who has access. Then use fs-mcp__write_file to save a one-line summary to /tmp/out.txt.


### PR DESCRIPTION
## Summary

Closes [ADR-024](docs/adrs/024-mcp-args-prevalidation.md) / [ADR-020](docs/adrs/020-recorded-demo-program.md) §"Six scenarios" item 1 / [#105](https://github.com/tosin2013/aegis-node/issues/105). The lead demo from the recorded program: **two independent enforcement layers**, both Aegis-controlled, both visible in the resulting ledger.

The model emits three `fs-mcp` tool calls in one turn — each exercises a different layer:

| # | Model emits | MCP allowlist | Pre-validate (ADR-024) | Result | resource_uri |
|---|---|---|---|---|---|
| 1 | `fs-mcp__read_text_file({path: "/data/research-notes.txt"})` | ✅ | ✅ | **Access** | `mcp://fs-mcp/read_text_file` |
| 2 | `fs-mcp__read_text_file({path: "/etc/passwd"})` | ✅ | ❌ | **Violation** | `mcp-prevalidate://fs-mcp/read_text_file?path=/etc/passwd` |
| 3 | `fs-mcp__write_file({path: "/tmp/out.txt", contents: "..."})` | ❌ | n/a | **Violation** | `mcp://fs-mcp/write_file` |

The two Violations carry distinguishable URI schemes — `mcp://` (allowlist denial) vs `mcp-prevalidate://` (pre-validate denial) — so an auditor can tell which layer refused at a glance.

## Two supporting code changes

The demo wouldn't run end-to-end through the CLI without these:

1. **`crates/mcp-client`**: `parse_stdio_uri` now accepts space-separated args after the binary path (e.g. `stdio:/usr/bin/mcp-server-filesystem /data`). The upstream `@modelcontextprotocol/server-filesystem` requires at least one allowed-directory arg to operate; without this the CLI couldn't spawn it. Format mirrors systemd-style `ExecStart` strings; more exotic quoting (spaces in paths) is out of Phase 1 scope — operators wrap with a shell script as an escape hatch.
2. **`crates/cli/src/run.rs`**: when the manifest declares any `tools.mcp[]` servers, attach a `StdioMcpClient` on session boot. Without this the mediator denied every MCP tool call with "no mcp client configured for session" — fine for script-mode runs that don't use MCP, but a regression for `--prompt` against an MCP-bearing manifest. Adds `aegis-mcp-client` as a non-optional CLI dependency.

## Acceptance against #105

- [x] Manifest pins `inference.determinism: { seed: 42, temperature: 0.0, ... }` for reproducibility.
- [x] Recorded against Qwen 1.5B / llama backend per ADR-020 §"Decision" item 8.
- [x] MCP server invoked is the upstream `@modelcontextprotocol/server-filesystem` at `/usr/bin/mcp-server-filesystem` with `/data` as the allowed-directory arg.
- [x] One render produces all three call outcomes deterministically — verified end-to-end:

```
{"entryType":"session_start","..."}
{"entryType":"reasoning_step","..."}
{"entryType":"access","accessType":"mcp_tool_call","resourceUri":"mcp://fs-mcp/read_text_file"}
{"entryType":"violation","accessType":"mcp_pre_validate","resourceUri":"mcp-prevalidate://fs-mcp/read_text_file?path=/etc/passwd"}
{"entryType":"violation","accessType":"mcp_tool_call","resourceUri":"mcp://fs-mcp/write_file"}
{"entryType":"network_attestation","..."}
{"entryType":"session_end","..."}
```

## Test plan

- [x] `cargo test -p aegis-mcp-client` — 4 pass (parse_stdio_uri test + handshake unit tests)
- [x] `cargo clippy --workspace --exclude aegis-litertlm-backend --all-targets -- -D warnings` clean
- [x] `cargo test -p aegis-cli --all-targets` — 9 default + 9 llama-feature tests pass; new MCP-client wiring doesn't regress existing fixtures
- [x] End-to-end render against Qwen 1.5B + Anthropic mcp-server-filesystem: ledger has the canonical 7-entry sequence
- [x] `demo.gif` is GIF89a, 4.2 MB, ~30s of content

## Files

```
demos/01-mcp-sandboxed-twice/
├── manifest.yaml      tools.mcp + filesystem.read [/data] + pre_validate
├── prompt.txt         directive: read X, read Y, write Z
├── demo.tape          ~30s VHS recording
├── demo.gif           4.2 MB
└── README.md          F-feature mapping + run-locally recipe
```

## Related

- [ADR-018](docs/adrs/018-adopt-mcp-protocol-for-agent-tool-boundary.md) — MCP as the agent-tool boundary
- [ADR-024](docs/adrs/024-mcp-args-prevalidation.md) — per-tool pre-validation; this demo is its primary recorded artifact
- ADR-024-A (#103, merged): schema bump for `allowed_tools` union
- ADR-024-B (#104, merged): mediator pre-validation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)