### PR TITLE
feat(ci): release.yml — tag push → draft GitHub Release from RELEASE_PLAN.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,217 @@
+name: Release
+
+# Tags vX.Y.Z[-suffix] trigger the workflow. The job composes release notes
+# from RELEASE_PLAN.md's matching milestone card + the GitHub auto-generated
+# "What's Changed" list, then creates a *draft* GitHub Release for operator
+# review. The operator clicks Publish in the GitHub UI.
+#
+# workflow_dispatch supports dry-run previews: pass dry_run=true to print
+# the composed body without calling `gh release create`.
+#
+# Pre-release detection: any pre-1.0 tag (v0.x.y) or any tag with a suffix
+# (v1.0.0-rc.1, v1.0.0-beta.2) is marked --prerelease. v1.0.0 and later
+# without a suffix are marked --latest.
+#
+# Policy decisions (see docs/RELEASE_PROCESS.md once written):
+#   - Hard-require: matching milestone card in RELEASE_PLAN.md (else fail)
+#   - Report-only: GitHub milestone open-issue count (rendered, not blocking)
+#   - Always draft: never auto-publish (pre-1.0 caution; typo / scope safety)
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version to compose notes for (e.g. v0.9.0). For dry-run the tag does not need to exist."
+        required: true
+        type: string
+      dry_run:
+        description: "If true, print the composed release body without creating a GitHub Release."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write   # gh release create needs this
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Compose release body + create draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need full history for git describe + auto-changelog
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+            echo "::error::Version '$VERSION' doesn't match vX.Y.Z[-suffix] pattern"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Detect pre-release flag
+        id: prerel
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+            echo "Reason: suffixed semver (rc/beta/alpha/etc.)"
+          elif [[ "$VERSION" =~ ^v0\. ]]; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+            echo "Reason: pre-1.0 per RELEASE_PLAN.md versioning policy"
+          else
+            echo "flag=--latest" >> "$GITHUB_OUTPUT"
+            echo "Reason: stable semver >= 1.0.0"
+          fi
+
+      - name: Extract milestone card from RELEASE_PLAN.md
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          chmod +x scripts/release/extract-milestone-notes.sh
+          if ! scripts/release/extract-milestone-notes.sh "$VERSION" RELEASE_PLAN.md > /tmp/milestone-card.md; then
+            echo "::error::Missing RELEASE_PLAN.md milestone card for $VERSION. Add an H3 entry to the LOCAL MILESTONES block before tagging."
+            exit 1
+          fi
+          echo "Milestone card extracted:"
+          cat /tmp/milestone-card.md
+
+      - name: Look up GitHub milestone status (report-only)
+        id: ms
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MILESTONE=$(gh api "repos/${GITHUB_REPOSITORY}/milestones?state=all&per_page=100" \
+            --jq "[.[] | select(.title | startswith(\"$VERSION \") or startswith(\"$VERSION—\") or startswith(\"$VERSION-\"))][0]")
+          if [ -z "$MILESTONE" ] || [ "$MILESTONE" = "null" ]; then
+            echo "::warning::No matching GitHub milestone for $VERSION (looked for prefix '$VERSION '). Skipping milestone status block."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            OPEN=$(echo "$MILESTONE" | jq -r .open_issues)
+            CLOSED=$(echo "$MILESTONE" | jq -r .closed_issues)
+            URL=$(echo "$MILESTONE" | jq -r .html_url)
+            TITLE=$(echo "$MILESTONE" | jq -r .title)
+            {
+              echo "found=true"
+              echo "open=$OPEN"
+              echo "closed=$CLOSED"
+              echo "url=$URL"
+              echo "title=$TITLE"
+            } >> "$GITHUB_OUTPUT"
+            echo "Found milestone: $TITLE — open=$OPEN closed=$CLOSED"
+            if [ "$OPEN" -gt 0 ]; then
+              echo "::warning::Milestone $TITLE has $OPEN open issue(s). Release will still publish (Balanced policy)."
+            fi
+          fi
+
+      - name: Generate auto-changelog
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Prefer GitHub's generate-notes API (rich PR list + contributors) when
+          # the tag exists on the remote. Fall back to git log for dry-runs of
+          # tags that haven't been pushed yet.
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${VERSION}" >/dev/null 2>&1; then
+            gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -F tag_name="${VERSION}" \
+              --jq .body > /tmp/auto-changelog.md
+            echo "Auto-changelog source: GitHub generate-notes API (tag exists)"
+          else
+            PREV_TAG=$(git tag --list 'v*.*.*' --sort=-v:refname | head -n 1 || echo "")
+            {
+              echo "_Generated from \`git log\` (tag $VERSION not yet pushed; use the GitHub Releases API for richer notes once tagged)._"
+              echo
+              if [ -n "$PREV_TAG" ]; then
+                echo "### Commits since $PREV_TAG"
+                echo
+                git log --pretty=format:"- %s" "${PREV_TAG}..HEAD"
+              else
+                echo "### Recent commits"
+                echo
+                git log --pretty=format:"- %s" --max-count=30 HEAD
+              fi
+              echo
+            } > /tmp/auto-changelog.md
+            echo "Auto-changelog source: git log (tag does not exist yet)"
+          fi
+
+      - name: Compose release body
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          MS_FOUND: ${{ steps.ms.outputs.found }}
+          MS_OPEN: ${{ steps.ms.outputs.open }}
+          MS_CLOSED: ${{ steps.ms.outputs.closed }}
+          MS_URL: ${{ steps.ms.outputs.url }}
+          MS_TITLE: ${{ steps.ms.outputs.title }}
+        run: |
+          {
+            echo "## Scope (from RELEASE_PLAN.md)"
+            echo
+            cat /tmp/milestone-card.md
+            echo
+            if [ "${MS_FOUND:-false}" = "true" ]; then
+              echo "## Milestone status"
+              echo
+              echo "[**${MS_TITLE}**](${MS_URL}) — open: \`${MS_OPEN}\` · closed: \`${MS_CLOSED}\`"
+              if [ "${MS_OPEN:-0}" != "0" ]; then
+                echo
+                echo "_⚠️ ${MS_OPEN} issue(s) still open against this milestone — see linked milestone for the in-flight scope._"
+              fi
+              echo
+            fi
+            echo "## What's Changed"
+            echo
+            cat /tmp/auto-changelog.md
+          } > /tmp/release-body.md
+
+          echo "===== composed release body ====="
+          cat /tmp/release-body.md
+          echo "===== end ====="
+
+      - name: Dry-run preview (workflow_dispatch with dry_run=true)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          PRERELEASE: ${{ steps.prerel.outputs.flag }}
+        run: |
+          echo "::notice::Dry-run only — no GitHub Release created. Body printed above."
+          echo "version: $VERSION"
+          echo "prerelease flag: $PRERELEASE"
+
+      - name: Create draft GitHub Release
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false')
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          PRERELEASE: ${{ steps.prerel.outputs.flag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag ${VERSION} doesn't exist on origin. Push the tag (\`git push --tags\`) before running with dry_run=false."
+            exit 1
+          fi
+          gh release create "${VERSION}" \
+            --draft \
+            --title "${VERSION}" \
+            --notes-file /tmp/release-body.md \
+            ${PRERELEASE}
+          URL=$(gh release view "${VERSION}" --json url --jq .url)
+          echo "::notice::Draft release created: ${URL}"
+          echo "Review the draft and click Publish in the GitHub UI to ship."

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -47,6 +47,13 @@ Once `gh auth login` succeeds and a GitHub remote is added:
 
 _Synced from `.mcp-adr-cache/milestones.local.json`. Run `release_tracking` with `operation: "push_local_milestones"` to publish to GitHub._
 
+> **Format note (consumed by `.github/workflows/release.yml`):** each card
+> below must start with an H3 header in the exact form `### vX.Y.Z — <name>`
+> (em-dash, not hyphen). The release workflow extracts the matching card
+> when a tag is pushed and includes it in the GitHub Release body. Pre-
+> release tags (`vX.Y.Z-rc.N`) fall back to the base-version card. See
+> `scripts/release/extract-milestone-notes.sh` for the parser.
+
 ### v0.1.0 — Foundations
 <!-- milestone-id: v0-1-0-foundations -->
 - **Status:** pushed (#1)

--- a/scripts/release/extract-milestone-notes.sh
+++ b/scripts/release/extract-milestone-notes.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Extract a single milestone card from RELEASE_PLAN.md by version.
+#
+# Usage:
+#   scripts/release/extract-milestone-notes.sh <version> [release-plan-path]
+#
+# Examples:
+#   scripts/release/extract-milestone-notes.sh v0.9.0
+#   scripts/release/extract-milestone-notes.sh v0.9.0 RELEASE_PLAN.md
+#
+# Writes the milestone's H3 section to stdout. Exits 1 with an actionable
+# error if no matching card is found.
+#
+# Card format expected (per RELEASE_PLAN.md "Local Milestones"):
+#   ### vX.Y.Z — <Milestone Title>
+#   <!-- milestone-id: ... -->
+#   - **Status:** ...
+#   - **Due:** ...
+#
+#   <freeform paragraph>
+#
+# A card runs from its `### vX.Y.Z` header to the next `### vX.Y.Z` header
+# (or the closing `<!-- /LOCAL MILESTONES -->` marker).
+
+set -euo pipefail
+
+VERSION="${1:-}"
+RELEASE_PLAN="${2:-RELEASE_PLAN.md}"
+
+if [ -z "$VERSION" ]; then
+    echo "usage: $0 <version> [release-plan-path]" >&2
+    echo "example: $0 v0.9.0" >&2
+    exit 2
+fi
+
+if [ ! -f "$RELEASE_PLAN" ]; then
+    echo "ERROR: $RELEASE_PLAN not found" >&2
+    exit 2
+fi
+
+extract_card() {
+    local target="$1"
+    awk -v ver="$target" '
+        BEGIN { in_card = 0 }
+        /^### v[0-9]+\.[0-9]+\.[0-9]+/ {
+            if ($0 ~ "^### " ver " ") {
+                in_card = 1
+                print
+                next
+            } else if (in_card) {
+                in_card = 0
+                exit
+            }
+        }
+        /^<!-- \/LOCAL MILESTONES -->/ {
+            if (in_card) {
+                in_card = 0
+                exit
+            }
+        }
+        {
+            if (in_card) print
+        }
+    ' "$RELEASE_PLAN"
+}
+
+CARD=$(extract_card "$VERSION")
+
+# Pre-release tags (vX.Y.Z-rc.1, -beta.2, etc.) reuse their base version's
+# milestone card. e.g. v0.9.0-rc.1 → look up v0.9.0.
+if [ -z "$CARD" ] && [[ "$VERSION" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)- ]]; then
+    BASE="${BASH_REMATCH[1]}"
+    echo "INFO: no card for $VERSION; falling back to base version $BASE" >&2
+    CARD=$(extract_card "$BASE")
+fi
+
+if [ -z "$CARD" ]; then
+    {
+        echo "ERROR: no milestone card for $VERSION found in $RELEASE_PLAN"
+        echo
+        echo "The release workflow expects an H3 header like:"
+        echo "  ### $VERSION — <Milestone Title>"
+        echo "inside the <!-- LOCAL MILESTONES --> ... <!-- /LOCAL MILESTONES --> block."
+        echo
+        echo "Available milestone cards:"
+        grep -E '^### v[0-9]+\.[0-9]+\.[0-9]+' "$RELEASE_PLAN" || echo "  (none found)"
+    } >&2
+    exit 1
+fi
+
+printf '%s\n' "$CARD"


### PR DESCRIPTION
## Summary

Adds release automation gating v0.9.0 (and every future tag). On `git tag vX.Y.Z && git push --tags`, the workflow composes a release body from `RELEASE_PLAN.md`'s milestone card + GitHub's auto-generated "What's Changed" + a milestone-status line, and creates a **draft** GitHub Release for operator review. The operator clicks Publish in the GitHub UI.

Closes the gap noted in `RELEASE_PLAN.md` line 6 — the doc has been the source-of-truth for milestone scope but there was no link between tagging and a published GitHub Release.

## Changes

- **`.github/workflows/release.yml`** (new) — triggered on `push: tags: ['v*.*.*']` + `workflow_dispatch` (for dry-runs).
- **`scripts/release/extract-milestone-notes.sh`** (new) — small awk-based helper that extracts a single milestone card from `RELEASE_PLAN.md` by version. Pre-release tags (e.g. `v0.9.0-rc.1`) fall back to the base version's card.
- **`RELEASE_PLAN.md`** — adds a format docstring noting that cards are machine-parsed by `release.yml`. Bumping the format requires updating both.

## Policy decisions (from in-conversation question)

| Decision | Choice | Rationale |
|---|---|---|
| Missing milestone card | Hard fail with actionable error | Cards are the source-of-truth; release should not silently publish empty notes |
| Open milestone issues | Report-only (rendered, not blocking) | Operator may know more than the workflow |
| Publish mode | Always draft | Pre-1.0 caution; protects against typo'd tags and accidental scope errors |
| Pre-release detection | Auto: \`vX.Y.Z-suffix\` or \`v0.x.y\` → \`--prerelease\` | Matches \`RELEASE_PLAN.md\` versioning policy |

## What this PR doesn't do

- Doesn't trigger downstream artifact publishes (`devbox.yml`, `models-publish.yml`, `litertlm-runtime-publish.yml`). Those stay `workflow_dispatch`-only through v0.9.0; revisit in v1.0.0.
- Doesn't introduce new release tooling (release-please, goreleaser, semantic-release). `RELEASE_PLAN.md` remains the curated authority; the workflow consumes it, doesn't replace it.
- Doesn't tag v0.9.0 — that's the operator's call after this PR + #128 merge.

## Test plan

- [x] Helper script tested locally:
  - `extract-milestone-notes.sh v0.9.0` → extracts the v0.9.0 card cleanly
  - `extract-milestone-notes.sh v0.9.0-rc.1` → falls back to v0.9.0 base card
  - `extract-milestone-notes.sh v9.9.9` → fails with actionable error + lists available cards
- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge: `gh workflow run release.yml -f tag=v0.9.0-rc.0 -f dry_run=true` produces the expected body in the workflow log without creating a release
- [ ] After merge: throwaway tag `v0.0.0-test` end-to-end test in pre-release mode; delete release + tag after
- [ ] Production: tag `v0.9.0`, verify draft GH Release appears with milestone scope + auto-changelog

## Out of scope

- Tagging v0.9.0 itself (downstream)
- README front-matter rewrite to reflect actual v0.9.0 scope (separate PR after this + #128 land)
- Multi-turn agent loop engine work (v1.0.0; research brief at \`docs/research/multi-turn-agent-loop.md\`)
- Web UI scaffolding (v1.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)