### PR TITLE
feat(litertlm-publish): upstream_owner/upstream_repo inputs for fork-as-insurance (LiteRT-D, #119)

### DIFF
--- a/.github/workflows/litertlm-runtime-publish.yml
+++ b/.github/workflows/litertlm-runtime-publish.yml
@@ -1,23 +1,29 @@
 name: Publish LiteRT-LM runtime OCI artifact
 
-# Per ADR-023 (Update — 2026-05-01: prebuilt path doesn't exist; Aegis
-# publishes its own). Manual-dispatch only — no scheduled runs, no
-# implicit fetches. Each invocation:
+# Per ADR-023 + LiteRT-D (#119) — manual-dispatch publish of the
+# LiteRT-LM runtime `.so`. Each invocation:
 #
-#   1. Checks out google-ai-edge/LiteRT-LM at the pinned tag.
+#   1. Checks out the LiteRT-LM source at `<upstream_owner>/<upstream_repo>@<upstream_tag>`.
+#      Default owner/repo is `google-ai-edge/LiteRT-LM`; the inputs
+#      let an operator point at a fork (e.g. `tosin2013/LiteRT-LM`)
+#      that carries Aegis-side patches against upstream-broken
+#      paths — the bridge we use for upstream gaps Google hasn't
+#      addressed yet, e.g. the CPU decode crash on Gemma 4 we filed
+#      as `google-ai-edge/LiteRT-LM#2149`.
 #   2. Installs Bazel + clang.
-#   3. Patches the upstream `c/BUILD` with a small overlay
-#      (`engine_cpu_shared`) — Bazel doesn't expose a shared-library
-#      target by default, only the `cc_library` static archives.
-#      The overlay is one cc_shared_library rule that links engine_cpu's
-#      transitive deps into a single .so we can ship outside Bazel.
-#   4. Runs `bazel build //c:engine_cpu_shared` (CPU-only — Phase 1
-#      per ADR-023 §"Decision" item 3).
-#   5. Computes SHA-256 of the resulting .so.
-#   6. `oras push` to GHCR with the new
-#      `application/vnd.aegis-node.litertlm-runtime.v1` artifact-type
-#      + annotations capturing the upstream commit / Bazel version /
-#      glibc target / C ABI source SHA.
+#   3. Appends the Aegis overlay to upstream's `c/BUILD` — a
+#      `cc_binary(linkshared=True, linkstatic=True)` mirror of
+#      upstream's own `python/litert_lm/litert_lm_ext.so` rule that
+#      bundles `engine_cpu`'s transitive deps (incl. the Rust
+#      `llguidance` crate) into a single `.so` consumable from
+#      outside Bazel.
+#   4. Runs `bazel build //c:libaegis_litertlm_engine_cpu.so`
+#      (CPU-only — Phase 1 per ADR-023 §"Decision" item 3).
+#   5. Bundles the four upstream-vendored prebuilt sidekicks
+#      (`libGemmaModelConstraintProvider`, `libLiteRt`,
+#      `libLiteRtTopKWebGpuSampler`, `libLiteRtWebGpuAccelerator`).
+#   6. Computes SHA-256s and pushes via `oras` to GHCR with the
+#      `application/vnd.aegis-node.litertlm-runtime.v1` artifact-type.
 #   7. `cosign sign --yes` keyless via Sigstore Fulcio + Rekor.
 #   8. Prints pinning info for the ADR-023 amendment + LiteRT-A
 #      (#95)'s `litertlm-sys/build.rs`.
@@ -29,8 +35,18 @@ name: Publish LiteRT-LM runtime OCI artifact
 on:
   workflow_dispatch:
     inputs:
+      upstream_owner:
+        description: "GitHub owner of the LiteRT-LM source (default upstream; override to fork — e.g. tosin2013 — when shipping Aegis-side patches against upstream-broken paths per LiteRT-D / #119)"
+        required: false
+        default: "google-ai-edge"
+        type: string
+      upstream_repo:
+        description: "Repo name of the LiteRT-LM source (rarely changed; left as input for forks that rename)"
+        required: false
+        default: "LiteRT-LM"
+        type: string
       upstream_tag:
-        description: "LiteRT-LM upstream tag (e.g. v0.10.2)"
+        description: "Tag (or branch) to build (e.g. v0.10.2 or aegis/v0.10.2-base when building from a fork)"
         required: true
         default: "v0.10.2"
         type: string
@@ -64,16 +80,20 @@ jobs:
       - name: Validate upstream_tag shape
         run: |
           tag='${{ inputs.upstream_tag }}'
-          # Accept v<semver> or v<semver>-rc.N
-          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?$ ]]; then
-            echo "::error::upstream_tag must look like v<semver> or v<semver>-rc[.N] (got '$tag')." >&2
+          # Accept v<semver>, v<semver>-rc.N, or aegis/* fork
+          # branches (per LiteRT-D #119 — the fork-branch path lets
+          # operators dispatch against patched branches like
+          # aegis/v0.10.2-base while the upstream tag itself is
+          # still the canonical reference for cosign annotations).
+          if [[ ! "$tag" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?|aegis/.+)$ ]]; then
+            echo "::error::upstream_tag must look like v<semver>, v<semver>-rc[.N], or aegis/<branch> (got '$tag')." >&2
             exit 2
           fi
 
-      - name: Checkout LiteRT-LM upstream at pinned tag
+      - name: Checkout LiteRT-LM source at pinned tag
         uses: actions/checkout@v4
         with:
-          repository: google-ai-edge/LiteRT-LM
+          repository: ${{ inputs.upstream_owner }}/${{ inputs.upstream_repo }}
           ref: ${{ inputs.upstream_tag }}
           path: upstream
           # We need to capture the resolved commit SHA for the OCI
@@ -314,11 +334,11 @@ jobs:
 
           oras push "$ref" \
             --artifact-type "application/vnd.aegis-node.litertlm-runtime.v1" \
-            --annotation "org.opencontainers.image.source=https://github.com/google-ai-edge/LiteRT-LM" \
+            --annotation "org.opencontainers.image.source=https://github.com/${{ inputs.upstream_owner }}/${{ inputs.upstream_repo }}" \
             --annotation "org.opencontainers.image.revision=${{ steps.upstream.outputs.commit }}" \
             --annotation "org.opencontainers.image.title=libaegis_litertlm_engine_cpu.so" \
             --annotation "dev.aegis-node.upstream=github" \
-            --annotation "dev.aegis-node.upstream.repo=google-ai-edge/LiteRT-LM" \
+            --annotation "dev.aegis-node.upstream.repo=${{ inputs.upstream_owner }}/${{ inputs.upstream_repo }}" \
             --annotation "dev.aegis-node.upstream.tag=${{ inputs.upstream_tag }}" \
             --annotation "dev.aegis-node.upstream.commit=${{ steps.upstream.outputs.commit }}" \
             --annotation "dev.aegis-node.bazel.version=${{ steps.env.outputs.bazel }}" \

--- a/docs/adrs/023-litertlm-as-second-inference-backend.md
+++ b/docs/adrs/023-litertlm-as-second-inference-backend.md
@@ -408,6 +408,72 @@ workflow + the first publish run; LiteRT-A's wrapper effort
 The amendment is purely a build-supply-chain change — the runtime
 contract the rest of the ADR commits to is unchanged.
 
+## Update — 2026-05-02: Fork-as-insurance for upstream-broken paths (LiteRT-D, [#119](https://github.com/tosin2013/aegis-node/issues/119))
+
+PR #121 (LiteRT-D-A/B) landed the Conversation API integration and
+proved that LiteRT-LM v0.10.2's CPU decode path is upstream-broken
+on Gemma 4: **prefill succeeds**, then `RunDecodeAsync` segfaults
+on E4B / hangs silently on E2B
+([upstream issue #2149](https://github.com/google-ai-edge/LiteRT-LM/issues/2149)).
+Combined with the still-open CPU sampler bug
+([upstream #2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080)
+/ PR #2081), this means **Demo 2/3/4 GIF rendering is blocked
+upstream** and Google's `CONTRIBUTING.md` explicitly refuses
+external PRs ("the LiteRT-LM repository is not currently ready for
+code contributions").
+
+### Posture
+
+- **Issue route is open**, PR route is closed — file all findings
+  via issues. We did this for the decode bug (#2149) and will
+  cross-comment any future findings.
+- **Apache-2.0 license** permits fork + redistribute of patched
+  binaries via our `models-publish.yml`-style pipeline.
+- **`tosin2013/LiteRT-LM` is the operator-side fork**, branched
+  off upstream's tags. Patches against `aegis/v0.10.2-base` carry
+  Aegis-side workarounds for upstream-broken paths until upstream
+  fixes them. Each patched tag is built into the OCI runtime
+  artifact via the publish workflow's `upstream_owner` /
+  `upstream_repo` inputs.
+- **Default behavior is unchanged.** When the workflow dispatches
+  with `upstream_owner=google-ai-edge` (the default), the build
+  is byte-equivalent to the pre-fork pipeline. The fork path is
+  opt-in per dispatch.
+
+### `litertlm-runtime-publish.yml` change
+
+Two new inputs, both with upstream defaults so existing dispatches
+behave identically:
+
+```yaml
+upstream_owner: { default: "google-ai-edge" }   # override to "tosin2013" for fork builds
+upstream_repo:  { default: "LiteRT-LM" }
+upstream_tag:   #  accepts v<semver> | v<semver>-rc.N | aegis/<branch>
+```
+
+The `aegis/<branch>` shape is the contract for fork branches —
+both the validator and the manifest annotations
+(`org.opencontainers.image.source`,
+`dev.aegis-node.upstream.repo`) record the actual source so an
+auditor pulling an artifact built from a fork can tell at a
+glance which one signed it.
+
+### When we'd dispatch from the fork
+
+Only when an upstream-broken path needs an Aegis-side patch and
+upstream hasn't fixed it. Today's gap inventory (per #119):
+
+- **CPU decode crash on Gemma 4** ([upstream #2149](https://github.com/google-ai-edge/LiteRT-LM/issues/2149)) — blocks
+  Demo 2/3/4 rendering. If we patch this in the fork, dispatch
+  the workflow with `upstream_owner=tosin2013 upstream_tag=aegis/...`.
+- **CPU sampler UNIMPLEMENTED** ([upstream #2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080)) — already
+  worked around at the Aegis layer (kTypeUnspecified emit in
+  `crates/litertlm-backend/src/lib.rs::build_sampler_params`).
+
+When upstream fixes either, the workflow flips back to
+`upstream_owner=google-ai-edge` on the next dispatch and the
+fork's patch becomes obsolete.
+
 ## Related
 
 - [ADR-014 CPU-First GGUF Inference via llama.cpp](014-cpu-first-gguf-inference-via-llama-cpp.md) —


### PR DESCRIPTION
## Summary

Phase 2 of the LiteRT-D plan ([#119](https://github.com/tosin2013/aegis-node/issues/119)). Mechanical workflow change so the publish pipeline can build from a LiteRT-LM fork without code changes; no actual fork patches in this PR.

## Context

After PR #121 (LiteRT-D-A/B) landed the Conversation API integration, validation inside ubuntu:24.04 + glibc 2.39 docker found that LiteRT-LM v0.10.2's CPU decode path is upstream-broken on Gemma 4: prefill succeeds, then `RunDecodeAsync` segfaults on E4B / hangs on E2B. Filed upstream as **[google-ai-edge/LiteRT-LM#2149](https://github.com/google-ai-edge/LiteRT-LM/issues/2149)**.

Two facts make a fork-as-insurance posture viable:

1. Upstream is actively maintained but **does not accept external PRs** (`CONTRIBUTING.md`: *"the LiteRT-LM repository is not currently ready for code contributions"*).
2. License is Apache-2.0 — fork + redistribute patched binaries is fully compatible.

This PR adds the workflow plumbing so an operator can dispatch the publish pipeline against a fork branch carrying Aegis-side patches against any upstream-broken path. **Default behavior is unchanged**.

## What changes

**`litertlm-runtime-publish.yml`** — two new inputs, both with upstream defaults:

```yaml
upstream_owner: { default: "google-ai-edge" }    # override to "tosin2013" for fork builds
upstream_repo:  { default: "LiteRT-LM" }         # rarely overridden
upstream_tag:   #  accepts v<semver> | v<semver>-rc.N | aegis/<branch>
```

The `aegis/<branch>` shape is the contract for fork branches; the existing validator regex is widened to accept it.

OCI annotations now reflect the actual repo built (was hardcoded to `google-ai-edge/LiteRT-LM`):

| annotation | new value |
|---|---|
| `org.opencontainers.image.source` | `https://github.com/<owner>/<repo>` |
| `dev.aegis-node.upstream.repo` | `<owner>/<repo>` |

So an auditor pulling an artifact from GHCR can tell at a glance whether it's from upstream or a fork.

**ADR-023** — new §"Update — 2026-05-02: Fork-as-insurance for upstream-broken paths" documents the policy (when we'd dispatch from the fork vs upstream, when we'd flip back, the gap inventory tying to upstream issues #2149 + #2080).

## What does NOT change

- Default-path artifacts (no `upstream_owner` override) are byte-equivalent to the pre-PR pipeline.
- No actual fork patches in this PR — the fork itself (`tosin2013/LiteRT-LM`) needs to be created manually because the local PAT lacks fork-creation scope. Once it exists, the workflow can dispatch against it without further code changes.
- No changes to `crates/litertlm-sys/build.rs`, `crates/litertlm-backend/`, or any consumer.

## Verification

- [x] YAML parses (no syntax errors)
- [x] Default values preserve current behavior — when dispatched without `upstream_owner` override, the workflow checks out `google-ai-edge/LiteRT-LM` exactly as before
- [x] `aegis/<branch>` validator accepts the new shape; existing `v<semver>` validation unchanged
- [ ] **Real-world verification** (post-merge): dispatch with default inputs, confirm the produced artifact's annotations + digest match `sha256:6add795d...` (the current pin) — proves the change is a no-op for upstream
- [ ] **Fork-path verification** (deferred to Phase 3): once `tosin2013/LiteRT-LM` exists with `aegis/v0.10.2-base` branched off `v0.10.2`, dispatch with `upstream_owner=tosin2013 upstream_tag=aegis/v0.10.2-base` and confirm the artifact's `dev.aegis-node.upstream.repo` annotation reads `tosin2013/LiteRT-LM`

## Related

- [LiteRT-D #119](https://github.com/tosin2013/aegis-node/issues/119) — umbrella for the upstream gaps
- [google-ai-edge/LiteRT-LM#2149](https://github.com/google-ai-edge/LiteRT-LM/issues/2149) — the CPU decode crash we filed
- [google-ai-edge/LiteRT-LM#2080](https://github.com/google-ai-edge/LiteRT-LM/issues/2080) — the sampler UNIMPLEMENTED bug (already worked around in `build_sampler_params`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)