### PR TITLE
fix(ci): release.yml boolean comparisons for dry_run input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           echo "===== end ====="
 
       - name: Dry-run preview (workflow_dispatch with dry_run=true)
-        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           PRERELEASE: ${{ steps.prerel.outputs.flag }}
@@ -197,7 +197,7 @@ jobs:
           echo "prerelease flag: $PRERELEASE"
 
       - name: Create draft GitHub Release
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false')
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           PRERELEASE: ${{ steps.prerel.outputs.flag }}


### PR DESCRIPTION
## Summary

The dry-run preview step (and the create-draft step's else-branch) were silently always skipping because `inputs.dry_run == 'true'` is comparing a real boolean to a string.

For \`type: boolean\` inputs in \`workflow_dispatch\`, GHA passes a real boolean. The string comparison \`== 'true'\` always evaluates false. Switch to truthy form (\`inputs.dry_run\` / \`!inputs.dry_run\`).

Verified on workflow run [25387216302](https://github.com/tosin2013/aegis-node/actions/runs/25387216302) (a v0.9.0 dry-run):
- \"Dry-run preview\" → \`skipped\` (despite \`dry_run=true\`)
- \"Create draft GitHub Release\" → \`skipped\` (correct for dry-run, but for the wrong reason — neither clause matched)

The Compose step's body output already confirmed the rest of the pipeline is correct; only the two conditionals are wrong.

## Impact on tagging

Low. Tag pushes still work end-to-end (the \`github.event_name == 'push'\` clause fires regardless of this bug). This fix unblocks the workflow_dispatch dry-run flow, which is what we'd use to preview a future tag's body without committing.

## Test plan

- [x] Diff is one-line in two places
- [ ] After merge: re-run \`gh workflow run release.yml -f tag=v0.9.0 -f dry_run=true\` and confirm \"Dry-run preview\" step now runs (logs \"version: v0.9.0 / prerelease flag: --prerelease\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)