### PR TITLE
fix(litertlm-backend): emit kTypeUnspecified for sampler — work around CPU-UNIMPLEMENTED upstream

### DIFF
--- a/crates/litertlm-backend/src/chat.rs
+++ b/crates/litertlm-backend/src/chat.rs
@@ -81,6 +81,15 @@ impl RuntimeBackend for LiteRtLmBackend {
         // lands (LiteRT-LM #2080 / PR #2081).
         check_phase1_determinism(&self.options)?;
 
+        // Surface upstream INFO+ logs to stderr if AEGIS_LITERTLM_DEBUG
+        // is set — the LiteRT-LM C ABI returns NULL on session-create
+        // failure without a structured reason, and the upstream log
+        // line is the only signal an operator can act on. Off by
+        // default to keep the demo recordings noise-free.
+        if std::env::var_os("AEGIS_LITERTLM_DEBUG").is_some() {
+            crate::set_min_log_level(0);
+        }
+
         let engine = Engine::load(model_path).map_err(map_err)?;
         Ok(Box::new(LiteRtLmLoadedModel {
             engine,
@@ -116,22 +125,36 @@ impl LoadedModel for LiteRtLmLoadedModel {
 }
 
 /// Refuse a [`SessionOptions`] that would activate the seed-aware
-/// random sampler. Phase 1 is CPU + greedy only — see
-/// [ADR-023](../../docs/adrs/023-litertlm-as-second-inference-backend.md)
-/// §"Determinism + replay" and the LiteRT-B acceptance criterion.
+/// random sampler. Phase 1 manifests are required to declare
+/// `temperature: 0.0` even though the underlying determinism
+/// guarantee is broken upstream — see the **honesty note** below.
 ///
 /// The boot-time refusal is the same posture llama-backend uses for
 /// invalid configurations (typed error, never a runtime surprise).
+///
+/// ## Honesty note (Phase 1 caveat)
+///
+/// LiteRT-LM v0.10.2's CPU executor returns `UNIMPLEMENTED` for
+/// every named sampler type (`kGreedy`/`kTopK`/`kTopP`) —
+/// empirically `engine.cc:445 "Sampler type: N not implemented yet"`.
+/// We work around this by emitting `kTypeUnspecified` (the model's
+/// default baked into the `.litertlm` flatbuffer); the consequence
+/// is that the manifest's `temperature=0.0` declaration is
+/// **aspirational** on CPU until upstream's CPU sampler lands
+/// (LiteRT-LM #2080 / PR #2081). The gate here documents intent and
+/// keeps the manifest schema honest; the actual byte-determinism
+/// promise depends on the upstream fix.
 fn check_phase1_determinism(options: &SessionOptions) -> Result<(), BackendError> {
     let temp = options.determinism.temperature.unwrap_or(0.0);
     if temp > 0.0 {
         return Err(BackendError::new(
             BackendErrorKind::InvalidConfig,
             format!(
-                "litertlm backend Phase 1 (per ADR-023) requires temperature=0.0 (greedy); got temperature={temp}. \
-                 Probabilistic sampling is gated on upstream LiteRT-LM #2080 (CPU sampler determinism) \
-                 and PR #2081 (GPU sampler determinism); both must land before warm-temperature \
-                 sampling is unblocked. Set inference.determinism.temperature: 0.0 in the manifest."
+                "litertlm backend Phase 1 (per ADR-023) requires temperature=0.0; got temperature={temp}. \
+                 Note: the CPU sampler is upstream-UNIMPLEMENTED in v0.10.2 (LiteRT-LM #2080), so the \
+                 actual byte-determinism guarantee depends on that fix landing — but the gate here keeps \
+                 manifest declaration consistent across backends. Set inference.determinism.temperature: 0.0 \
+                 in the manifest."
             ),
         ));
     }

--- a/crates/litertlm-backend/src/chat.rs
+++ b/crates/litertlm-backend/src/chat.rs
@@ -407,7 +407,11 @@ mod tests {
         let err = check_phase1_determinism(&opts).expect_err("temp>0 must be refused");
         assert_eq!(err.kind, BackendErrorKind::InvalidConfig);
         assert!(err.detail.contains("temperature=0.7"));
-        assert!(err.detail.contains("#2080") && err.detail.contains("#2081"));
+        // Phase 1's CPU sampler is upstream-UNIMPLEMENTED (LiteRT-LM
+        // #2080); when that lands the gate flips to a real
+        // determinism guarantee. We just check the error message
+        // names the upstream issue an operator would search for.
+        assert!(err.detail.contains("#2080"), "got {err:?}");
     }
 
     #[test]

--- a/crates/litertlm-backend/src/lib.rs
+++ b/crates/litertlm-backend/src/lib.rs
@@ -196,74 +196,47 @@ impl Default for SessionOptions {
     }
 }
 
-/// Sampler choice fed to LiteRT-LM. Phase 1 is **CPU + greedy** per
-/// ADR-023; the other variants are exposed for parity with the C ABI's
-/// `Type` enum and will activate when upstream's GPU sampler-determinism
-/// fix lands.
-///
-/// The mapping `[`DeterminismKnobs`] → `Sampler`] is performed by
-/// [`pick_sampler`] and reflects the current
-/// `LiteRtLmSamplerParams` surface.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Sampler {
-    /// argmax — fully deterministic regardless of seed.
-    Greedy,
-    /// top-k probabilistic sampling (seed-aware).
-    TopK,
-    /// top-p / nucleus probabilistic sampling (seed-aware).
-    TopP,
-}
-
-impl Sampler {
-    fn as_c_type(self) -> sys::Type {
-        match self {
-            Sampler::Greedy => sys::Type_kGreedy,
-            Sampler::TopK => sys::Type_kTopK,
-            Sampler::TopP => sys::Type_kTopP,
-        }
-    }
-}
-
-/// Reduce a [`DeterminismKnobs`] block to a single C-ABI sampler
-/// choice.
-///
-/// LiteRT-LM's `LiteRtLmSamplerParams` selects exactly one sampler
-/// stage (unlike llama.cpp's chained samplers). We therefore project
-/// the knobs onto the closest single stage:
-///
-/// - `temperature = Some(0.0)` (or unset) → [`Sampler::Greedy`]
-/// - `top_p` set → [`Sampler::TopP`]
-/// - `top_k` set → [`Sampler::TopK`]
-/// - else → [`Sampler::Greedy`] (Phase 1 default).
-///
-/// `top_p` wins ties against `top_k` because the upstream sampler
-/// applies top-k first internally when both are set; exposing both
-/// would require a cascaded API LiteRT-LM doesn't currently offer.
-fn pick_sampler(knobs: &DeterminismKnobs) -> Sampler {
-    let temp = knobs.temperature.unwrap_or(0.0);
-    if temp <= 0.0 {
-        return Sampler::Greedy;
-    }
-    if knobs.top_p.is_some_and(|p| p < 1.0) {
-        return Sampler::TopP;
-    }
-    if knobs.top_k.is_some_and(|k| k > 0) {
-        return Sampler::TopK;
-    }
-    Sampler::Greedy
-}
+// `Sampler` enum + `pick_sampler` were the original C-ABI sampler
+// projection. Removed because LiteRT-LM v0.10.2's CPU executor
+// returns UNIMPLEMENTED for every named sampler type (1, 2, 3),
+// leaving `kTypeUnspecified` (0) — "use the model's baked default"
+// — as the only working CPU choice. Restore both when upstream's
+// CPU sampler ships (LiteRT-LM #2080 / PR #2081); the
+// `DeterminismKnobs` → `Sampler` projection logic is the natural
+// shape we'll want once the fix is in.
 
 /// Build a `LiteRtLmSamplerParams` from the determinism knobs.
+///
+/// **Sampler upstream gap:** LiteRT-LM v0.10.2's CPU executor
+/// returns `UNIMPLEMENTED` for `kGreedy` (type 3), `kTopK`
+/// (type 1), and `kTopP` (type 2) — empirically verified via
+/// `engine.cc:445` "Sampler type: N not implemented yet". The
+/// only CPU-implemented option in this release is
+/// `kTypeUnspecified` (0), which falls back to the model's
+/// default sampler baked into the `.litertlm` flatbuffer's
+/// `LlmMetadata.sampler_params`. For Gemma 4 the default is
+/// top-k=64 / top-p=0.95 / temperature=1.0 (per upstream's
+/// model card), which is NOT byte-deterministic — but Phase 1
+/// gets us a working session the demo recordings can iterate
+/// against.
+///
+/// Determinism is therefore deferred until upstream lands a
+/// CPU sampler (LiteRT-LM #2080 / PR #2081 — the same fix that
+/// unblocks GPU determinism). When that lands, this function
+/// flips back to emitting `Type_kGreedy` directly and the
+/// per-demo seed/temperature contract holds again.
+///
+/// The `seed` field is still emitted from the manifest knob
+/// even though kTypeUnspecified ignores it — keeps the manifest
+/// round-trip stable and makes the ledger entry's recorded
+/// seed-vs-output correspondence trivial to update once
+/// upstream's CPU sampler ships.
 fn build_sampler_params(knobs: &DeterminismKnobs) -> sys::LiteRtLmSamplerParams {
-    let sampler = pick_sampler(knobs);
     sys::LiteRtLmSamplerParams {
-        type_: sampler.as_c_type(),
+        type_: sys::Type_kTypeUnspecified,
         top_k: knobs.top_k.map(|k| k as i32).unwrap_or(0),
         top_p: knobs.top_p.unwrap_or(1.0),
         temperature: knobs.temperature.unwrap_or(0.0),
-        // LiteRtLmSamplerParams.seed is i32; manifest seeds are u32.
-        // Truncate via wrapping cast — auditors run with seed=42 in
-        // practice (per ADR-020), well within the i32 positive range.
         seed: knobs.seed.unwrap_or(0) as i32,
     }
 }
@@ -652,65 +625,23 @@ mod tests {
         assert!(err.to_string().contains("not found or unreadable"));
     }
 
-    #[test]
-    fn pick_sampler_default_knobs_picks_greedy() {
-        assert_eq!(pick_sampler(&DeterminismKnobs::default()), Sampler::Greedy);
-    }
+    // pick_sampler tests removed alongside the function — see the
+    // "// `Sampler` enum + `pick_sampler` were the original C-ABI
+    // sampler projection..." comment above the function for the
+    // restoration plan. The DeterminismKnobs round-trip from the
+    // manifest is still tested below.
 
     #[test]
-    fn pick_sampler_temp_zero_picks_greedy_even_with_top_p() {
-        let knobs = DeterminismKnobs {
-            seed: Some(42),
-            temperature: Some(0.0),
-            top_p: Some(0.9),
-            top_k: Some(40),
-            repeat_penalty: None,
-        };
-        assert_eq!(pick_sampler(&knobs), Sampler::Greedy);
-    }
-
-    #[test]
-    fn pick_sampler_warm_temp_with_top_p_picks_top_p() {
-        let knobs = DeterminismKnobs {
-            seed: Some(42),
-            temperature: Some(0.7),
-            top_p: Some(0.9),
-            top_k: Some(40),
-            repeat_penalty: None,
-        };
-        assert_eq!(pick_sampler(&knobs), Sampler::TopP);
-    }
-
-    #[test]
-    fn pick_sampler_warm_temp_with_only_top_k_picks_top_k() {
-        let knobs = DeterminismKnobs {
-            seed: Some(42),
-            temperature: Some(0.7),
-            top_p: None,
-            top_k: Some(40),
-            repeat_penalty: None,
-        };
-        assert_eq!(pick_sampler(&knobs), Sampler::TopK);
-    }
-
-    #[test]
-    fn pick_sampler_warm_temp_no_filters_picks_greedy_phase1_default() {
-        let knobs = DeterminismKnobs {
-            seed: Some(42),
-            temperature: Some(0.7),
-            top_p: None,
-            top_k: None,
-            repeat_penalty: None,
-        };
-        assert_eq!(pick_sampler(&knobs), Sampler::Greedy);
-    }
-
-    #[test]
-    fn build_sampler_params_default_is_greedy_temp0_seed0() {
+    fn build_sampler_params_default_emits_k_type_unspecified() {
+        // Per the build_sampler_params docstring: LiteRT-LM v0.10.2's
+        // CPU executor returns UNIMPLEMENTED for kGreedy (3), kTopK
+        // (1), and kTopP (2) — only kTypeUnspecified (0) is
+        // implemented on CPU, and that means "use the default sampler
+        // baked into the .litertlm flatbuffer." When upstream wires
+        // kGreedy on CPU (LiteRT-LM #2080 / #2081), this test flips
+        // back to expecting Type_kGreedy.
         let params = build_sampler_params(&DeterminismKnobs::default());
-        // The C-ABI enum value comparison is intentional — we want
-        // future bindgen output to keep `Type_kGreedy` stable.
-        assert_eq!(params.type_, sys::Type_kGreedy);
+        assert_eq!(params.type_, sys::Type_kTypeUnspecified);
         assert_eq!(params.temperature, 0.0);
         assert_eq!(params.top_p, 1.0);
         assert_eq!(params.top_k, 0);


### PR DESCRIPTION
## Summary

While attempting to render Demo 2/3/4 GIFs from PR #118 inside an ubuntu:24.04 / glibc 2.39 container, two upstream gaps surfaced. This PR ships the salvageable bug fix; the larger gap is filed as [#119 LiteRT-D](https://github.com/tosin2013/aegis-node/issues/119).

## What this fixes

LiteRT-LM v0.10.2's CPU executor returns `UNIMPLEMENTED` for every named sampler type:

| sampler enum | CPU result |
|---|---|
| `kTopK` (1) | UNIMPLEMENTED |
| `kTopP` (2) | UNIMPLEMENTED |
| `kGreedy` (3) | UNIMPLEMENTED |
| `kTypeUnspecified` (0) | works — falls back to the model's bake |

`build_sampler_params` previously emitted `kGreedy` (or topK/topP based on `pick_sampler`); session-create failed with `engine.cc:445 "Sampler type: N not implemented yet"`. Now emits `kTypeUnspecified` unconditionally → sessions boot cleanly. Seed/temp/top_k/top_p still flow through the struct so the bake sees them when upstream lands a CPU sampler.

## What this does NOT fix (filed as #119)

- The model still emits empty output because `chat.rs`'s flat-prompt path doesn't apply Gemma 4's chat template. **Demos 2/3/4 GIF rendering is still blocked** — the fix is the Conversation API integration tracked in #119.
- The CPU sampler is non-deterministic (kTypeUnspecified bakes to top-k=64+top-p=0.95+temperature=1.0 for Gemma 4). ADR-020's byte-identical re-render guarantee depends on upstream LiteRT-LM #2080 / #2081.

## Other changes

- **`Sampler` enum + `pick_sampler` removed** — they only mapped onto upstream-UNIMPLEMENTED types. Commented placeholder explains the restoration plan when the upstream CPU sampler lands.
- **`AEGIS_LITERTLM_DEBUG=1` env var** — sets `litert_lm_set_min_log_level(0)` so an operator can see the upstream INFO+ logs when debugging session-create failures (the FFI returns NULL without a structured reason; the upstream log line is the only signal).
- **`check_phase1_determinism` docstring + error message** updated to truthfully describe the upstream gap. The gate is kept (manifests still must declare `temperature: 0.0`) for cross-backend manifest consistency; flips to a real guarantee when upstream catches up.

## Tests

- [x] `cargo clippy -p aegis-litertlm-backend --all-targets -- -D warnings` clean
- [x] `cargo fmt -p aegis-litertlm-backend -- --check` clean
- [x] Session-create empirically succeeds inside ubuntu:24.04 + glibc 2.39 with the new sampler emit (model boot + tool catalog initialization + clean shutdown — all the structural F1/F2/F4/F6/F9 paths work). Tool-call emission is the gap #119 covers.

## Repro path used

```bash
docker build -t aegis-demo-renderer /tmp/aegis-demo-renderer  # ubuntu:24.04 + Rust + VHS + Chrome + oras + libclang
docker run --rm \
  -v /root/aegis-node:/work \
  -v /root/.cache/aegis:/root/.cache/aegis \
  -v /root/.config/aegis:/root/.config/aegis \
  -v /tmp:/tmp -v /data:/data \
  --network host \
  aegis-demo-renderer \
  bash -c 'cargo install --path /work/crates/cli --features llama,litertlm \
            && AEGIS_LITERTLM_DEBUG=1 aegis run --backend litertlm ...'
```

The Dockerfile is staged at `/tmp/aegis-demo-renderer/Dockerfile` and could be promoted to `.github/scripts/` in a follow-up if the demo rendering pipeline becomes part of CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)