### PR TITLE
docs(adrs, plan): WebUI architecture (ADRs 031–034) for v0.9.5 + v2.5.0

### DIFF
--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -20,8 +20,10 @@
 | **v0.5.0** | Core Security Primitives: F1 identity, F2 manifest enforcement, F9 ledger writer + verify, F4 access log emitter | 2026-07-20 | ADR-003, ADR-004, ADR-006, ADR-011 / Phase 1a |
 | **v0.8.0** | Reasoning + Approval: F5 trajectory, F3 approval gate, F6 network deny, F7 read-only default | 2026-08-31 | ADR-005, ADR-007, ADR-008, ADR-009 / Phase 1b |
 | **v0.9.0** | Tooling + Replay: F10 validator, F8 replay viewer, OCI pull + Cosign, llama.cpp FFI, MCP client | 2026-10-05 | ADR-010, ADR-012, ADR-013, ADR-014, ADR-018 / Phase 1c |
-| **v1.0.0** | **Phase 1 GA — Security Review Milestone:** multi-turn agent loop with per-turn enforcement, web UI, conformance suite, auditor evidence package, design-partner review passed, Apache 2.0 community release | **2026-11-02** | ADR-001, ADR-016, ADR-025, ADR-026, ADR-027, ADR-028, ADR-029, ADR-030 / Phase 1 GA |
+| **v0.9.5** | Community UI: localhost chat, live trajectory, inline F3 approvals, visual manifest builder, model library, MCP catalog | 2026-10-20 | ADR-031, ADR-032, ADR-033 / Phase 1d |
+| **v1.0.0** | **Phase 1 GA — Security Review Milestone:** multi-turn agent loop with per-turn enforcement, conformance suite, auditor evidence package, design-partner review passed, Apache 2.0 community release | **2026-11-02** | ADR-001, ADR-016, ADR-025, ADR-026, ADR-027, ADR-028, ADR-029, ADR-030 / Phase 1 GA |
 | **v2.0.0** | Kubernetes Runtime: Operator + CRDs, SPIRE attestation, GPU backends (vLLM/TGI/KServe), persistent ledger | 2027-01-25 | ADR-002, ADR-015 / Phase 2 |
+| **v2.5.0** | Enterprise UI: multi-tenant fleet dashboard, RBAC + SSO/SAML, automated compliance exports (CMMC / FedRAMP / SOC 2 / EU AI Act) | 2027-03-01 | ADR-034 / Phase 2.5 |
 | **v3.0.0** | OpenShift Enterprise Runtime: SCCs, disconnected install, GitOps, automated CMMC/FedRAMP exports | 2027-04-19 | ADR-015 / Phase 3 |
 
 ## Strategic Anchor: CMMC 2.0 Deadline
@@ -82,6 +84,13 @@ Phase 1b: F5 pre-execution trajectory recorder, F3 human approval gate (CLI + lo
 
 Phase 1c: F10 policy-as-code validator (aegis validate) with composition + linter, F8 deterministic offline single-file HTML replay viewer, OCI artifact pull + Cosign verification (aegis pull), llama.cpp Rust FFI binding integrated with Backend trait, MCP client adoption per ADR-018 (manifest gains optional `tools.mcp[]`; F5 reasoning entries carry MCP tool names). Maps to ADRs 010, 012, 013, 014, 018.
 
+### v0.9.5 — Community UI
+<!-- milestone-id: v0-9-5-community-ui -->
+- **Status:** planned
+- **Due:** 2026-10-20
+
+Phase 1d: localhost-bound Apache-2.0 Community UI for the single-user / single-agent workflow. Ships four core surfaces (chat, live trajectory streaming, inline F3 approval cards, visual manifest builder with live `aegis validate` feedback) plus a visual Model Library wrapping `aegis pull` and an MCP Server Catalog with discovery-driven allowlist toggles. Static SPA bundled into the `aegis` binary; no external services. Multi-turn-aware (renders per-turn ledger structure from ADR-026). Maps to ADRs 031, 032, 033.
+
 ### v1.0.0 — Phase 1 GA / Security Review Milestone
 <!-- milestone-id: v1-0-0-phase-1-ga-security-review-milestone -->
 - **Status:** pushed (#5)
@@ -98,7 +107,7 @@ Phase 1 GA. Closes the gap between "agent runtime" the project name and what the
 - ADR-030: per-turn SPIFFE/mTLS workload attestation (ephemeral SVIDs, `aud` claim binds to turn)
 
 **Other v1.0.0 deliverables:**
-- Web UI (operator console for live agent observation + approval routing — details TBD)
+- Community UI polish on top of v0.9.5 (per-turn fold/unfold rendering for ADR-026, quota visualization for ADR-027, escalation routing for ADR-029)
 - End-to-end conformance test suite green
 - `aegis evidence cmmc` evidence-pack generator (signed report from F9 ledger; see [docs/COMPLIANCE_MATRIX.md](docs/COMPLIANCE_MATRIX.md))
 - First design-partner security review passed
@@ -113,6 +122,13 @@ Anchored to the U.S. CMMC 2.0 deadline (PRD §9 — defense beachhead). Maps to 
 - **Due:** 2027-01-25
 
 Phase 2: Kubernetes Operator + CRDs (AegisAgent, PermissionManifest, Ledger), SPIRE workload-attestation integration, GPU backends (vLLM/TGI/KServe) against the Backend trait, persistent ledger storage, NetworkPolicies stacked under runtime-level F6 deny. Maps to ADRs 002, 003, 008, 014, 015.
+
+### v2.5.0 — Enterprise UI
+<!-- milestone-id: v2-5-0-enterprise-ui -->
+- **Status:** planned
+- **Due:** 2027-03-01
+
+Phase 2.5: commercial-licensed multi-tenant Enterprise Management Dashboard built on top of the Phase 2 Kubernetes Operator. Surfaces fleet-wide agent state across the cluster, RBAC + SSO/SAML (Okta / Azure AD / Google / Keycloak air-gapped), multi-tenant manifest authoring with quota inheritance, live + historical ledger view, automated compliance report exports (CMMC 2.0 / FedRAMP / SOC 2 Type II / EU AI Act). Does not weaken or replace the community-tier runtime gates — operates them at scale. Maps to ADR-034.
 
 ### v3.0.0 — OpenShift Enterprise Runtime
 <!-- milestone-id: v3-0-0-openshift-enterprise-runtime -->

--- a/TODO.md
+++ b/TODO.md
@@ -76,11 +76,32 @@ Priority key: **P0** = release blocker · **P1** = required for the phase exit m
 - [ ] **P1** [ADR-013] Document operator workflow: download upstream, scan, sign with org Cosign key, push to internal registry.
 - [ ] **P2** [ADR-010, F8] CI test: fixed ledger fixture renders to fixed DOM snapshot.
 
+## Phase 1d — Community UI (target: v0.9.5, 2026-10-20)
+
+- [ ] **P0** [ADR-031] Build the Community WebUI as a static React/Vite SPA, bundled into the `aegis` binary at compile time. New crate `crates/ui-server/` (axum) serves the SPA + WebSocket/REST API on `127.0.0.1:7777`.
+- [ ] **P0** [ADR-031] Implement live trajectory streaming over WebSocket: F5 reasoning + F4 access entries render inline in chat as they're written to the F9 ledger. Read path is the existing `crates/ledger-writer/` reader API.
+- [ ] **P0** [ADR-031, ADR-029] Implement inline F3 approval cards in the chat flow: render F5 reasoning + tool args + manifest tier (advisory/validating/blocking/escalating) + cumulative ADR-027 quota state; allow / deny / escalate buttons write the same `approval_decision` ledger entry the CLI does.
+- [ ] **P0** [ADR-031, ADR-012] Implement the visual Manifest Builder backed by `crates/policy/src/validate.rs` for live `aegis validate` warnings. Output is the same YAML; hand-edit and builder coexist.
+- [ ] **P0** [ADR-032] Implement the "Model Library" view as a visual wrapper around `crates/cli/src/pull.rs`. Stream pull progress + cosign verification result over WebSocket. No file uploads — OCI ref only.
+- [ ] **P0** [ADR-032] Implement Session Forking: ending one session and booting a new one when the operator switches models in the UI. Replay chat history as the new session's prompt context. Backend auto-detects llama vs. litertlm from the OCI artifact's media type.
+- [ ] **P0** [ADR-033] Build the MCP Server Catalog page that runs `tools/list` against configured `server_uri`s and renders tool schemas with checkbox-toggled allowlist state. Reuses `crates/mcp-client/`.
+- [ ] **P0** [ADR-033, ADR-024] Infer `pre_validate` mappings from each tool's JSON schema; surface in the UI with operator override.
+- [ ] **P1** [ADR-031] Add per-session bearer token auth on the loopback API (stored in `~/.config/aegis/ui-token` with 0600 perms). Closes the local-malicious-process gap.
+- [ ] **P1** [ADR-031] WCAG 2.1 AA accessibility — keyboard navigation for approvals + screen-reader semantics on the chat feed. No color-only state encoding.
+- [ ] **P2** [ADR-031] localStorage persistence for manifest drafts; no PII or session content stored UI-side.
+
 ## Phase 1 GA — Security Review Milestone (target: v1.0.0, 2026-11-02 — CMMC deadline)
 
-- [ ] **P0** [ADR-001] Build the auditor evidence package generator: combine manifest + ledger + replay viewer + policy summary into a single signed bundle.
-- [ ] **P0** [ADR-001] Cross-language conformance suite green: every manifest accepted by the Go validator is enforced consistently by the Rust runtime, and vice versa.
-- [ ] **P0** [ADR-001] Pass a real security review with at least one design-partner organization (defense beachhead preferred).
+- [ ] **P0** [ADR-025] Implement the multi-turn agent loop in `crates/inference-engine/src/turn.rs` with the Triple-Bound Circuit Breaker (--max-turns 10, --max-tokens, --max-seconds 300). TurnCapExceeded preserves partial F9 ledger; CLI returns structured error.
+- [ ] **P0** [ADR-026] Bump ledger schema to v2 with hierarchical per-turn entries (`turn_start`, `tool_call`, `tool_result`, `turn_end`, `approval_decision`). Hash tool-result payloads inline; sidecar blob mechanism for >32KB results. `aegis verify` validates v1 + v2.
+- [ ] **P0** [ADR-027] Extend the F2 manifest schema with `tools.<class>.quota` sub-objects + the in-memory accumulator in `crates/policy/src/aggregate.rs`. AggregateCapExceeded prevents (halts + denies); rendered in `turn_end.quotaSnapshots[]`.
+- [ ] **P0** [ADR-028] Build the Adversarial Pre-Filter Gate. Default `RegexHeuristicClassifier` in-process; opt-in `LiteRtLmGuardClassifier` via manifest. Sanitize-and-warn pattern (no drop-and-retry). Verdict in F9 ledger.
+- [ ] **P0** [ADR-029] Implement Task-Scoped Ephemeral Approval Grants: TTL + sha256(canonical_args) binding; auto-consume on identical retry; tier schema (advisory / validating / blocking / escalating); pause-and-resume for headless mTLS approvals.
+- [ ] **P0** [ADR-030] Per-turn SVID rebinding at `turn_start` / destroy at `turn_end`. `aud="aegis-turn://<session>/<turn>"` claim binds replay scope; `context_digest_hex` selector detects inter-turn tampering. Performance budget <50ms per turn.
+- [ ] **P0** [ADR-001] `aegis evidence cmmc` evidence-pack generator: signed report from F9 ledger mapping observed runtime activity to NIST 800-171 controls (per `docs/COMPLIANCE_MATRIX.md`).
+- [ ] **P0** [ADR-001] Cross-language conformance suite green: every manifest accepted by the Go validator is enforced consistently by the Rust runtime, and vice versa. Includes new ADR-027 quota cases + ADR-028 IPI fixtures.
+- [ ] **P0** [ADR-001] Independent third-party red-team validation against MITRE ATLAS threat matrices.
+- [ ] **P0** [ADR-001] Pass a design-partner security review (defense beachhead preferred).
 - [ ] **P0** [ADR-016] v1.0.0 community release under Apache 2.0; tag, sign, publish.
 - [ ] **P1** [ADR-001] Public security documentation organized by the F1–F10 questions (one section per question, mapping to features and ADRs).
 - [ ] **P1** [ADR-001] Establish PR-review rule: every new feature must reference the security-review question it answers (or be marked post-MVP).
@@ -92,6 +113,15 @@ Priority key: **P0** = release blocker · **P1** = required for the phase exit m
 - [ ] **P0** [ADR-014, ADR-015] Implement GPU backend(s) against the `Backend` trait: at minimum vLLM; design space for TGI / KServe.
 - [ ] **P0** [ADR-008] Stack F6 runtime-deny under cluster NetworkPolicies (defense in depth).
 - [ ] **P0** [ADR-011] Persistent ledger storage strategy (PVC + retention/archival).
+
+## Phase 2.5 — Enterprise UI (target: v2.5.0, 2027-03-01)
+
+- [ ] **P0** [ADR-034] Build the multi-tenant Enterprise Management Dashboard on top of the Phase 2 Kubernetes Operator. Lives in the commercial-tier repository (separate from the open-core monorepo).
+- [ ] **P0** [ADR-034] Implement RBAC + SSO/SAML (Okta / Azure AD / Google Workspace / Auth0 / Keycloak air-gapped). Defaults: Security Admin / Operator / Auditor; custom roles supported.
+- [ ] **P0** [ADR-034] Multi-tenant manifest authoring with quota inheritance (tenant policy → workload policy → session policy). Tenant policy is a floor, not a ceiling.
+- [ ] **P0** [ADR-034] Live + historical fleet ledger view backed by tenant-scoped persistent ledger storage from Phase 2. Cryptographic chain remains source of truth; UI is a query surface.
+- [ ] **P1** [ADR-034] Automated compliance report exports — CMMC 2.0 Level 2 + FedRAMP Moderate/High + SOC 2 Type II + EU AI Act. Continuous (scheduled) + on-demand. Reports signed by runtime identity.
+- [ ] **P2** [ADR-034] Pricing / SKU shape decided by the business team; ADR sets the philosophical boundary (open-core per ADR-016), not the line items.
 
 ## Phase 3 — OpenShift Enterprise (target: v3.0.0, 2027-04-19)
 

--- a/docs/adrs/031-community-webui-for-local-collaboration.md
+++ b/docs/adrs/031-community-webui-for-local-collaboration.md
@@ -1,0 +1,217 @@
+# 31. Community WebUI for Local Collaboration
+
+**Status:** Proposed
+**Date:** 2026-05-05
+**Domain:** UI / runtime (extends [ADR-005](005-human-approval-gate-for-sensitive-actions.md), [ADR-007](007-pre-execution-reasoning-trajectory.md), [ADR-010](010-deterministic-trajectory-replay-offline-viewer.md), [ADR-016](016-open-core-licensing-model.md), [ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md))
+**Targets:** v0.9.5 Phase 1d (release date 2026-10-20)
+
+## Context
+
+Through v0.9.0 the operator surface is `aegis run --prompt "..."` plus
+the [F8 offline replay viewer](010-deterministic-trajectory-replay-offline-viewer.md)
+(after-the-fact) and the localhost web channel for [F3 approvals](005-human-approval-gate-for-sensitive-actions.md)
+(narrow scope). That's enough to prove the runtime works; it isn't
+enough to make the runtime *usable* day-to-day.
+
+Three friction points dominate first-run feedback:
+
+1. **No live transparency.** F5 reasoning entries land in the F9 ledger
+   in real time, but watching them requires `tail -f` on a JSONL file.
+   Operators want to see *what the agent is doing right now* while it
+   does it — not after.
+2. **Manifest authoring is YAML.** Operators draft `manifest.yaml`
+   in their editor of choice, run `aegis validate`, see linter output,
+   edit, repeat. F10 ships in v0.9.0 but is CLI-only. A 50-line
+   manifest with three nested `tools.mcp[]` entries is hard to keep
+   correct under hand-edit pressure.
+3. **F3 approvals are out-of-band.** TTY approvals interrupt the
+   terminal; file approvals require a side-channel; the localhost
+   web UI for approvals isn't tied to the agent's chat context.
+   Operators don't see *why* the agent wants the action (the F5
+   reasoning) at the moment of decision.
+
+[ADR-016](016-open-core-licensing-model.md) sets the open-core
+licensing model: the community runtime stays Apache-2.0; commercial
+tiers add convenience and integration, not previously-blocked
+compliance. The Web UI splits along this line — a free, locally-
+scoped Community UI proves the runtime is usable; the
+[Enterprise UI (ADR-034)](034-enterprise-management-dashboard-and-rbac.md)
+adds fleet management and is commercial.
+
+The arrival of bounded multi-turn ([ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md))
+makes this UI work especially load-bearing — agents executing 5–10
+turns of read-reason-act with inline approvals are no longer
+inspectable from a single CLI invocation.
+
+## Decision
+
+**Ship a Community WebUI in v0.9.5 (Phase 1d) under Apache-2.0. The
+UI runs strictly on localhost, manages exactly one local `aegis`
+process, and exposes four core surfaces: chat, live trajectory,
+inline F3 approvals, and a visual manifest builder. It is a static
+SPA served by the existing `aegis` binary on a configurable
+localhost port; no separate UI server, no external dependencies, no
+network egress.**
+
+### Surfaces
+
+1. **Context-aware chat.** Multi-turn conversation against a single
+   agent. Each user message becomes a fresh `Session::run_turn`
+   prompt; the chat history is the prompt context. Bounded by the
+   manifest's `inference.*` and `--max-turns` ([ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md))
+   exactly as the CLI is.
+
+2. **Live trajectory streaming.** As the agent runs, F5
+   reasoning entries and F4 access entries stream into the chat
+   alongside the assistant's text. Implementation: WebSocket (or SSE
+   fallback) feed of new ledger entries, rendered inline in the
+   conversation. Each entry is the same JSON-LD that lands in the
+   ledger — UI is a real-time view of the same source-of-truth.
+
+3. **Inline F3 approvals.** When the agent hits an approval gate (per
+   [ADR-005](005-human-approval-gate-for-sensitive-actions.md) and
+   [ADR-029](029-task-scoped-ephemeral-approval-grants.md)), the
+   pending approval surfaces as an interactive card in the chat
+   feed: the F5 reasoning context, the proposed tool call args, the
+   manifest tier (advisory / validating / blocking / escalating),
+   the cumulative quota state from [ADR-027](027-aggregate-quota-schema.md),
+   and Approve / Deny / Escalate buttons. Approval decisions write
+   the same `approval_decision` ledger entry the CLI writes — the
+   UI is a channel, not a different policy.
+
+4. **Visual manifest builder.** Form-driven editor for the F2
+   manifest. As the operator edits, the in-process F10
+   `aegis validate` ([ADR-012](012-policy-as-code-validation.md))
+   engine returns warnings live: overly broad paths, redundant
+   `pre_validate` ([ADR-024](024-mcp-args-prevalidation.md)) clauses,
+   missing `quota` ([ADR-027](027-aggregate-quota-schema.md)) on
+   network outbound, etc. Output is the same YAML that lands on disk;
+   "Save" writes the file the CLI would consume. Hand-edit and
+   builder coexist — operators can switch back to text at any time.
+
+### Architecture
+
+```text
+┌──────────────────────────────────────────────────────────┐
+│  Browser (localhost:7777)                                │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │  Community UI — React/Vite SPA, served as static │   │
+│  │  assets bundled into the `aegis` binary.         │   │
+│  │  - Chat / trajectory / approvals / manifest      │   │
+│  └────────────────┬─────────────────────────────────┘   │
+│                   │ WebSocket /api/v1/stream             │
+│                   │ HTTP    /api/v1/{session,manifest…}  │
+└───────────────────┼──────────────────────────────────────┘
+                    │
+┌───────────────────▼──────────────────────────────────────┐
+│  aegis run --ui --listen 127.0.0.1:7777                  │
+│  ┌────────────────┐  ┌─────────────────────┐             │
+│  │ existing       │  │ new: ui_server      │             │
+│  │ Session +      │◄─┤ axum/tower handler  │             │
+│  │ run_turn loop  │  │ /api/v1/* routes    │             │
+│  └────────────────┘  └─────────────────────┘             │
+└──────────────────────────────────────────────────────────┘
+```
+
+- **Localhost-only.** The listener binds 127.0.0.1; the UI server
+  refuses non-loopback connections at the socket level. This is
+  enforced not just by configuration but by binding semantics — there
+  is no flag to expose it externally. Operators who want network-
+  reachable UI deploy the [Enterprise UI](034-enterprise-management-dashboard-and-rbac.md)
+  (different threat model, different licensing).
+- **Single agent, single user.** No multi-tenancy, no auth. The
+  threat model is "the operator and the runtime share a host"; the
+  UI inherits the host's process boundary as its trust boundary.
+- **Static SPA bundled into the binary.** No separate UI server, no
+  Node.js runtime requirement at production. The dev workflow uses
+  Vite for HMR; the release pipeline builds the SPA and embeds the
+  static assets via `include_bytes!` (or `rust-embed`) into
+  `crates/cli/`.
+- **WebSocket + HTTP REST.** WS for live trajectory + approval
+  prompts; HTTP for session lifecycle (`POST /api/v1/sessions`,
+  `GET /api/v1/manifests/:id`, etc.). All endpoints serve JSON.
+
+### Implementation phasing
+
+v0.9.5 ships **all four surfaces** at minimum-viable depth. Polish
+ships in v0.9.6+/v1.0.0:
+
+| Surface | v0.9.5 must | v1.0.0 polish |
+|---|---|---|
+| Chat | Single-turn + multi-turn + history scrollback | Markdown rendering of assistant output, syntax highlighting |
+| Trajectory | Render reasoning + access entries inline | Hierarchical fold/unfold per [ADR-026](026-hierarchical-per-turn-ledger-protocol.md) turn brackets |
+| Approvals | Card with reasoning, args, allow/deny | Quota visualization, escalation routing per [ADR-029](029-task-scoped-ephemeral-approval-grants.md) |
+| Manifest builder | Form for tools.{filesystem,network,mcp,exec} + live `aegis validate` warnings | Quota schema editor ([ADR-027](027-aggregate-quota-schema.md)), tier picker ([ADR-029](029-task-scoped-ephemeral-approval-grants.md)) |
+
+Plus two adjacent capabilities ship as their own ADRs:
+
+- [ADR-032 — Visual Model Library and Session Forking](032-webui-model-library-and-session-forking.md)
+- [ADR-033 — Visual MCP Server Management](033-webui-visual-mcp-server-management.md)
+
+## Why not the alternatives
+
+- **Browser extension / electron app.** Either path requires shipping
+  a separate distribution channel, a separate signing chain, and
+  separate security review. The bundled-SPA approach inherits the
+  runtime's existing supply chain ([ADR-013](013-oci-artifacts-for-model-distribution.md)
+  + [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md)) — one signed binary, one trust boundary.
+- **Web UI shipped separately as its own crate / Docker image.**
+  Adds operational surface for a feature that's supposed to *reduce*
+  friction. The first-run promise is "install one binary, run one
+  command" — a separate UI distribution breaks that.
+- **Skip the UI; rely on third-party tooling (LangSmith / Helicone /
+  custom dashboards).** Those exist for the LangChain ecosystem
+  precisely because LangChain doesn't ship one. They also bind the
+  user to a third-party SaaS. For Aegis-Node's compliance posture,
+  shipping our own localhost UI is the right answer.
+- **Defer to Enterprise UI only.** Splits the funnel awkwardly:
+  developers evaluating the open-source tier don't see the UX they'd
+  get on the commercial tier, so they make adoption decisions
+  against the worst-case CLI experience. The Community UI is the
+  "free trial" that proves the runtime is usable.
+
+## Implementation tracking
+
+- New crate `crates/ui-server/` (axum routes, WS upgrades, manifest
+  builder backend that wraps `crates/policy/` validate functions).
+- New static SPA at `ui/` (Vite + React + TypeScript). Build output
+  bundled into the CLI binary at compile time.
+- Extend `crates/cli/src/run.rs` with `--ui --listen <addr:port>`
+  flags. Default listen address `127.0.0.1:7777`.
+- Reuse: `crates/ledger-writer/` reader API for the live trajectory
+  feed; `crates/approval-gate/src/channels/web.rs` (existing) for the
+  in-chat approval channel; `crates/policy/src/validate.rs` for the
+  builder's live linting.
+- Tracking issue: see v0.9.5 milestone tracker.
+
+## Open questions for follow-up
+
+- **Auth on localhost.** The threat model is "operator owns the
+  host," so no auth at all is defensible. But: a malicious local
+  process can drive the UI via the loopback API. Should we require
+  a per-session token in `Authorization` headers (stored in a
+  user-readable file with 0600 perms; same trust as kubectl
+  config)? Lean yes — costs nothing, closes a small gap.
+- **Cookie storage of session state.** UI may want to persist
+  drafts of manifests across browser refreshes. localStorage is
+  acceptable; no PII or secrets stored UI-side. Decision: yes,
+  manifest drafts only, no session content.
+- **i18n.** Out of scope for v0.9.5; English only. Translation
+  hooks (`i18next`) are wired in the SPA scaffold so future PRs can
+  add locales without rewriting components.
+- **Accessibility.** WCAG 2.1 AA target. Keyboard navigation for
+  approvals is required (operator may be approving from a
+  screen-reader environment). Color is informational — not
+  load-bearing.
+
+## References
+
+- [ADR-005](005-human-approval-gate-for-sensitive-actions.md) F3 baseline
+- [ADR-007](007-pre-execution-reasoning-trajectory.md) F5 reasoning
+- [ADR-010](010-deterministic-trajectory-replay-offline-viewer.md) F8 offline replay
+- [ADR-012](012-policy-as-code-validation.md) F10 validate
+- [ADR-016](016-open-core-licensing-model.md) Open-core licensing model
+- [ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md) Multi-turn loop
+- [ADR-026](026-hierarchical-per-turn-ledger-protocol.md) Per-turn ledger
+- [ADR-029](029-task-scoped-ephemeral-approval-grants.md) F3 ephemeral grants
+- HashiCorp Vault UI / GitLab CE patterns for open-core front-ends

--- a/docs/adrs/032-webui-model-library-and-session-forking.md
+++ b/docs/adrs/032-webui-model-library-and-session-forking.md
@@ -1,0 +1,203 @@
+# 32. WebUI Model Library and Session Forking
+
+**Status:** Proposed
+**Date:** 2026-05-05
+**Domain:** UI / supply chain (extends [ADR-013](013-oci-artifacts-for-model-distribution.md), [ADR-022](022-trust-boundary-format-agnosticism.md), [ADR-023](023-litertlm-as-second-inference-backend.md), supports [ADR-031](031-community-webui-for-local-collaboration.md))
+**Targets:** v0.9.5 Phase 1d
+
+## Context
+
+Once the [Community UI (ADR-031)](031-community-webui-for-local-collaboration.md)
+gives operators a chat surface, the next question is "how do I switch
+the model the agent is running?" In the CLI workflow, this is
+explicit: `aegis pull <oci-ref>` then `aegis run --model
+~/.cache/aegis/...`. In a chat UI, the model name is invisible —
+operators reach for a dropdown.
+
+Two zero-trust constraints make naive UX dangerous:
+
+1. **No arbitrary file uploads.** Per [ADR-013](013-oci-artifacts-for-model-distribution.md)
+   and [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md),
+   models enter the runtime exclusively via signed OCI artifacts.
+   A "drop a `.gguf` file here" UX would bypass the entire supply
+   chain, defeating the F1 binding to a verified model digest.
+2. **No mid-session model swap.** F1 binds workload identity to the
+   `(model_digest, manifest_digest, config_digest)` triple at session
+   start ([ADR-003](003-cryptographic-workload-identity-spiffe-spire.md)).
+   The hash-chained ledger ([ADR-011](011-hash-chained-tamper-evident-ledger.md))
+   anchors the entire session to that triple. Hot-swapping a model
+   mid-conversation would invalidate the chain or require a new chain
+   that pretends the prior one used a different model — both unsafe.
+
+The UI must offer "switch the model" as a feature without violating
+either constraint.
+
+## Decision
+
+**Model loading in the WebUI is a visual wrapper around `aegis pull`
+that streams progress, surfaces cosign verification results, and adds
+the verified artifact to the local library — never accepting arbitrary
+file uploads. Model switching is implemented as Session Forking: the
+current session is gracefully ended, a new session is booted with the
+new model digest, and the chat history is replayed as the user prompt
+context. The UI auto-detects the required backend (llama / litertlm)
+from the OCI artifact's media type.**
+
+### Model Library — visual `aegis pull`
+
+The "Model Library" view (in the Community UI's Settings / Models
+sidebar) lists locally-cached models with:
+
+- OCI ref + digest
+- Cosign verification result (verified-by identity, signature timestamp)
+- Backend kind (llama / litertlm)
+- Cache size + last-used timestamp
+
+**Adding a model:** the operator pastes an OCI ref (e.g.
+`ghcr.io/tosin2013/aegis-node-models/gemma-4-e4b-it@sha256:...`).
+The UI shells out to the existing `crates/cli/src/pull.rs` flow and
+streams progress over WebSocket:
+
+```text
+[1/4] Resolving manifest digest …
+[2/4] Pulling oras blobs …  ████████████░░░░  72% (2.1 GB / 2.9 GB)
+[3/4] cosign verify --keyless …  ✓ verified by ${KEYLESS_IDENTITY}
+[4/4] Caching to ~/.cache/aegis/models/<digest>/  ✓
+```
+
+If verification fails, the model is **not** added to the library and
+a clear error surfaces. There is no "I trust this anyway" override.
+
+**Removing a model:** purges from the local cache and the library
+view. Does not affect any in-progress session that loaded the model
+(the running session keeps the file via the cache symlink contract
+in `examples/01-hello-world/setup.sh`-style staging).
+
+**No file uploads.** The browser's `<input type="file">` element does
+not appear anywhere in the Model Library. Operators who want to add
+a model that isn't on a public registry first publish it to their
+internal OCI registry (per [docs/MODEL_MIRRORING.md](../MODEL_MIRRORING.md))
+and then paste that ref into the UI.
+
+### Session Forking — switching models in chat
+
+When the operator picks a different model from the chat dropdown:
+
+1. **End current session.** UI emits a synthetic "session boundary"
+   message ("Switching from `gemma-4-e4b-it@sha256:de89…` to
+   `qwen-2.5-1.5b-instruct@sha256:c740…`"). The current
+   `Session::run_turn` loop runs to completion if a turn is in
+   flight; no in-flight turn is interrupted. The F9 ledger emits
+   its `session_end` entry as normal.
+2. **Boot new session.** A fresh `Session` is created with the new
+   model digest. F1 mints a new SVID for the new identity triple.
+   The F9 ledger starts a new chain anchored to the new digests.
+3. **Replay chat history as context.** The new session's first turn
+   receives the prior session's chat history as part of its prompt
+   context (operator-visible, the same way the user types). The
+   model has visibility into "we just switched models — here's what
+   we discussed previously" without inheriting any of the prior
+   session's enforcement state.
+
+Properties:
+
+- The two sessions share **no** identity, **no** manifest binding,
+  **no** F9 chain, **no** F3 grants ([ADR-029](029-task-scoped-ephemeral-approval-grants.md))
+  — by design.
+- The two sessions share **the chat history (text only)** as a
+  prompt input — by design, for UX continuity.
+- An auditor inspecting either session's ledger sees a clean
+  beginning-to-end record. Cross-session links are inferred from the
+  UI's metadata (timestamps, the synthetic boundary message), not
+  from the cryptographic chain.
+
+### Backend auto-detection
+
+The WebUI inspects the OCI artifact's media type or annotations to
+choose the backend:
+
+| Annotation / format | Backend | Required CLI feature |
+|---|---|---|
+| `org.opencontainers.image.title=*.gguf` (and llama-style cosign sig) | llama (per [ADR-014](014-cpu-first-gguf-inference-via-llama-cpp.md)) | `--features llama` |
+| `*.litertlm` artifact, paired chat-template digest | litertlm (per [ADR-023](023-litertlm-as-second-inference-backend.md)) | `--features litertlm` |
+
+If the running `aegis` binary lacks the required feature (built with
+`--features llama` only, asked to load a `.litertlm`), the UI
+surfaces the rebuild hint:
+
+```text
+This model requires the LiteRT-LM backend. Rebuild aegis with:
+  cargo install --locked --path crates/cli --features "llama litertlm" --force
+```
+
+The detection is the same logic the CLI uses; the UI is
+defense-in-depth for a confused user.
+
+## Why not the alternatives
+
+- **Drop-a-file model upload.** Defeats the entire OCI/cosign trust
+  chain. Rejected unconditionally. Internal/private models go
+  through the operator's own OCI registry per
+  [MODEL_MIRRORING.md](../MODEL_MIRRORING.md).
+- **Mid-session hot-swap.** Cryptographically incoherent — the F9
+  ledger and F1 SVID are bound to the model digest at boot. Even if
+  we tolerated re-binding mid-session, the chat history would carry
+  reasoning produced by a model that's no longer running, with no
+  way to verify which turn was authored by which model. Rejected.
+- **Soft model switch (continue chain, just update digest field).**
+  Same problem at lower volume. Rejected.
+- **Restart from scratch on switch (lose chat history).** Honest
+  but bad UX. Operators would learn to avoid switching.
+  Session Forking with replayed-history is the compromise that
+  preserves both UX and chain integrity.
+- **Auto-pull on first use without confirmation.** Operators might
+  paste a malicious OCI ref by accident. Show the verification step
+  explicitly so the operator sees who signed the artifact before it
+  enters their cache.
+
+## Implementation tracking
+
+- UI: Model Library page in `ui/src/pages/Models.tsx`.
+- Backend: `crates/ui-server/src/handlers/models.rs` wraps
+  `crates/cli/src/pull.rs` exposing streaming progress over
+  WebSocket. No new auth / verification logic — reuses pull.rs
+  exactly.
+- Session forking: `crates/ui-server/src/handlers/sessions.rs`
+  implements the end-current → boot-new → replay-history sequence.
+  `crates/inference-engine/src/session.rs` gains no new public API
+  (the existing `Session::new` + `Session::shutdown` cover this);
+  the orchestration is in the UI server.
+- Tracking issue: see v0.9.5 milestone tracker.
+
+## Open questions for follow-up
+
+- **Replay-history token budget.** A long chat history may not fit
+  in the new model's context window (e.g., switching from a 32K
+  Gemma 4 to an 8K Qwen). The UI summarizes/truncates older turns
+  with a visible boundary marker. Strategy: keep last N turns in
+  full, summarize older ones via a non-tool summarization pass,
+  surface the truncation so the operator can manually re-send key
+  context if needed.
+- **OCI registry auth.** Operators using private GHCR / ECR /
+  Artifactory need to provide credentials. Reuse the operator's
+  existing `~/.docker/config.json` / `oras login` state — the UI's
+  pull wrapper is just `oras` underneath. Document this rather than
+  build credential UI.
+- **Pre-cached models.** If a model is already in
+  `~/.cache/aegis/models/`, the Library should detect it without
+  re-running `aegis pull`. Trade-off: a malicious local process
+  could plant a "verified" cache directory. Resolution: list cached
+  models but don't mark them "verified" unless the runtime can
+  re-verify the cosign signature against the cache's stored
+  signature artifact.
+
+## References
+
+- [ADR-013](013-oci-artifacts-for-model-distribution.md) OCI artifacts
+- [ADR-021](021-huggingface-as-upstream-oci-as-trust-boundary.md) HF as upstream
+- [ADR-022](022-trust-boundary-format-agnosticism.md) Trust boundary
+- [ADR-023](023-litertlm-as-second-inference-backend.md) LiteRT-LM
+- [ADR-031](031-community-webui-for-local-collaboration.md) Community UI baseline
+- [docs/MODEL_MIRRORING.md](../MODEL_MIRRORING.md) operator workflow
+- `crates/cli/src/pull.rs` (the existing pull implementation that the
+  UI wraps)

--- a/docs/adrs/033-webui-visual-mcp-server-management.md
+++ b/docs/adrs/033-webui-visual-mcp-server-management.md
@@ -1,0 +1,179 @@
+# 33. WebUI Visual MCP Server Management
+
+**Status:** Proposed
+**Date:** 2026-05-05
+**Domain:** UI / MCP (extends [ADR-018](018-adopt-mcp-protocol-for-agent-tool-boundary.md), [ADR-024](024-mcp-args-prevalidation.md), supports [ADR-031](031-community-webui-for-local-collaboration.md))
+**Targets:** v0.9.5 Phase 1d
+
+## Context
+
+[ADR-018](018-adopt-mcp-protocol-for-agent-tool-boundary.md) made
+MCP the agent-to-tool boundary. The manifest's `tools.mcp[]` array
+declares which servers and tools the agent can reach; everything is
+closed-by-default.
+
+In CLI workflows that's manageable for one or two MCP servers — the
+Examples 02 + 06 manifests have 1–2 servers each. As the surface area
+grows (operator wires up filesystem, sqlite, web, github, gmail, …)
+hand-editing `tools.mcp[]` becomes a source of two distinct bugs:
+
+1. **Stale allowlists.** Operator adds a new MCP server but copies
+   the wrong tool names into `allowed_tools`. The server exposes
+   `read_text_file` but the manifest grants `read_file`. Every call
+   denies; the agent's tool catalog has phantom entries.
+2. **Over-grant by copy-paste.** Operator copies an example
+   `allowed_tools` block from another manifest and forgets to trim.
+   The new server is granted tools that don't exist there but exist
+   elsewhere — silently shifting blast radius if a new MCP server is
+   later added with that tool name.
+
+[ADR-024](024-mcp-args-prevalidation.md)'s `pre_validate` mappings
+amplify both bugs because they reference per-tool argument shapes;
+typing them by hand against an MCP server's actual JSON schema is
+error-prone.
+
+The Community UI ([ADR-031](031-community-webui-for-local-collaboration.md))
+already builds and validates manifests. ADR-033 promotes MCP from
+"another manifest field operators hand-edit" to "first-class
+discoverable management surface."
+
+## Decision
+
+**Add an "Integrations" / "Tools" tab to the Community UI that
+catalogs known MCP servers, queries them for their tool list and
+JSON schemas, and lets operators visually toggle `tools.mcp[]`
+allowlist entries with checkboxes. The tab also renders the
+[ADR-024](024-mcp-args-prevalidation.md) `pre_validate` mappings
+inferred from each tool's schema, with operator override.**
+
+### Catalog data shape
+
+Each MCP server entry in the catalog carries:
+
+| Field | Source |
+|---|---|
+| `server_name` | Operator-provided (matches the manifest's `tools.mcp[].server_name`) |
+| `server_uri` | Operator-provided (`stdio:npx -y …`, `https://…`, etc.) |
+| `discovered_tools` | Live `tools/list` MCP RPC against the server |
+| `tool_schemas` | Per-tool JSON schema returned by the server |
+| `pre_validate_inferred` | Mapping derived from each tool's schema (e.g., a tool with `path: string` arg → `kind: filesystem_read, arg: path`) |
+| `allowlist_state` | Set of tool names operator has checked |
+| `last_discovered_at` | Timestamp; refresh button re-runs discovery |
+
+The catalog is **session-scoped state in the UI**, not a manifest
+artifact. Saving to manifest serializes `allowlist_state` +
+`pre_validate` overrides into the YAML.
+
+### Discovery flow
+
+1. **Add server.** Operator clicks "Add MCP Server", fills `name` +
+   `server_uri`, clicks Save.
+2. **Discovery.** UI server runs the existing `crates/mcp-client/`
+   stdio transport against the server, sends `tools/list`. Returns
+   the tool list + schemas. (Re-uses the FastMCP-aware notification
+   handling already in v0.9.0.)
+3. **Render.** UI shows a table per server:
+   ```
+   fs-mcp                                        [ Refresh ] [ Remove ]
+   ┌──────────────────────────────────────────────────────────────┐
+   │ ☑ read_text_file       (path: string)                       │
+   │   pre_validate: filesystem_read, arg=path  [override...]    │
+   │ ☑ read_multiple_files  (paths: array<string>)               │
+   │   pre_validate: filesystem_read, arg_array=paths            │
+   │ ☐ list_directory       (path: string)                       │
+   │ ☐ list_allowed_directories                                  │
+   └──────────────────────────────────────────────────────────────┘
+   ```
+4. **Toggle.** Operator checks/unchecks tools. UI updates
+   `allowlist_state`.
+5. **Save to manifest.** Operator clicks "Apply to manifest". UI
+   serializes the catalog state into `tools.mcp[]` entries on the
+   active manifest, runs `aegis validate`, surfaces any warnings.
+
+### `pre_validate` inference
+
+For each tool the server returns, the UI inspects the JSON schema
+and proposes a [ADR-024](024-mcp-args-prevalidation.md) mapping:
+
+| Schema shape | Inferred clause |
+|---|---|
+| `{ path: string }` | `kind: filesystem_read, arg: path` (or `_write` if tool name matches `^(write_*|delete_*|truncate_*)$`) |
+| `{ paths: string[] }` | `kind: filesystem_read, arg_array: paths` |
+| `{ url: string }` | `kind: network_outbound, arg: url` |
+| `{ command: string, args?: string[] }` | `kind: exec, arg: command` |
+
+The inference is conservative — when in doubt, default to the
+read-shaped clause and surface a warning in the UI ("review this:
+read or write?"). Operators override with a free-form editor.
+[ADR-024](024-mcp-args-prevalidation.md)'s schema is the contract;
+the UI is a generator for it.
+
+### Closed-by-default reinforced
+
+The default state of every checkbox is **unchecked**. Adding a
+server doesn't auto-grant any tool. Operators check the boxes they
+want, manifest serializes only those. This mirrors the runtime's
+posture: discovery does not equal authorization.
+
+The catalog also distinguishes "tools the server exposes" from
+"tools the agent is granted." Operators see the full surface
+(closing the "what tools exist?" knowledge gap that drives copy-
+paste bugs) without granting anything they don't intend.
+
+## Why not the alternatives
+
+- **Auto-grant all tools when a server is added.** Inverts the
+  posture from closed-by-default to open-by-default. Rejected.
+- **Make `pre_validate` discovery the operator's responsibility.**
+  Status quo. Hand-typing schema-derived mappings is a major source
+  of misconfiguration. Inference + override is materially better.
+- **Skip discovery; trust the operator's manual `allowed_tools`
+  list.** What the CLI does today. Works for small numbers of
+  servers; doesn't scale, and the v0.9.0 firecrawl experience
+  showed how easy it is to mis-name tools (`search` vs.
+  `firecrawl_search`).
+- **Centralized MCP server registry.** A future enhancement (the
+  "Integrations marketplace" pattern). Out of scope for v0.9.5;
+  v1.x decision.
+- **Run discovery on every manifest edit.** Wasteful; servers may
+  spawn child processes. Cache discovery per server, refresh on
+  user click.
+
+## Implementation tracking
+
+- UI: `ui/src/pages/Integrations.tsx`, `ui/src/components/McpToolCatalog.tsx`.
+- Backend: `crates/ui-server/src/handlers/mcp.rs` exposes
+  `POST /api/v1/mcp/discover` (runs `tools/list` against a given
+  `server_uri`), `POST /api/v1/manifests/:id/mcp` (serialize catalog
+  state into the manifest).
+- Reuses: `crates/mcp-client/src/lib.rs` (the existing FastMCP-
+  aware client). Schema inference logic lives in
+  `crates/policy/src/mcp_schema_infer.rs` (new, small, pure rust)
+  so the same logic is testable and shared with `aegis validate`
+  warnings.
+- Tracking issue: see v0.9.5 milestone tracker.
+
+## Open questions for follow-up
+
+- **Server health monitoring.** Should the catalog show whether each
+  server is currently reachable / responsive? Useful for
+  troubleshooting, but adds polling load. Lean: opt-in indicator,
+  refresh-on-demand by default.
+- **Schema drift detection.** When a server's tool schema changes
+  between two discovery runs, surface the diff. The previous
+  `pre_validate` mapping may no longer be correct. Lean: warn on
+  refresh; never silently overwrite operator-confirmed mappings.
+- **Sandboxed MCP wrappers.** [ADR-024](024-mcp-args-prevalidation.md)'s
+  rejected alternative (Linux user-namespace + seccomp jail per MCP
+  server) becomes more attractive once operators run dozens of
+  servers. The UI tab would surface "this server runs sandboxed"
+  vs. "this server has full host access." Not v0.9.5; revisit when
+  malicious-MCP threat models become a customer concern.
+
+## References
+
+- [ADR-018](018-adopt-mcp-protocol-for-agent-tool-boundary.md) MCP boundary
+- [ADR-024](024-mcp-args-prevalidation.md) `pre_validate` mappings
+- [ADR-028](028-adversarial-pre-filter-gate.md) post-tool result filtering
+- [ADR-031](031-community-webui-for-local-collaboration.md) Community UI
+- `crates/mcp-client/src/lib.rs` FastMCP-aware client (v0.9.0)

--- a/docs/adrs/034-enterprise-management-dashboard-and-rbac.md
+++ b/docs/adrs/034-enterprise-management-dashboard-and-rbac.md
@@ -1,0 +1,231 @@
+# 34. Enterprise Management Dashboard and RBAC
+
+**Status:** Proposed
+**Date:** 2026-05-05
+**Domain:** Enterprise UI / governance (extends [ADR-016](016-open-core-licensing-model.md), [ADR-031](031-community-webui-for-local-collaboration.md), supports Phase 2.5)
+**Targets:** v2.5.0 Phase 2.5 (release date 2027-03-01)
+
+## Context
+
+The [Community UI (ADR-031)](031-community-webui-for-local-collaboration.md)
+is purposefully scoped to "the operator and the runtime share a
+host." It's the right tool for a developer evaluating Aegis-Node, a
+solo engineer running a personal agent, or a small team
+experimenting with a single workload.
+
+It's the wrong tool for:
+
+- A Fortune-500 security team running 100+ Aegis-Node agents
+  across a Kubernetes cluster.
+- A regulated enterprise that needs to demonstrate to auditors
+  that only "Security Admins" can mutate manifests, while
+  "Operators" can only chat and approve.
+- A managed-services provider running Aegis-Node for multiple
+  customer tenants, with strict cross-tenant isolation.
+- A defense contractor needing automated CMMC 2.0 / FedRAMP
+  evidence packages exported continuously rather than per-session.
+
+The [Open-Core Licensing Model (ADR-016)](016-open-core-licensing-model.md)
+sets the boundary: the community runtime is sufficient to **pass** a
+security review. Commercial tiers add **convenience and
+integration** — multi-tenancy, fleet management, automated
+compliance reporting — not previously-blocked compliance.
+
+Phase 2.5 (v2.5.0) targets these enterprise workflows. Phase 2
+(v2.0.0) ships the [Kubernetes Operator + CRDs](002-split-language-architecture-rust-and-go.md);
+Phase 2.5 ships the management surface that operates on top of them.
+
+## Decision
+
+**Ship an Enterprise Management Dashboard in v2.5.0 under a
+commercial license. It is a multi-tenant, RBAC-enforced, network-
+reachable UI deployed alongside the Kubernetes Operator. It surfaces
+fleet-wide agent state, multi-tenant manifest authoring, SSO/SAML
+identity, and automated compliance report generation. The runtime
+gates that drive security (F1–F10 + ADR-025–030) are the same as
+the community tier — the Enterprise UI does not weaken or replace
+them; it operates them at scale.**
+
+### Surfaces
+
+1. **Multi-tenant fleet dashboard.** A single view showing every
+   Aegis-Node agent across the Kubernetes cluster (or fleet). Per-
+   agent cards show: workload identity (SPIFFE ID), current session
+   state (idle / running / pending-approval), aggregate quota usage,
+   recent F9 ledger violations, last-attestation timestamp. Filters
+   by tenant, namespace, agent class, manifest digest.
+
+2. **RBAC + SSO/SAML.** Roles configurable per organization, with
+   defaults:
+   - **Security Admin** — author + approve manifests, approve all
+     F3 escalations, configure tenant policy. Cannot run agents.
+   - **Operator** — run agents, approve F3 prompts within scope of
+     assigned workloads, view ledger entries. Cannot mutate
+     manifests.
+   - **Auditor** — read-only access to all sessions, ledgers,
+     attestations, compliance exports. Cannot run agents or
+     mutate anything.
+   - **Custom roles** — declared in commercial-tier configuration,
+     enforced at the dashboard's API gateway and at the operator
+     pattern in the Kubernetes Operator (Phase 2).
+   SSO via SAML 2.0 + OIDC. Identity providers: Okta, Azure AD,
+   Google Workspace, Auth0, Keycloak (open-source IdP for
+   air-gapped deployments).
+
+3. **Multi-tenant manifest authoring.** The Visual Manifest Builder
+   from [ADR-031](031-community-webui-for-local-collaboration.md)
+   evolves to support **per-tenant** manifest stores with policy
+   inheritance (tenant policy → workload policy → session policy).
+   Aggregate quotas ([ADR-027](027-aggregate-quota-schema.md)) can
+   be set at the tenant level and inherited; tenants cannot exceed
+   their parent caps.
+
+4. **Live + historical fleet ledger view.** The community UI shows
+   one agent's live trajectory; the Enterprise UI streams from
+   every agent in the fleet, with filtering, search, and saved
+   views. Backed by a tenant-scoped persistent ledger store
+   (Phase 2's [persistent ledger storage](../../RELEASE_PLAN.md)).
+   The cryptographic chain remains the source of truth — the UI is
+   a query surface, not a re-write of the audit data.
+
+5. **Automated compliance report exports.** Continuous evidence-pack
+   generation from the F9 ledger:
+   - **CMMC 2.0 Level 2** — quarterly auditor-ready report mapping
+     observed runtime activity to NIST SP 800-171 controls (the
+     [docs/COMPLIANCE_MATRIX.md](../COMPLIANCE_MATRIX.md) is the
+     mapping; the report is the evidence).
+   - **FedRAMP Moderate / High** — same shape, FedRAMP control
+     family mapping.
+   - **SOC 2 Type II** — control-objective coverage from the
+     ledger's access entries + approval decisions.
+   - **EU AI Act high-risk system** — assessment artifact bundle
+     for high-risk classification AI systems.
+   Reports are signed by the runtime's identity and exported as
+   PDF + JSON-LD.
+
+### Architecture
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│  Enterprise Management Dashboard (multi-tenant)              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │  React SPA + TypeScript + Tailwind                      │ │
+│  │  - Fleet dashboard / RBAC / manifests / reports         │ │
+│  └─────────┬───────────────────────────────────────────────┘  │
+│            │ HTTPS + SAML/OIDC session                        │
+└────────────┼──────────────────────────────────────────────────┘
+             │
+┌────────────▼──────────────────────────────────────────────────┐
+│  aegis-mgmt API (commercial-tier)                             │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ - Auth / RBAC enforcement (every request)              │  │
+│  │ - Tenant routing / isolation                           │  │
+│  │ - Persistent ledger query API (read-only)              │  │
+│  │ - Manifest authoring API (writes through Operator)     │  │
+│  │ - Report generator (cron + on-demand)                  │  │
+│  └────────────────┬───────────────────────────────────────┘  │
+└───────────────────┼───────────────────────────────────────────┘
+                    │ Kubernetes API
+┌───────────────────▼───────────────────────────────────────────┐
+│  Aegis-Node Kubernetes Operator (Phase 2 / v2.0.0)            │
+│  ┌────────────────┐  ┌────────────────────┐  ┌────────────┐  │
+│  │ AegisAgent CRD │  │ PermissionManifest │  │ Ledger CRD │  │
+│  │                │  │ CRD                │  │            │  │
+│  └────────────────┘  └────────────────────┘  └────────────┘  │
+└───────────────────────────────────────────────────────────────┘
+```
+
+The dashboard is layered **on top of** the Phase 2 Kubernetes
+Operator. The Operator is the source of truth; the dashboard is a
+governance + observability surface.
+
+### Non-replacement of community runtime
+
+The runtime gates that pass a security review remain the
+community-tier F1–F10 + ADR-025–030 implementations. The Enterprise
+UI does not provide a parallel enforcement path. An auditor
+inspecting the runtime sees:
+
+- The same `aegis verify` chain validation.
+- The same hash-chained F9 ledger.
+- The same per-turn SVID rebinding (ADR-030).
+- The same aggregate quota enforcement (ADR-027).
+
+What's commercial:
+- Reading those primitives at fleet scale (cross-agent dashboard).
+- Managing those primitives across tenants (RBAC).
+- Continuously publishing those primitives as auditor evidence
+  (compliance exports).
+
+A customer who churns from the commercial tier still has every
+audit and security property they had on the commercial tier — the
+data lives in the F9 ledger, the Operator's CRDs, and the
+manifests, all open formats. They lose the ergonomics and the
+report generation, not the runtime guarantees.
+
+## Why not the alternatives
+
+- **Single-tenant Enterprise UI.** Doesn't solve the actual
+  enterprise problem (multi-team / multi-customer governance).
+  Customers running Aegis-Node for one team can stay on the
+  Community UI.
+- **Open-source Enterprise UI.** Conflicts with the Open-Core
+  model ([ADR-016](016-open-core-licensing-model.md)) — the
+  commercial tier's economic moat is the Day-2 ops UX. Free fleet
+  management would re-invest engineering time without funding it.
+- **Bolt RBAC onto the Community UI.** Would muddy the threat model
+  ("localhost-only single-user" is load-bearing simplicity) and
+  expand the open-source maintenance surface in a way that
+  commercial customers won't fund. Two distinct UIs at distinct
+  threat models is cleaner.
+- **Build on Grafana / Datadog / general-purpose dashboarding.**
+  Plausible for a thin observability layer, but compliance report
+  generation is Aegis-Node-specific (the ledger schema, the F-feature
+  mapping). Generic dashboards can't generate signed
+  CMMC/FedRAMP evidence packs without bespoke Aegis-Node logic.
+  The Enterprise UI ships that logic.
+- **Defer compliance reporting; ship dashboard-only first.** Removes
+  the load-bearing commercial differentiator. Reports are the
+  highest-margin feature; shipping dashboard without them
+  underprices the tier.
+
+## Implementation tracking
+
+- New crate `crates/aegis-mgmt-api/` (commercial license; lives in
+  the Aegis-Node Enterprise repository, not the open-source
+  monorepo).
+- New SPA `enterprise-ui/` (commercial license; same separation).
+- Reuses: Kubernetes Operator (Phase 2), the F9 ledger format
+  (ADR-026), the SPIFFE identity model (ADR-003 + ADR-030), the
+  policy schema (ADR-004 + ADR-027).
+- Tracking: v2.5.0 milestone in RELEASE_PLAN.md. Issues live in
+  the Enterprise repository (private).
+
+## Open questions for follow-up
+
+- **Air-gapped deployments.** Customers in classified environments
+  cannot use Okta / Azure AD. Keycloak as the bundled IdP for
+  air-gapped tier. Manifest authoring and reports must work fully
+  offline.
+- **Pricing / packaging.** Commercial decision, out of scope for
+  this ADR. The Open-Core model ([ADR-016](016-open-core-licensing-model.md))
+  sets the philosophical boundary; the SKU shape is for the
+  business team.
+- **Cross-tenant policy floor.** A managed-services provider may
+  want to enforce a cross-tenant minimum (e.g., "all tenants must
+  have F6 network deny-by-default"). Implementable as a
+  dashboard-level admission webhook against the Kubernetes
+  Operator. v2.6.x scope.
+- **Compliance frameworks beyond CMMC / FedRAMP / SOC 2 / EU AI
+  Act.** ISO 27001, HIPAA, PCI-DSS — added per customer demand
+  rather than upfront. Each is a mapping pass over the existing
+  ledger schema; mechanism is reusable.
+
+## References
+
+- [ADR-016](016-open-core-licensing-model.md) Open-core licensing
+- [ADR-031](031-community-webui-for-local-collaboration.md) Community UI
+- [docs/COMPLIANCE_MATRIX.md](../COMPLIANCE_MATRIX.md) Compliance mapping
+- [RELEASE_PLAN.md](../../RELEASE_PLAN.md) Phase 2 + 2.5 + 3
+- HashiCorp Vault Enterprise (open-core reference)
+- GitLab Premium / Ultimate (open-core reference)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -38,6 +38,10 @@ The decisions are anchored in the Architecture Principles (PRD §7) and the ten-
 | [028](028-adversarial-pre-filter-gate.md) | Adversarial Pre-Filter Gate for Inbound Tool Results | §4 F2 |
 | [029](029-task-scoped-ephemeral-approval-grants.md) | Task-Scoped Ephemeral Approval Grants (F3 Evolution) | §4 F3 |
 | [030](030-per-turn-spiffe-mtls-attestation.md) | Per-Turn SPIFFE / mTLS Workload Attestation | §4 F1 |
+| [031](031-community-webui-for-local-collaboration.md) | Community WebUI for Local Collaboration | §1, §7 (#1) |
+| [032](032-webui-model-library-and-session-forking.md) | WebUI Model Library and Session Forking | §6.1 |
+| [033](033-webui-visual-mcp-server-management.md) | WebUI Visual MCP Server Management | §4 F2 |
+| [034](034-enterprise-management-dashboard-and-rbac.md) | Enterprise Management Dashboard and RBAC | §9.1 (open-core) |
 
 ADRs 025–030 form a coherent set: the Phase 1 GA (v1.0.0)
 multi-turn agent loop architecture with per-turn enforcement.
@@ -49,6 +53,16 @@ human-factors realities; ADR-030 binds workload identity to each
 turn's content. See the research input at
 [docs/research/multi-turn-agent-loop.md](../research/multi-turn-agent-loop.md)
 and the compliance mapping at [docs/COMPLIANCE_MATRIX.md](../COMPLIANCE_MATRIX.md).
+
+ADRs 031–033 are the Community WebUI set targeting v0.9.5 (Phase 1d):
+ADR-031 ships the localhost UI with chat / live trajectory / inline
+F3 approvals / visual manifest builder under Apache-2.0; ADR-032 wraps
+`aegis pull` as a visual Model Library and implements Session Forking
+so model swaps don't break F1 binding; ADR-033 promotes MCP servers to
+a discoverable catalog with checkbox-toggled allowlists. ADR-034 is
+the v2.5.0 commercial-licensed Enterprise Management Dashboard
+(multi-tenant fleet, RBAC + SSO, automated compliance reports) — same
+runtime gates as the community tier, fleet-scale operations on top.
 
 ## Decision Coverage Matrix
 


### PR DESCRIPTION
## Summary

Adds four Web UI ADRs and lands the v0.9.5 (Community UI) + v2.5.0 (Enterprise UI) milestones in RELEASE_PLAN.md and TODO.md.

**ADR numbering renumbered from the user's draft (025-028) to 031-034** to avoid the collision with PR #132's multi-turn architecture set.

## ADRs added

| ADR | Title | Phase / target |
|---|---|---|
| [031](https://github.com/tosin2013/aegis-node/blob/feat/v0.9.5-and-v2.5.0-webui-adrs/docs/adrs/031-community-webui-for-local-collaboration.md) | Community WebUI for Local Collaboration | Phase 1d / v0.9.5 |
| [032](https://github.com/tosin2013/aegis-node/blob/feat/v0.9.5-and-v2.5.0-webui-adrs/docs/adrs/032-webui-model-library-and-session-forking.md) | WebUI Model Library and Session Forking | Phase 1d / v0.9.5 |
| [033](https://github.com/tosin2013/aegis-node/blob/feat/v0.9.5-and-v2.5.0-webui-adrs/docs/adrs/033-webui-visual-mcp-server-management.md) | WebUI Visual MCP Server Management | Phase 1d / v0.9.5 |
| [034](https://github.com/tosin2013/aegis-node/blob/feat/v0.9.5-and-v2.5.0-webui-adrs/docs/adrs/034-enterprise-management-dashboard-and-rbac.md) | Enterprise Management Dashboard and RBAC | Phase 2.5 / v2.5.0 |

## Key design decisions

**Community UI (v0.9.5, Apache-2.0):**
- Localhost-only at the binding level (not just config). Single user, single agent.
- Static SPA bundled into the \`aegis\` binary — one trust boundary, one supply chain (existing OCI + cosign chain).
- Model loads exclusively via OCI ref (visual wrapper around \`aegis pull\`); no file upload buttons.
- Model switches via Session Forking (end → boot → replay chat history) — preserves F1 binding integrity.
- MCP servers promoted to discoverable catalog with checkbox-toggled \`tools.mcp[]\` allowlists. Closed-by-default: adding a server doesn't grant any tools.
- \`pre_validate\` mappings (ADR-024) inferred from tool JSON schemas with operator override.

**Enterprise UI (v2.5.0, commercial license per ADR-016):**
- Multi-tenant fleet dashboard on top of the Phase 2 Kubernetes Operator.
- RBAC + SSO/SAML — defaults Security Admin / Operator / Auditor; custom roles supported. Air-gapped tier uses Keycloak.
- Same runtime gates as community tier — F1-F10 + ADR-025-030 unchanged. Commercial value is fleet-scale operations + automated compliance exports, not policy primitives.
- Compliance report generation: CMMC 2.0 Level 2 / FedRAMP / SOC 2 Type II / EU AI Act. Continuous + on-demand, signed.

## RELEASE_PLAN.md / TODO.md updates

- v0.9.5 inserted between v0.9.0 (just shipped) and v1.0.0 GA (CMMC anchor 2026-11-02). Phase 1d.
- v2.5.0 inserted between v2.0.0 (Kubernetes runtime) and v3.0.0 (OpenShift). Phase 2.5.
- v1.0.0 card updated — Web UI is polish-on-top-of-v0.9.5, not a separate deliverable.
- TODO.md gains Phase 1d (12 tasks) + Phase 2.5 (6 tasks). Phase 1 GA section now lists the multi-turn implementation tasks explicitly (ADR-025-030).

## Dependency note

This PR depends on **PR #132** (multi-turn ADRs 025-030) for the ADR numbering not to collide. Branch is \`feat/v1.0.0-multi-turn-adrs\`; merge order should be #132 then this.

## Out of scope

- Implementation work (each ADR has an "Implementation tracking" section pointing at v0.9.5 / v2.5.0 milestone issues — followup PR opens those issues).
- SPA scaffolding code (separate PR opens \`crates/ui-server/\` + \`ui/\`).
- Pricing / SKU shape for the Enterprise tier (business decision, not architectural).

🤖 Generated with [Claude Code](https://claude.com/claude-code)