### PR TITLE
feat(demos): Demo 02/03/04 sources + Gemma 4 E4B pin (ADR-020)

### DIFF
--- a/demos/02-read-only-research/README.md
+++ b/demos/02-read-only-research/README.md
@@ -1,0 +1,90 @@
+# Demo 02 — Read-only research assistant
+
+Per [ADR-020](../../docs/adrs/020-recorded-demo-program.md) §"Six
+scenarios" item 2. The canonical "agent reads docs, cannot write"
+narrative — the agent gets read access to a single directory plus
+deny-by-default network, and the closed-by-default manifest
+refuses everything else.
+
+## What this demonstrates
+
+The agent (Gemma 4 E4B) is given exactly enough surface to do its
+job: read `/data` and produce a summary. Every other capability
+is closed-by-default at the manifest layer.
+
+| Layer | Behavior in this demo |
+|---|---|
+| **F2 Permission Manifest** | `tools.filesystem.read: ["/data"]` is the only I/O grant. No `tools.filesystem.write`, no `tools.network.outbound: allow`, no `exec_grants`, no `tools.mcp[]`. Any attempt at writing, networking, or MCP dispatch lands as a Violation. |
+| **F4 Access Log** | The agent's read of `/data/research-notes.txt` lands as an Access entry. Auditor sees what the agent touched, byte-for-byte. |
+| **F6 Network Deny-by-Default** | Closed outbound + inbound. The session's NetworkAttestation at shutdown summarizes zero connections (`totalConnections: 0`) — proof that the agent never even tried to phone home. |
+| **F9 Hash-chained ledger** | All entries chain into a tamper-evident root; `aegis verify` confirms. |
+
+## What you see in the GIF
+
+| t | Frame | Note |
+|---|---|---|
+| 0–4s | `grep -A4 'tools:'` showing read-only posture | One read grant, no write/network/exec |
+| 4–28s | `aegis run --backend litertlm --prompt "..."` runs Gemma 4 E4B | E4B is ~3× the size of E2B; CPU inference budget is ~25s |
+| 28–32s | `grep access` shows the F4 Access entry | `accessType: read`, `resourceUri: file:///data/research-notes.txt` |
+| 32–36s | `grep network_attestation` shows zero connections | `totalConnections: 0` |
+| 36–40s | `aegis verify` confirms the chain | Tamper-evident, root hash matches |
+
+## Run locally
+
+```bash
+# 1) Pull the cosign-verified Gemma 4 E4B artifact
+aegis pull \
+  ghcr.io/tosin2013/aegis-node-models/gemma-4-e4b-it@sha256:de89d03b650a86410d1c9f48ee2239fdf7d5f8895ad00621e20b9c2ed195f931 \
+  --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
+  --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# 2) Stage the demo workdir
+mkdir -p /tmp/aegis-demo-02 /data
+cp ~/.cache/aegis/models/<gemma-4-e4b-blob-sha>/blob.bin \
+   /tmp/aegis-demo-02/model.litertlm
+ln -sf ~/.cache/aegis/models/<gemma-4-e4b-blob-sha>/chat_template.sha256.txt \
+   /tmp/aegis-demo-02/chat_template.sha256.txt
+echo "Q3 2025: revenue $147M, EBITDA $42M, headcount 380." > /data/research-notes.txt
+
+# 3) Render
+make -C demos 02-read-only-research
+```
+
+## Glibc requirement
+
+The LiteRT-LM runtime (`libaegis_litertlm_engine_cpu.so`, per
+[ADR-023](../../docs/adrs/023-litertlm-as-second-inference-backend.md))
+is built against ubuntu-24.04 and requires **glibc 2.38+**. Render
+on:
+
+- A native ubuntu-24.04+ host, OR
+- A docker container based on ubuntu:24.04, OR
+- The `litertlm.yml` CI workflow (which runs on `ubuntu-24.04`).
+
+Ubuntu 22.04 hosts (glibc 2.35) cannot load the `.so` directly.
+Pre-LiteRT demos (5, 6) used the llama.cpp backend which has no
+such requirement.
+
+## Reproducibility
+
+Per ADR-020 hard requirements, `manifest.yaml` pins
+`inference.determinism` (seed 42 + temperature 0). With the same
+prompt + the same Gemma 4 E4B blob, every render produces
+byte-identical text output.
+
+## Why Gemma 4 E4B (not Qwen 1.5B)
+
+Per the per-demo model selection table in ADR-020 §"Decision" item 8,
+this demo runs against **Gemma 4 E4B**:
+
+- The narrative payoff is the *summary itself* — bigger model =
+  more useful output, which sells the "read-only research
+  assistant" pitch better.
+- The 4B model + Apache-2.0/Gemma-Terms licensing matters for
+  enterprise audiences who can't (or won't) use Chinese-origin
+  weights.
+- E4B is ~3× the inference time of E2B, but the per-turn budget
+  (~25s) still fits within the ~30s ADR-020 GIF target.
+
+E2B (`sha256:365c6a8b...`) is a drop-in replacement for hosts
+that can't budget the larger model.

--- a/demos/02-read-only-research/demo.tape
+++ b/demos/02-read-only-research/demo.tape
@@ -1,0 +1,71 @@
+# Demo 02 — Read-only research assistant.
+# Per ADR-020 §"Six scenarios" item 2.
+#
+# The agent gets read access to /data plus deny-by-default network.
+# No writes, no exec, no MCP. Every other I/O attempt would land
+# as an F2 Violation.
+#
+# Backend: LiteRT-LM with Gemma 4 E4B (per ADR-020 §"Decision" item 8).
+#
+# Workdir setup (auto-prepared by `make 02-read-only-research`):
+#   /tmp/aegis-demo-02/{model.litertlm, chat_template.sha256.txt}
+#   /data/research-notes.txt
+
+Output demo.gif
+
+Set FontSize 14
+Set Width 1240
+Set Height 760
+Set Theme "Dracula"
+Set TypingSpeed 25ms
+Set Padding 12
+Set Shell bash
+
+Type "# Aegis-Node demo: Read-only research assistant"
+Enter
+Sleep 1.2s
+
+Type "cd /tmp/aegis-demo-02 && rm -f ledger-*.jsonl"
+Enter
+Sleep 600ms
+
+# Show the manifest's read-only posture at a glance.
+Type "grep -A4 'tools:' /root/aegis-node/demos/02-read-only-research/manifest.yaml | head -8"
+Enter
+Sleep 3s
+
+# Run the agent. Gemma 4 E4B at greedy temperature → deterministic
+# summary across re-renders.
+Type "aegis run --backend litertlm \"
+Enter
+Type "    --manifest /root/aegis-node/demos/02-read-only-research/manifest.yaml \"
+Enter
+Type "    --model model.litertlm --chat-template-sidecar chat_template.sha256.txt \"
+Enter
+Type "    --session-id demo-02 \"
+Enter
+Type "    --prompt 'Read /data/research-notes.txt and write a one-paragraph summary of the key findings. Quote one specific number from the source. Do not access any other files.'"
+Enter
+Sleep 25s
+
+# Surface the F-features the demo exercised:
+Type "echo && echo '--- F4 Access entries (what the agent read) ---'"
+Enter
+Sleep 600ms
+Type "grep entryType.:.access ledger-demo-02.jsonl | jq -c '{accessType, resourceUri}'"
+Enter
+Sleep 3s
+
+Type "echo && echo '--- F6 NetworkAttestation (zero connections — agent never tried to phone home) ---'"
+Enter
+Sleep 600ms
+Type "grep network_attestation ledger-demo-02.jsonl | jq -c '{accessType, totalConnections, allowedCount, deniedCount}'"
+Enter
+Sleep 4s
+
+Type "echo && echo '--- F9 Tamper-evident chain ---'"
+Enter
+Sleep 600ms
+Type "aegis verify ledger-demo-02.jsonl"
+Enter
+Sleep 4s

--- a/demos/02-read-only-research/manifest.yaml
+++ b/demos/02-read-only-research/manifest.yaml
@@ -1,0 +1,42 @@
+# Demo 02 — Read-only research assistant.
+# Per ADR-020 §"Six scenarios" item 2.
+#
+# Canonical "agent reads docs, cannot write" narrative. The agent
+# is granted read access to /data plus deny-by-default network.
+# No write_grants, no exec_grants, no MCP servers — every mutating
+# action gets refused at the manifest layer.
+#
+# Per ADR-020 §"Decision item 8" the demo runs against
+# Gemma 4 E4B via the LiteRT-LM backend (per ADR-023). The
+# bigger-model summary is the user-visible payoff; the security
+# story is that the bigger model + MORE capability surface still
+# fits inside an explicit closed-by-default manifest.
+
+schemaVersion: "1"
+agent:
+  name: "research-readonly"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/research-readonly/inst-001"
+tools:
+  # Read-only access to /data — that's where the research notes
+  # live. The agent has no other I/O surface.
+  filesystem:
+    read:
+      - "/data"
+  # Deny-by-default outbound. Catches any attempt at exfiltration
+  # via F6 NetworkAttestation at session shutdown.
+  network:
+    outbound: deny
+    inbound: deny
+
+# REQUIRED for demos (per ADR-020 §"Decision" item 5): pinned seed
+# + temperature 0 → byte-identical model output across renders so
+# `make all && git status` stays clean.
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/demos/02-read-only-research/prompt.txt
+++ b/demos/02-read-only-research/prompt.txt
@@ -1,0 +1,1 @@
+Read /data/research-notes.txt and write a one-paragraph summary of the key findings. Quote one specific number from the source. Do not access any other files.

--- a/demos/03-code-review-time-bounded/README.md
+++ b/demos/03-code-review-time-bounded/README.md
@@ -1,0 +1,87 @@
+# Demo 03 — Code review with time-bounded write grant
+
+Per [ADR-020](../../docs/adrs/020-recorded-demo-program.md) §"Six
+scenarios" item 3. The agent gets just enough surface to do a code
+review: read the source, run `git diff` to see what changed,
+write a review file. The write grant is **time-bounded** — valid
+for one hour after session start, after which the same
+`check_filesystem_write` returns Deny.
+
+## What this demonstrates
+
+| Layer | Behavior in this demo |
+|---|---|
+| **F2 Permission Manifest** | Three explicit grants: read /repo, write /data narrowed by an explicit `write_grant`, exec `git` (basename match). Nothing else — no network, no MCP, no other binaries. |
+| **F2 Exec grant** | `exec_grants[].program: /usr/bin/git` lets the agent run `git diff`. The path is pinned absolute — `aegis validate` (AEGIS003) refuses bare basenames since any `/git` on PATH would match (security risk). |
+| **F7 Time-bounded write grant** | `write_grants[].duration: "PT1H"` (ISO 8601, per ADR-009 + the F7 extension at PR #38). Within the window, `check_filesystem_write(/data/review.md)` allows the write; outside, the same call returns Deny. |
+| **ADR-019 Explicit-precedence** | The broader `tools.filesystem.write: ["/data"]` is narrowed by the explicit `write_grant`. A write to `/data/anything-else.md` would Deny because the explicit grant is for `/data/review.md` only. |
+| **F4 Access Log** | The git diff exec, the write of /data/review.md, and the read of /repo all surface as Access entries. |
+| **F9 Hash-chained ledger** | Tamper-evident; `aegis verify` confirms the chain. |
+
+## What you see in the GIF
+
+| t | Frame | Note |
+|---|---|---|
+| 0–4s | `grep write_grants` + `grep exec_grants` showing the explicit grants | One hour write window; basename-match exec for git |
+| 4–32s | `aegis run --backend litertlm --prompt "..."` runs Gemma 4 E4B | Inference + git diff + write ~28s on a single CPU |
+| 32–36s | `grep accessType.:.exec` shows F2 exec entry | `accessType: exec`, resource_uri carries `git` and the args |
+| 36–40s | `grep accessType.:.write` shows F7 within-window write | `accessType: write`, `resourceUri: file:///data/review.md` |
+| 40–46s | `grep access` shows the full sequence | read + exec + write — the canonical review flow |
+
+## Run locally
+
+```bash
+# 1) Pull the cosign-verified Gemma 4 E4B artifact (also used by Demo 2)
+aegis pull \
+  ghcr.io/tosin2013/aegis-node-models/gemma-4-e4b-it@sha256:de89d03b650a86410d1c9f48ee2239fdf7d5f8895ad00621e20b9c2ed195f931 \
+  --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
+  --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# 2) Stage the demo workdir + a real git repo for diffing
+mkdir -p /tmp/aegis-demo-03 /repo /data
+cp ~/.cache/aegis/models/<gemma-4-e4b-blob-sha>/blob.bin \
+   /tmp/aegis-demo-03/model.litertlm
+ln -sf ~/.cache/aegis/models/<gemma-4-e4b-blob-sha>/chat_template.sha256.txt \
+   /tmp/aegis-demo-03/chat_template.sha256.txt
+git -C /repo init -q
+echo 'pub fn add(a: i32, b: i32) -> i32 { a + b }' > /repo/lib.rs
+git -C /repo add . && git -C /repo commit -q -m "initial"
+echo 'pub fn add(a: i32, b: i32) -> i32 {\n    a.checked_add(b).unwrap_or(0)\n}' > /repo/lib.rs
+git -C /repo add . && git -C /repo commit -q -m "saturate on overflow"
+
+# 3) Render
+make -C demos 03-code-review-time-bounded
+```
+
+## Glibc requirement
+
+Same as Demo 2 — the LiteRT-LM runtime needs **glibc 2.38+**. Render
+on ubuntu-24.04+ host or in CI's `litertlm.yml` job. Pre-LiteRT
+demos (5, 6) using llama.cpp work on older hosts.
+
+## Why a 1-hour duration (and what about post-expiry)
+
+Per ADR-020 §"Six scenarios" item 3: "*the recording includes a
+deliberate clock skip showing the post-expiry Deny entry.*" In
+practice that requires a `aegis run --now <iso>` flag we don't
+have yet — Phase 1 of this demo demonstrates the **within-window**
+flow only. The post-expiry frame is a future enhancement that
+needs the clock-override CLI surface. The current GIF makes the
+in-manifest time-bounding visible (visible `duration: PT1H`) and
+shows the agent's write succeeding inside the window; an auditor
+reading the manifest knows the same write at session_start + 70min
+would Deny.
+
+## Reproducibility
+
+Manifest pins `inference.determinism` (seed 42 + temperature 0).
+With the same Gemma 4 E4B blob + the same git repo state, every
+render produces byte-identical text output.
+
+## Why Gemma 4 E4B (not Qwen)
+
+Per ADR-020 §"Decision" item 8: code-shaped reasoning benefits
+from the larger model. Qwen 1.5B can produce a plausible
+"saturate on overflow" line, but Gemma 4 E4B's review covers
+edge cases (`i32::MIN`, signed overflow semantics) that read as
+meaningful technical feedback rather than auto-completion.

--- a/demos/03-code-review-time-bounded/demo.tape
+++ b/demos/03-code-review-time-bounded/demo.tape
@@ -1,0 +1,70 @@
+# Demo 03 — Code review agent with time-bounded write grant.
+# Per ADR-020 §"Six scenarios" item 3.
+#
+# Workdir setup (auto-prepared by `make 03-code-review-time-bounded`):
+#   /tmp/aegis-demo-03/{model.litertlm, chat_template.sha256.txt}
+#   /repo  — a real git repo with at least 2 commits
+#   /data  — empty; review.md lands here
+#
+# Backend: LiteRT-LM / Gemma 4 E4B (per ADR-020 §"Decision" item 8).
+
+Output demo.gif
+
+Set FontSize 14
+Set Width 1240
+Set Height 760
+Set Theme "Dracula"
+Set TypingSpeed 25ms
+Set Padding 12
+Set Shell bash
+
+Type "# Aegis-Node demo: Code review with time-bounded write grant"
+Enter
+Sleep 1.2s
+
+Type "cd /tmp/aegis-demo-03 && rm -f ledger-*.jsonl /data/review.md"
+Enter
+Sleep 600ms
+
+# Show the time-bounded write_grant + the exec_grant.
+Type "grep -A3 'write_grants:' /root/aegis-node/demos/03-code-review-time-bounded/manifest.yaml"
+Enter
+Sleep 3s
+Type "grep -A2 'exec_grants:' /root/aegis-node/demos/03-code-review-time-bounded/manifest.yaml"
+Enter
+Sleep 2s
+
+# Run the agent. Gemma 4 E4B uses git diff + writes the review.
+Type "aegis run --backend litertlm \"
+Enter
+Type "    --manifest /root/aegis-node/demos/03-code-review-time-bounded/manifest.yaml \"
+Enter
+Type "    --model model.litertlm --chat-template-sidecar chat_template.sha256.txt \"
+Enter
+Type "    --session-id demo-03 \"
+Enter
+Type "    --prompt 'Use exec__run to call git with arguments [diff, --stat, HEAD~1, HEAD] from /repo. Then write a one-paragraph code review to /data/review.md using filesystem__write.'"
+Enter
+Sleep 28s
+
+# Surface the F-features the demo exercised:
+Type "echo && echo '--- F2 Exec grant (git diff) ---'"
+Enter
+Sleep 600ms
+Type "grep accessType.:.exec ledger-demo-03.jsonl | jq -c '{accessType, resourceUri}'"
+Enter
+Sleep 3s
+
+Type "echo && echo '--- F7 Time-bounded write — within window ---'"
+Enter
+Sleep 600ms
+Type "grep accessType.:.write ledger-demo-03.jsonl | jq -c '{accessType, resourceUri, bytesAccessed}'"
+Enter
+Sleep 4s
+
+Type "echo && echo '--- F4 Access entries (full sequence) ---'"
+Enter
+Sleep 600ms
+Type "grep entryType.:.access ledger-demo-03.jsonl | jq -c '{accessType, resourceUri}'"
+Enter
+Sleep 5s

--- a/demos/03-code-review-time-bounded/manifest.yaml
+++ b/demos/03-code-review-time-bounded/manifest.yaml
@@ -1,0 +1,63 @@
+# Demo 03 — Code review agent with time-bounded write grant.
+# Per ADR-020 §"Six scenarios" item 3.
+#
+# The agent gets just enough to do a code review:
+#
+#   - Read access to /repo (the source it reviews)
+#   - Exec grant for git (so it can run `git diff` to find changes)
+#   - Time-bounded write grant for /data/review.md (the review
+#     it produces — explicit-grant via ADR-019; valid for 1 hour
+#     after session start)
+#   - Deny-by-default network
+#
+# Outside the time window, the same write_grant entry still exists
+# in the manifest but check_filesystem_write returns Deny (per
+# ADR-009 + ADR-019 + the F7 time-bounded extension in PR #38).
+# Auditors can see in the ledger which window the write happened
+# in, and the manifest itself documents the policy intent.
+#
+# Backend: LiteRT-LM with Gemma 4 E4B (per ADR-020 §"Decision" item 8).
+# Code-shaped reasoning benefits from the bigger model.
+
+schemaVersion: "1"
+agent:
+  name: "code-reviewer"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/code-reviewer/inst-001"
+tools:
+  # Read the source under review.
+  filesystem:
+    read:
+      - "/repo"
+    # No broad write coverage — the explicit write_grant below is
+    # the *only* path that authorizes a write. Per ADR-019,
+    # explicit grants take precedence; closed-by-default keeps
+    # everything else denied.
+  # Network closed.
+  network:
+    outbound: deny
+    inbound: deny
+
+# Time-bounded write grant. Valid for 1 hour after session start.
+# `duration: PT1H` is the ISO 8601 form aegis-policy parses (per
+# ADR-009 + the F7 extension at #38).
+write_grants:
+  - resource: "/data/review.md"
+    actions: ["write"]
+    duration: "PT1H"
+
+# git is the only exec the agent may run. Pinned to the canonical
+# Linux path; AEGIS003 refuses bare basenames (any /git on PATH
+# would match — security risk).
+exec_grants:
+  - program: "/usr/bin/git"
+
+# REQUIRED for demos: pinned seed + temperature 0.
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/demos/03-code-review-time-bounded/prompt.txt
+++ b/demos/03-code-review-time-bounded/prompt.txt
@@ -1,0 +1,1 @@
+Use exec__run to call git with arguments ['diff', '--stat', 'HEAD~1', 'HEAD'] from the /repo directory. Then write a one-paragraph code review to /data/review.md using filesystem__write.

--- a/demos/04-customer-support-approval/README.md
+++ b/demos/04-customer-support-approval/README.md
@@ -1,0 +1,83 @@
+# Demo 04 — Customer support with F3 approval gate
+
+Per [ADR-020](../../docs/adrs/020-recorded-demo-program.md) §"Six
+scenarios" item 4. The agent reads a customer's case, drafts a
+refund letter, and **the write requires F3 approval** before it
+lands. The recording demonstrates the approved path; the rejected
+path is a one-line edit (flip `decision` in the approval file).
+
+## What this demonstrates
+
+| Layer | Behavior in this demo |
+|---|---|
+| **F2 Permission Manifest** | Read `/cases`, write `/drafts` narrowed by an explicit `write_grant` with `approval_required: true`. No network, no exec, no MCP. |
+| **F3 Human Approval Gate** | The explicit `write_grant`'s `approval_required: true` upgrades the policy decision from Allow to RequireApproval. The mediator routes through the F3 channel — here the **file channel** (per ADR-005 + the v0.8.0 implementation) — and writes only after a positive decision. |
+| **F4 Access Log** | The read of `/cases/case-1024.txt`, the post-approval write of `/drafts/refund-letter.md`, and the approval entry itself all chain into the ledger. |
+| **F7 Time-bounded** | `duration: PT1H` makes the grant valid for one hour after session start. Combined with F3 — the grant is *both* time-bounded and approval-gated. |
+| **F9 Hash-chained ledger** | Tamper-evident; `aegis verify` confirms. |
+
+## What you see in the GIF
+
+| t | Frame | Note |
+|---|---|---|
+| 0–4s | `grep write_grants` showing `approval_required: true` | The grant exists; approval still required |
+| 4–6s | `echo > approval.json` pre-stages the human decision | F3 file channel: `{decision: approved, approver, reason}` |
+| 6–24s | `aegis run --backend litertlm --prompt "..."` runs Gemma 4 E2B | Read + RequireApproval + approval decision + write — ~18s |
+| 24–28s | `grep accessType.:.read` shows F4 read entry | The case file the agent grounded its draft in |
+| 28–32s | `grep approval` shows F3 approval entry | `entryType: approval`, `decision: approved`, `approver: alice@org` |
+| 32–37s | `grep accessType.:.write` shows F2 + F7 write entry | Post-approval write to `/drafts/refund-letter.md` |
+
+## Run locally
+
+```bash
+# 1) Pull the cosign-verified Gemma 4 E2B artifact
+aegis pull \
+  ghcr.io/tosin2013/aegis-node-models/gemma-4-e2b-it@sha256:365c6a8b3b226ec825b74ed16404515ec61521b2d7f24490eac672d74466b2ea \
+  --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
+  --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# 2) Stage the demo workdir + a sample case
+mkdir -p /tmp/aegis-demo-04 /cases /drafts
+cp ~/.cache/aegis/models/<gemma-4-e2b-blob-sha>/blob.bin \
+   /tmp/aegis-demo-04/model.litertlm
+ln -sf ~/.cache/aegis/models/<gemma-4-e2b-blob-sha>/chat_template.sha256.txt \
+   /tmp/aegis-demo-04/chat_template.sha256.txt
+cat > /cases/case-1024.txt <<EOF
+Customer #1024 reports their package arrived damaged on 2026-04-15.
+Order total: \$87.43. They request a full refund.
+EOF
+
+# 3) Render
+make -C demos 04-customer-support-approval
+```
+
+## The approval file format
+
+The F3 file channel reads a JSON document the operator hand-edits
+(or a workflow tool produces). Schema per ADR-005:
+
+```json
+{
+  "decision": "approved",
+  "approver": "alice@org",
+  "reason": "verified case; refund within policy"
+}
+```
+
+`decision` may be `"approved"` or `"rejected"`. The approval
+entry that lands in the ledger carries the decision verbatim plus
+the approver/reason for the audit trail.
+
+## Glibc requirement
+
+Same as Demos 2 and 3 — LiteRT-LM runtime needs **glibc 2.38+**.
+Render on ubuntu-24.04+ host or in CI. Pre-LiteRT demos (5, 6)
+using llama.cpp work on older hosts.
+
+## Why Gemma 4 E2B (not Qwen 1.5B or E4B)
+
+Per ADR-020 §"Decision" item 8: customer-support narrative reads
+better with a realistic agent voice — Qwen 1.5B's draft tends to
+sound like auto-completion. E2B (~2.6 GB) is a sweet spot: better
+voice than Qwen, faster than E4B, and the per-turn budget (~15s)
+keeps the GIF tight.

--- a/demos/04-customer-support-approval/demo.tape
+++ b/demos/04-customer-support-approval/demo.tape
@@ -1,0 +1,79 @@
+# Demo 04 — Customer-support agent with F3 approval gate.
+# Per ADR-020 §"Six scenarios" item 4.
+#
+# Workdir setup (auto-prepared by `make 04-customer-support-approval`):
+#   /tmp/aegis-demo-04/{model.litertlm, chat_template.sha256.txt, approval.json}
+#   /cases/case-1024.txt          — the customer complaint
+#   /drafts                       — empty; refund-letter.md lands here
+#
+# The recording uses the F3 file-channel: AEGIS_APPROVAL_FILE
+# points at /tmp/aegis-demo-04/approval.json which we pre-stage
+# with `decision: approved` so the write proceeds. A second take
+# with `decision: rejected` would show the deny path.
+#
+# Backend: LiteRT-LM / Gemma 4 E2B (per ADR-020 §"Decision" item 8).
+
+Output demo.gif
+
+Set FontSize 14
+Set Width 1240
+Set Height 760
+Set Theme "Dracula"
+Set TypingSpeed 25ms
+Set Padding 12
+Set Shell bash
+
+Type "# Aegis-Node demo: Customer support with F3 approval gate"
+Enter
+Sleep 1.2s
+
+Type "cd /tmp/aegis-demo-04 && rm -f ledger-*.jsonl /drafts/refund-letter.md"
+Enter
+Sleep 600ms
+
+# Show the explicit write_grant + approval_required.
+Type "grep -A3 'write_grants:' /root/aegis-node/demos/04-customer-support-approval/manifest.yaml"
+Enter
+Sleep 3s
+
+# Pre-stage the approval file (the human approver's decision).
+Type "echo '{\"decision\":\"approved\",\"approver\":\"alice@org\",\"reason\":\"verified case\"}' > approval.json"
+Enter
+Sleep 600ms
+
+# Run the agent. AEGIS_APPROVAL_FILE wires the F3 file-channel.
+Type "AEGIS_APPROVAL_FILE=/tmp/aegis-demo-04/approval.json aegis run \"
+Enter
+Type "    --backend litertlm \"
+Enter
+Type "    --manifest /root/aegis-node/demos/04-customer-support-approval/manifest.yaml \"
+Enter
+Type "    --model model.litertlm --chat-template-sidecar chat_template.sha256.txt \"
+Enter
+Type "    --session-id demo-04 \"
+Enter
+Type "    --prompt 'Read /cases/case-1024.txt to understand the customer complaint. Then use filesystem__write to save a one-paragraph refund-letter draft to /drafts/refund-letter.md.'"
+Enter
+Sleep 18s
+
+# Surface the F-features the demo exercised:
+Type "echo && echo '--- F2 + F4: read of the case ---'"
+Enter
+Sleep 600ms
+Type "grep accessType.:.read ledger-demo-04.jsonl | jq -c '{accessType, resourceUri}'"
+Enter
+Sleep 3s
+
+Type "echo && echo '--- F3 Approval entry ---'"
+Enter
+Sleep 600ms
+Type "grep approval ledger-demo-04.jsonl | jq -c '{entryType, accessType, approvalDecision: (.approvalDecision // \"-\")}'"
+Enter
+Sleep 4s
+
+Type "echo && echo '--- F2 + F7: post-approval write of the draft ---'"
+Enter
+Sleep 600ms
+Type "grep accessType.:.write ledger-demo-04.jsonl | jq -c '{accessType, resourceUri, bytesAccessed}'"
+Enter
+Sleep 5s

--- a/demos/04-customer-support-approval/manifest.yaml
+++ b/demos/04-customer-support-approval/manifest.yaml
@@ -1,0 +1,53 @@
+# Demo 04 — Customer-support agent with F3 approval gate.
+# Per ADR-020 §"Six scenarios" item 4.
+#
+# The agent reads a customer's case file and proposes a refund-
+# letter draft. The write of the draft requires F3 approval —
+# the F3 file-channel pre-approval (per ADR-005 + the v0.8.0
+# implementation) gates the dispatch.
+#
+# Three states are demonstrable in one recording:
+#   1. Agent reads the case (Allow path)
+#   2. Agent attempts to write the draft (RequireApproval)
+#   3. Approval is granted via the file channel → write proceeds
+#
+# Backend: LiteRT-LM with Gemma 4 E2B (per ADR-020 §"Decision" item 8).
+# Customer-support narrative reads better with a realistic agent
+# voice; E2B keeps the per-turn budget tight.
+
+schemaVersion: "1"
+agent:
+  name: "support-agent"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/support-agent/inst-001"
+tools:
+  filesystem:
+    read:
+      - "/cases"
+    # Broad write coverage to /drafts — narrowed by the explicit
+    # write_grant below with approval_required: true.
+    write:
+      - "/drafts"
+  network:
+    outbound: deny
+    inbound: deny
+
+# Explicit write grant requiring approval. Per ADR-005 / F3:
+# `approval_required: true` upgrades the policy decision from
+# Allow to RequireApproval, which the mediator routes through
+# the F3 channel (file / TTY / web / signed-API).
+write_grants:
+  - resource: "/drafts/refund-letter.md"
+    actions: ["write"]
+    duration: "PT1H"
+    approval_required: true
+
+# REQUIRED for demos: pinned seed + temperature 0.
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/demos/04-customer-support-approval/prompt.txt
+++ b/demos/04-customer-support-approval/prompt.txt
@@ -1,0 +1,1 @@
+Read /cases/case-1024.txt to understand the customer's complaint. Then use filesystem__write to save a one-paragraph refund-letter draft to /drafts/refund-letter.md.

--- a/docs/adrs/020-recorded-demo-program.md
+++ b/docs/adrs/020-recorded-demo-program.md
@@ -178,9 +178,30 @@ which caps the model size we can use without the recording feeling slow.
      --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
    ```
 
-   E4B (`gemma-4-E4B-it.litertlm`, ~3.7 GB) is published the same way
-   when a demo's per-turn budget can absorb the larger model — same
-   workflow inputs, just a different `litertlm_filename`.
+   **Published OCI artifact — Gemma 4 E4B (LiteRT-LM)** (per
+   [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md) §"License scope" amendment + [ADR-023](023-litertlm-as-second-inference-backend.md)):
+
+   - **Reference:** `ghcr.io/tosin2013/aegis-node-models/gemma-4-e4b-it:latest`
+   - **Manifest digest:** `sha256:de89d03b650a86410d1c9f48ee2239fdf7d5f8895ad00621e20b9c2ed195f931`
+   - **Blob SHA-256:** `f335f2bfd1b758dc6476db16c0f41854bd6237e2658d604cbe566bcefd00a7bc` (~3.65 GB)
+   - **Chat-template SHA-256:** `02b3091acf53c0b722e3db0c7a1b4980363edcc2d85549dafa339ff5dbfff629` (same `chat_template.jinja` as E2B — Google ships one canonical template across the Gemma 4 instruct family)
+   - **Upstream:** [`litert-community/gemma-4-E4B-it-litert-lm`](https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm) · file `gemma-4-E4B-it.litertlm` · revision `55b6eef9e490da991fe6bc5fec1834106927b727`
+   - **License:** Gemma Terms of Use (per ADR-021 §"License scope")
+   - **Backend:** LiteRT-LM (`aegis run --backend litertlm`)
+   - **Signed by:** `models-publish.yml` workflow ([run 25240337859](https://github.com/tosin2013/aegis-node/actions/runs/25240337859)) via Sigstore keyless. Carries `dev.aegis-node.chat-template.sha256` per [ADR-022](022-trust-boundary-format-agnosticism.md).
+
+   Demos pull this artifact at boot via:
+
+   ```bash
+   aegis pull ghcr.io/tosin2013/aegis-node-models/gemma-4-e4b-it@sha256:de89d03b650a86410d1c9f48ee2239fdf7d5f8895ad00621e20b9c2ed195f931 \
+     --keyless-identity '^https://github\.com/tosin2013/aegis-node/\.github/workflows/models-publish\.yml@.*$' \
+     --keyless-oidc-issuer 'https://token.actions.githubusercontent.com'
+   ```
+
+   Demos 2 + 3 (`02-read-only-research`, `03-code-review-time-bounded`)
+   are recorded against E4B per the per-demo selection table above.
+   Demo 4 (`04-customer-support-approval`) uses E2B for the tighter
+   per-turn budget; the model selection is per-demo, not per-program.
 
 ## Why these decisions
 


### PR DESCRIPTION
## Summary

Authors the three remaining ADR-020 §"Six scenarios" demos that target the LiteRT-LM backend. **Source files only — no GIFs in this PR**, see "Why no GIFs" below.

| # | Demo | Backend | Model |
|---|---|---|---|
| 02 | Read-only research assistant | LiteRT-LM | Gemma 4 E4B |
| 03 | Code review + time-bounded write_grant | LiteRT-LM | Gemma 4 E4B |
| 04 | Customer-support + F3 approval gate | LiteRT-LM | Gemma 4 E2B |

Plus the new **Gemma 4 E4B** OCI artifact pinned in ADR-020 §"Decision item 8" — same publish pipeline as E2B, fresh dispatch on this branch.

## Pinned artifact (Gemma 4 E4B)

```
ghcr.io/tosin2013/aegis-node-models/gemma-4-e4b-it@sha256:de89d03b650a86410d1c9f48ee2239fdf7d5f8895ad00621e20b9c2ed195f931
```

| field | value |
|---|---|
| blob SHA-256 | `f335f2bfd1b758dc6476db16c0f41854bd6237e2658d604cbe566bcefd00a7bc` (3.65 GB) |
| chat-template SHA-256 | `02b3091acf53c0b722e3db0c7a1b4980363edcc2d85549dafa339ff5dbfff629` (same as E2B — Google ships one canonical template across the Gemma 4 instruct family) |
| upstream | [`litert-community/gemma-4-E4B-it-litert-lm`](https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm) @ `55b6eef9e490da991fe6bc5fec1834106927b727` |
| signed by | [`models-publish.yml` run 25240337859](https://github.com/tosin2013/aegis-node/actions/runs/25240337859) via Sigstore keyless |

## Why no GIFs in this PR

The LiteRT-LM runtime `.so` (per [ADR-023](docs/adrs/023-litertlm-as-second-inference-backend.md), built on `ubuntu-24.04`) carries a `GLIBC_2.38+` dependency. The local authoring host runs Ubuntu 22.04 (glibc 2.35) and **can't load the dylib**. Verified earlier in the LiteRT-A series:

```
libaegis_litertlm_engine_cpu.so: /lib/x86_64-linux-gnu/libm.so.6:
  version `GLIBC_2.38' not found
```

Three rendering paths are documented per-demo in each `README.md`:

1. Native ubuntu-24.04+ host — render directly with `make -C demos NN-...`.
2. Docker `ubuntu:24.04` container — wrap the existing toolchain; auto-prepared workdir.
3. CI workflow extension — Phase 2b in ADR-020 caches the LiteRT-LM `.so` + Gemma 4 blobs and runs VHS in CI; future PR.

Each demo's manifest is `aegis validate`-clean; the `prompt.txt` and `demo.tape` are the only render-specific surfaces, both finalized here. Rendering becomes mechanical work whenever a glibc-2.39+ host is available.

## Validator findings caught during authoring

- **AEGIS003** refused `exec_grants[].program: "git"` (bare basename matches any `/git` on PATH — security risk). Demo 3 now pins `/usr/bin/git`.
- **AEGIS007** warned about broad write coverage without an approval class. Demo 3 now uses **explicit-grant-only** per [ADR-019](docs/adrs/019-explicit-write-grant-takes-precedence.md) — no `tools.filesystem.write` field; the time-bounded `write_grant` is the sole authorization.

All three manifests pass `aegis validate` clean.

## Demo highlights

**Demo 02 — Read-only research.** Canonical "agent reads docs, cannot write." Tools: `filesystem.read: ["/data"]` only. F4 access entries + F6 zero-connection NetworkAttestation + `aegis verify` confirm the closed-by-default story end-to-end.

**Demo 03 — Code review with F7 time-bounded write.** F2 read + F2 exec (`/usr/bin/git`) + F7 `write_grants[].duration: PT1H`. Within-window flow only (post-expiry deny demonstration needs a `aegis run --now <iso>` clock-override flag we don't have yet — flagged for a future enhancement).

**Demo 04 — Customer support + F3 approval.** Explicit `write_grant` with `approval_required: true`. The .tape pre-stages `/tmp/aegis-demo-04/approval.json` with `{decision: approved}` and runs aegis with `AEGIS_APPROVAL_FILE` pointing at it. Flipping `decision` to `rejected` produces the deny-path recording without any other change.

## Test plan

- [x] `aegis validate` clean across all 3 manifests
- [x] Each manifest pins `inference.determinism: { seed: 42, temperature: 0.0, ... }`
- [x] Existing `cargo test --workspace --exclude aegis-litertlm-backend`, `go test ./...` green (no code changes — sources + ADR amendment only)
- [ ] Render GIFs on glibc-2.39+ host — follow-up, blocked locally

## Status of the demo program (#73)

After this PR merges:

| # | Demo | State |
|---|---|---|
| 01 | MCP, sandboxed twice | ✅ shipped (PR #117) |
| 02 | Read-only research | sources here, GIF pending |
| 03 | Code review + time-bounded write | sources here, GIF pending |
| 04 | Customer support + approval | sources here, GIF pending |
| 05 | Tampered model halts | ✅ shipped (PR #93) |
| 06 | Egress containment | ✅ shipped (PR #102) |
| 07 | Multimodal vision | depends on #100 multipart `ChatMessage` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)