### PR TITLE
docs(adrs, plan): lock v0.9.5 UI stack + Phase 1d implementation plan

### DIFF
--- a/docs/adrs/031-community-webui-for-local-collaboration.md
+++ b/docs/adrs/031-community-webui-for-local-collaboration.md
@@ -1,7 +1,7 @@
 # 31. Community WebUI for Local Collaboration
 
 **Status:** Proposed
-**Date:** 2026-05-05
+**Date:** 2026-05-05 (amended 2026-05-06 — locked UI stack + wow-factor surface inventory)
 **Domain:** UI / runtime (extends [ADR-005](005-human-approval-gate-for-sensitive-actions.md), [ADR-007](007-pre-execution-reasoning-trajectory.md), [ADR-010](010-deterministic-trajectory-replay-offline-viewer.md), [ADR-016](016-open-core-licensing-model.md), [ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md))
 **Targets:** v0.9.5 Phase 1d (release date 2026-10-20)
 
@@ -55,11 +55,55 @@ network egress.**
 
 ### Surfaces
 
+The four core surfaces below ship in v0.9.5. Each one carries a
+"wow-factor" inventory of capabilities that distinguish Aegis-Node's
+UI from generic LLM-chat front-ends — these are properties only this
+runtime can deliver because they're anchored to the F1–F10 controls.
+
 1. **Context-aware chat.** Multi-turn conversation against a single
    agent. Each user message becomes a fresh `Session::run_turn`
    prompt; the chat history is the prompt context. Bounded by the
    manifest's `inference.*` and `--max-turns` ([ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md))
    exactly as the CLI is.
+
+   *Wow-factor capabilities:*
+   - **Verifiable badge per assistant turn** — small shield icon
+     beside each message; click opens the [F9](011-hash-chained-tamper-evident-ledger.md)
+     ledger entry with hash-chain visualization. No other open chat
+     UI cryptographically anchors messages.
+   - **Inline tool-call cards** rendering the gate decision per call:
+     manifest allowlist hit, [ADR-024](024-mcp-args-prevalidation.md)
+     `pre_validate` outcome, [F7](009-read-only-default-with-explicit-write-grants.md)
+     write-grant scope, [F6](008-network-deny-by-default-at-runtime-level.md)
+     network policy. Expand to see args + result; the result hash is
+     visible.
+   - **Live circuit breaker bar** — three thin gauges (turns / tokens
+     / wallclock) that drain in real time per [ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md).
+     A gauge hitting its cap pulses red and surfaces the partial-
+     ledger preservation message.
+   - **Indirect-prompt-injection banner** — when [ADR-028](028-adversarial-pre-filter-gate.md)'s
+     pre-filter sanitizes a tool result, a yellow `<aegis-system-warning>`
+     banner appears on that tool card. Click to inspect what was
+     filtered. This is something no commercial chat UI exposes.
+   - **Per-turn collapsible blocks** — multi-turn loops fold into
+     "Turn N of M" sections following [ADR-026](026-hierarchical-per-turn-ledger-protocol.md)'s
+     hierarchical schema. Hover any turn to highlight its node in
+     the trajectory side-panel.
+   - **Streaming reasoning trace** — [F5](007-pre-execution-reasoning-trajectory.md)
+     `toolsConsidered → toolSelected` renders as a thin "thinking"
+     strip *above* the tool call as it streams. Auditable provenance,
+     animated.
+   - **Citation chips on assistant text** — every claim links back to
+     the file path / MCP source it came from, click-to-verify
+     against the [F4](006-structured-access-log-jsonld-siem-format.md)
+     access entry.
+   - **Slash-command palette** — `/pause` (manually trip the circuit
+     breaker), `/approve <id>`, `/escalate`, `/replay`,
+     `/manifest`. Discoverable via `/`, keyboard-first.
+   - **Real stop button.** Pressing it triggers the circuit breaker
+     cleanly; the partial F9 ledger is preserved per [ADR-025](025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md).
+   - **Side-by-side trajectory mode.** Toggle splits the view: chat
+     left, animated DAG right, scroll-locked. README screenshot.
 
 2. **Live trajectory streaming.** As the agent runs, F5
    reasoning entries and F4 access entries stream into the chat
@@ -67,6 +111,26 @@ network egress.**
    fallback) feed of new ledger entries, rendered inline in the
    conversation. Each entry is the same JSON-LD that lands in the
    ledger — UI is a real-time view of the same source-of-truth.
+
+   *Wow-factor capabilities:*
+   - **Animated trajectory DAG** — turns light up left-to-right as
+     they execute; tool nodes pulse green on success, red on
+     [F2](004-declarative-yaml-permission-manifest.md) violation,
+     yellow on [ADR-027](027-aggregate-quota-schema.md) quota
+     warning. cmd+click any node to open the F9 ledger entry.
+   - **Replay scrub** — the same DAG drives the offline replay viewer
+     ([ADR-010](010-deterministic-trajectory-replay-offline-viewer.md)),
+     so a finished session can be replayed turn-by-turn with a
+     timeline scrubber.
+   - **Hierarchical fold/unfold** per [ADR-026](026-hierarchical-per-turn-ledger-protocol.md)
+     turn brackets — collapse a turn to a single node, expand to
+     see its tool_call/tool_result children.
+   - **Tampering visualization** — if [F9](011-hash-chained-tamper-evident-ledger.md)
+     verify detects a chain break, the affected nodes go grey with
+     a broken-link icon and the verify CLI's diagnostic text.
+   - **Quota meters** — sidebar shows live `tools.<class>.quota`
+     consumption per [ADR-027](027-aggregate-quota-schema.md).
+     Approaching a cap triggers a soft warning before the hard stop.
 
 3. **Inline F3 approvals.** When the agent hits an approval gate (per
    [ADR-005](005-human-approval-gate-for-sensitive-actions.md) and
@@ -79,6 +143,22 @@ network egress.**
    the same `approval_decision` ledger entry the CLI writes — the
    UI is a channel, not a different policy.
 
+   *Wow-factor capabilities:*
+   - **Inline cards, not modal dialogs** — slides into the
+     conversation thread without breaking flow.
+   - **Args diff vs. baseline** — when a tool was previously
+     approved with similar args, the card shows a side-by-side
+     diff so the operator sees exactly what changed.
+   - **Tier-aware UX** — advisory cards are dismissible warnings;
+     blocking cards halt the turn until decided; escalating cards
+     surface the [ADR-029](029-task-scoped-ephemeral-approval-grants.md)
+     async-approver flow with pause/resume.
+   - **TTL countdown** — task-scoped approval grants display their
+     remaining lifetime; the `sha256(canonical_args)` binding is
+     visible on hover.
+   - **Keyboard-first** — `a` approve, `d` deny, `e` escalate.
+     Cards are screen-reader accessible (WCAG 2.1 AA).
+
 4. **Visual manifest builder.** Form-driven editor for the F2
    manifest. As the operator edits, the in-process F10
    `aegis validate` ([ADR-012](012-policy-as-code-validation.md))
@@ -88,6 +168,22 @@ network egress.**
    network outbound, etc. Output is the same YAML that lands on disk;
    "Save" writes the file the CLI would consume. Hand-edit and
    builder coexist — operators can switch back to text at any time.
+
+   *Wow-factor capabilities:*
+   - **Monaco editor with red/green inline diagnostics** — type a
+     wildcard glob too broad and the line lights up red with the
+     same wording `aegis validate` would emit.
+   - **Schema-aware autocomplete** — manifest field names, allowed
+     values for enum-like fields (channels, tier names), valid
+     ISO 8601 durations for [F7](009-read-only-default-with-explicit-write-grants.md)
+     write_grants.
+   - **Form ↔ YAML round-trip** — toggle between the form view and
+     raw YAML preserves comments and key order; no lossy
+     reformatting.
+   - **Dry-run runner** — "Run validate" button executes
+     [ADR-012](012-policy-as-code-validation.md) on the current
+     buffer, displays the report inline, and links specific
+     warnings back to the offending line.
 
 ### Architecture
 
@@ -130,6 +226,71 @@ network egress.**
 - **WebSocket + HTTP REST.** WS for live trajectory + approval
   prompts; HTTP for session lifecycle (`POST /api/v1/sessions`,
   `GET /api/v1/manifests/:id`, etc.). All endpoints serve JSON.
+
+### UI stack and bundle pipeline
+
+The SPA is locked to a specific stack so contributors don't relitigate
+choices PR-by-PR:
+
+| Concern | Choice | Why |
+|---|---|---|
+| Framework | **React 19 + Vite 6 + TypeScript** | Largest mindshare in 2026 dev-tool front-ends; Vite gives instant HMR for dev and a small static-bundle output for embed. |
+| Styling | **Tailwind CSS + shadcn/ui** (Radix primitives) | shadcn is the de facto modern dev-tool aesthetic (Vercel, Resend, Trigger.dev, OpenStatus). Components are *copied* into the repo, no NPM dep on a UI lib, no surprise upgrades. |
+| Chat foundation | **assistant-ui** (MIT, shadcn-based, Vercel AI SDK underneath) | Open-source streaming chat primitive; gives us threads, tool-call rendering, stop/regenerate without writing a chat engine. We extend its primitives with the verifiable-badge / approval-card / circuit-breaker layers. |
+| Trajectory DAG | **xyflow/react** (formerly React Flow, MIT) | Best-in-class node graph in React; powers Inngest and Trigger.dev trace UIs. Lets us animate per-turn nodes lighting up as the agent executes. |
+| Manifest editor | **Monaco** (the VS Code editor, MIT) | YAML editing with inline diagnostics surfaced from `aegis validate`. Operators get an IDE-grade editor for the manifest. |
+| Command palette | **cmdk** (Radix-related, MIT) | Raycast/Linear-style cmd+k surface for slash commands and navigation. |
+| Toasts | **Sonner** (MIT) | Minimal, animated, shadcn-aligned. |
+| Icons | **lucide-react** (ISC) | Consistent set; matches shadcn out of the box. |
+| Time formatting | **date-fns** (MIT) | Tree-shakeable; small bundle. |
+| Data fetching | **TanStack Query** (MIT) | Standard for SSE/WebSocket-backed React. |
+
+**Aesthetic baseline:** dark-mode-first, monospace accents on
+identifiers (workload IDs, hashes, OCI digests). The visual language
+matches the runtime's zero-trust positioning rather than fighting it.
+WCAG 2.1 AA contrast is the floor for both light and dark themes.
+
+**Bundle pipeline:**
+
+```text
+ui/                              ui-server build invokes:
+├─ src/                          1. pnpm install (cached by lockfile)
+├─ index.html                    2. pnpm build → ui/dist/
+├─ vite.config.ts                3. cargo build then embeds ui/dist
+├─ package.json                     via rust-embed into the binary
+└─ pnpm-lock.yaml                4. axum tower-http ServeEmbed serves
+                                    the embedded files at /
+crates/ui-server/
+├─ build.rs                      Calls (1)+(2) when ui/dist is missing
+│                                or stale (compares ui/src mtimes).
+├─ src/
+│  ├─ lib.rs                     axum::Router with REST + WS routes
+│  ├─ embed.rs                   #[derive(rust_embed::Embed)] handle
+│  ├─ handlers/{sessions,
+│  │  manifests,models,mcp}.rs   feature-scoped handlers
+│  └─ ws.rs                      WebSocket upgrade for /api/v1/stream
+└─ Cargo.toml                    rust-embed, axum, tower-http
+```
+
+The `build.rs` is best-effort: if `ui/dist/` already exists (e.g., a
+contributor built the SPA themselves or a release artifact ships
+pre-built), the build script does *not* invoke pnpm. CI builds the
+SPA explicitly in a UI-build job and caches `ui/dist/` for the cargo
+build, mirroring how the existing Rust workflows cache `target/`.
+
+**Why not a build-step-free approach (HTMX, raw JS):** the multi-turn
+trajectory DAG, the live-streaming chat, and the Monaco-driven
+manifest editor all need real component state. HTMX + a couple
+hundred lines of vanilla JS could do the manifest builder, but the
+chat + DAG would be substantially harder to make feel polished. The
+build-step cost is paid once at release time; operators install one
+signed binary.
+
+**Why not Svelte / Solid:** smaller bundles (~40 KB vs. ~150 KB
+gzipped) but the React + shadcn ecosystem is what most front-end
+contributors recognize on sight. Bundle size is well within "single
+static binary" comfort. If bundle pressure becomes real (Phase 2.5
+Enterprise UI ships a much larger app), revisit at that point.
 
 ### Implementation phasing
 
@@ -174,15 +335,19 @@ Plus two adjacent capabilities ship as their own ADRs:
 
 - New crate `crates/ui-server/` (axum routes, WS upgrades, manifest
   builder backend that wraps `crates/policy/` validate functions).
-- New static SPA at `ui/` (Vite + React + TypeScript). Build output
-  bundled into the CLI binary at compile time.
+  `build.rs` invokes `pnpm build` in `ui/` when `ui/dist/` is absent
+  or stale; `rust-embed` bakes the dist output into the binary.
+- New static SPA at `ui/` per the locked stack above (React 19 +
+  Vite 6 + TypeScript + Tailwind + shadcn/ui + assistant-ui +
+  xyflow + Monaco + cmdk + Sonner + lucide + TanStack Query).
 - Extend `crates/cli/src/run.rs` with `--ui --listen <addr:port>`
   flags. Default listen address `127.0.0.1:7777`.
 - Reuse: `crates/ledger-writer/` reader API for the live trajectory
   feed; `crates/approval-gate/src/channels/web.rs` (existing) for the
   in-chat approval channel; `crates/policy/src/validate.rs` for the
   builder's live linting.
-- Tracking issue: see v0.9.5 milestone tracker.
+- Phase 1d implementation plan: [docs/plans/v0.9.5-ui-implementation.md](../plans/v0.9.5-ui-implementation.md).
+- Tracking issue: [#135](https://github.com/tosin2013/aegis-node/issues/135).
 
 ## Open questions for follow-up
 

--- a/docs/plans/v0.9.5-ui-implementation.md
+++ b/docs/plans/v0.9.5-ui-implementation.md
@@ -1,0 +1,327 @@
+# Plan: v0.9.5 Community UI Implementation (Phase 1d)
+
+**Status:** Proposed · 2026-05-06
+**Targets:** [v0.9.5 milestone](../../RELEASE_PLAN.md#v095--community-ui) (due 2026-10-20)
+**Owners:** project maintainers
+**Tracking issue:** [#135](https://github.com/tosin2013/aegis-node/issues/135)
+**ADRs:** [031](../adrs/031-community-webui-for-local-collaboration.md), [032](../adrs/032-webui-model-library-and-session-forking.md), [033](../adrs/033-webui-visual-mcp-server-management.md)
+
+## Context
+
+[ADR-031](../adrs/031-community-webui-for-local-collaboration.md)
+amended on 2026-05-06 locks the UI stack (React + Vite + shadcn/ui +
+Tailwind + assistant-ui + xyflow + Monaco) and the bundle pipeline
+(rust-embed → tower-http ServeDir, build.rs invoking pnpm). What
+remains is the engineering sequencing.
+
+Three observations drive the sub-phasing:
+
+1. **The trajectory viewer depends on [ADR-026](../adrs/026-hierarchical-per-turn-ledger-protocol.md)
+   ledger schema v2.** Single-pass v1 ledger has one `reasoning_step`
+   per session; v2 adds `turn_start` / `turn_end` / per-tool-call
+   entries. Building the DAG against v1 means rewriting it when v2
+   lands. Either v2 ships first or the viewer ships last.
+2. **Two surfaces have no ledger dependency at all:** the Model
+   Library ([ADR-032](../adrs/032-webui-model-library-and-session-forking.md))
+   wraps `aegis pull`, and the Visual Manifest Builder ([ADR-031](../adrs/031-community-webui-for-local-collaboration.md)
+   surface 4) wraps `aegis validate`. These can be built immediately,
+   in parallel with the ledger v2 spec work.
+3. **CMMC deadline is 2026-11-02** — v0.9.5 (2026-10-20) is 13 days
+   before that, and v1.0.0 multi-turn engine work also has to land.
+   This plan must not crowd out engine engineering. The ledger v2
+   schema spec is shared between v0.9.5 (UI consumes it) and v1.0.0
+   (engine emits it), so locking that spec early de-risks both.
+
+## Approach
+
+The implementation splits into three sub-phases with explicit gates
+between them.
+
+### Sub-phase 1d.0 — Schema and scaffolding (parallel, no UI work yet)
+
+Two streams run in parallel:
+
+**Stream A — Ledger v2 schema spec:** ADR-026 is the design; this
+stream produces the concrete JSON Schema document plus a Rust
+`ledger-v2` crate that defines the types. Engine emits no v2 entries
+yet — only the schema is locked. Output: `crates/ledger-v2/`,
+`docs/schemas/ledger-v2.schema.json`, conformance test cases.
+
+**Stream B — `crates/ui-server/` skeleton:** axum router with
+`/healthz`, the `rust-embed` plumbing, the `build.rs` that invokes
+`pnpm build` when `ui/dist/` is absent, and a placeholder `ui/` SPA
+that renders "Aegis-Node" + the runtime version. Listens on
+`127.0.0.1:7777` per ADR-031. CLI gains `aegis run --ui` flag that
+routes through the new server. No real UI yet — this is just proving
+the bundle pipeline ships a working binary.
+
+**Gate to 1d.1:** `cargo build --release && ./target/release/aegis
+run --ui` opens a browser tab on port 7777 showing the placeholder.
+Ledger v2 schema lands in a merged PR; the engine still emits v1.
+
+### Sub-phase 1d.1 — Surfaces with no ledger dependency
+
+Build the two surfaces that don't need the ledger:
+
+1. **Visual Manifest Builder** — Monaco editor + form view +
+   `aegis validate` integration via `POST /api/v1/manifests/validate`.
+   Form covers `tools.{filesystem,network,mcp,exec}`; quota schema
+   ([ADR-027](../adrs/027-aggregate-quota-schema.md)) and tier picker
+   ([ADR-029](../adrs/029-task-scoped-ephemeral-approval-grants.md))
+   are v1.0.0 polish per ADR-031's phasing table.
+2. **Model Library** — visual `aegis pull` per [ADR-032](../adrs/032-webui-model-library-and-session-forking.md).
+   Streaming progress over WebSocket, cosign verification result
+   surfaced explicitly, no file-upload affordance. Reuses
+   `crates/cli/src/pull.rs` exactly.
+
+Also lay down the design system: shadcn primitives copied into
+`ui/src/components/ui/`, dark theme, Tailwind config, lucide icon
+set, Sonner toaster, cmdk command palette (with the slash commands
+stubbed but no-op until 1d.2).
+
+**Gate to 1d.2:** an operator can compose a manifest from scratch in
+the UI, save it, run `aegis run` against it from the CLI, and
+successfully execute a tool call. Model Library can pull and verify
+a model. No chat surface yet.
+
+### Sub-phase 1d.2 — Chat foundation against single-pass engine
+
+Wire up the chat surface using assistant-ui + Vercel AI SDK
+streaming. The engine in this sub-phase is still single-pass
+([Session::run_turn](../adrs/025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md)
+without the loop), so the UI exercises one turn at a time but with
+the full chat history as prompt context (matching today's CLI).
+
+What ships:
+
+- Context-aware chat thread (assistant-ui), one prompt → one
+  assistant response with tool calls
+- **Inline tool-call cards** rendering the gate decision per call —
+  this is the first wow-factor surface and works even on single-pass
+- **Verifiable badge per turn** linking to the F9 ledger entry —
+  works on v1 ledger
+- **Citation chips** linking back to file paths / MCP sources read
+- **Real stop button** (sends SIGINT-equivalent to the engine; engine
+  preserves partial v1 ledger)
+- Slash commands `/manifest`, `/replay` that navigate to the other
+  surfaces; `/pause`, `/approve`, `/escalate` are stubbed and emit
+  "available in v1.0.0 multi-turn" toast
+
+Visual Mcp Server Management ([ADR-033](../adrs/033-webui-visual-mcp-server-management.md))
+ships in this sub-phase too — the discovery flow + checkbox catalog
+have no multi-turn dependency.
+
+**Gate to 1d.3:** an operator can have a two-message chat where the
+agent reads a file and answers a question; the verifiable badge
+opens the F9 entry; the tool-call card shows the manifest decision.
+MCP Catalog discovers a server's tools and saves them into a
+manifest.
+
+### Sub-phase 1d.3 — Live trajectory + approvals + circuit breaker
+
+This is the surface that most needs ledger v2. Sub-phase 1d.0 locked
+the schema; here we ship the consumers. The engine **may** still be
+single-pass at v0.9.5 release (multi-turn is v1.0.0 scope), in which
+case the trajectory renders one-turn-deep but the *components*
+correctly handle multi-turn structure when the engine catches up.
+
+What ships:
+
+- **Animated trajectory DAG** (xyflow) consuming v2 ledger entries
+  over WebSocket. Renders one node per turn even when N=1.
+- **Live circuit breaker bar** — three gauges. On single-pass, only
+  the wallclock + token gauges drain; the turn gauge is fixed at
+  1/1. Multi-turn (v1.0.0) lights up the third gauge.
+- **Inline F3 approval cards** with tier-aware UX, args diff vs.
+  baseline, and TTL countdown when [ADR-029](../adrs/029-task-scoped-ephemeral-approval-grants.md)
+  grants land in v1.0.0. v0.9.5 ships the card UI; v1.0.0 wires the
+  TTL semantics.
+- **Indirect-prompt-injection banner** when [ADR-028](../adrs/028-adversarial-pre-filter-gate.md)
+  pre-filter sanitizes a tool result. v0.9.5 may render the banner
+  even though the pre-filter itself is v1.0.0 scope — the UI is
+  ready when the engine catches up.
+- **Side-by-side trajectory toggle** — the README screenshot.
+
+**Gate to v0.9.5 release:** an end-to-end demo recording showing the
+chat surface, an inline tool call, the verifiable badge opening F9,
+the trajectory DAG rendering live, and the manifest builder catching
+an over-broad path. All on the same single-pass engine that shipped
+in v0.9.0.
+
+## Critical files
+
+```
+crates/ui-server/                            # NEW — axum + rust-embed
+├─ Cargo.toml                                #   axum, tower-http, rust-embed,
+│                                            #   tokio, serde_json
+├─ build.rs                                  #   invokes pnpm build when ui/dist
+│                                            #   is absent or stale
+├─ src/lib.rs                                #   Router with REST + WS routes
+├─ src/embed.rs                              #   rust_embed::Embed handle on ui/dist
+├─ src/handlers/sessions.rs                  #   chat / run_turn integration
+├─ src/handlers/manifests.rs                 #   validate + form ↔ YAML round-trip
+├─ src/handlers/models.rs                    #   wraps crates/cli/src/pull.rs
+├─ src/handlers/mcp.rs                       #   tools/list discovery + serialize
+└─ src/ws.rs                                 #   /api/v1/stream WebSocket upgrade
+
+crates/ledger-v2/                            # NEW — schema + Rust types for ADR-026
+├─ Cargo.toml
+├─ src/lib.rs                                #   TurnStart, TurnEnd, ToolCall,
+│                                            #   ToolResult, ApprovalDecision
+└─ tests/conformance.rs                      #   round-trips schema fixtures
+
+docs/schemas/ledger-v2.schema.json           # NEW — JSON Schema for ledger v2
+
+ui/                                          # NEW — Vite + React SPA
+├─ package.json                              #   pnpm workspace root for the SPA
+├─ pnpm-lock.yaml
+├─ vite.config.ts
+├─ index.html
+├─ tailwind.config.ts
+├─ src/main.tsx
+├─ src/app.tsx
+├─ src/components/ui/*                       #   shadcn primitives copied in
+├─ src/components/Chat/*                     #   assistant-ui extensions:
+│                                            #     - VerifiableBadge.tsx
+│                                            #     - ToolCallCard.tsx
+│                                            #     - CircuitBreakerBar.tsx
+│                                            #     - ApprovalCard.tsx
+│                                            #     - InjectionBanner.tsx
+│                                            #     - CitationChip.tsx
+├─ src/components/Trajectory/*               #   xyflow DAG + replay scrub
+├─ src/components/Manifest/*                 #   Monaco editor + form view
+├─ src/components/Models/*                   #   Model Library
+├─ src/components/Mcp/*                      #   MCP Catalog
+├─ src/components/Palette/*                  #   cmdk command palette
+└─ src/lib/api.ts                            #   TanStack Query hooks against
+                                              #   /api/v1/*
+
+crates/cli/src/run.rs                        # MODIFY — add --ui --listen flags
+crates/cli/Cargo.toml                        # MODIFY — depend on ui-server crate
+
+.github/workflows/rust.yml                   # MODIFY — add ui-build job that
+                                              #   runs `pnpm install && pnpm build`,
+                                              #   caches ui/dist for cargo build
+```
+
+## Reuse (existing precedents)
+
+- **`crates/cli/src/pull.rs`** — Model Library wraps this exactly.
+  Streams progress over WebSocket; no new auth / verification logic.
+- **`crates/policy/src/validate.rs`** — manifest builder calls this
+  on every keystroke (debounced) for live diagnostics.
+- **`crates/ledger-writer/`** — trajectory feed consumes the same
+  reader API the offline replay viewer ([ADR-010](../adrs/010-deterministic-trajectory-replay-offline-viewer.md))
+  uses. The offline viewer's React component reuse (or its
+  successor) is itself a candidate for the live trajectory DAG.
+- **`crates/approval-gate/src/channels/web.rs`** — the existing
+  localhost web channel for F3 approvals. Inline approval cards are
+  a UX layer over this same handler.
+- **`crates/mcp-client/src/lib.rs`** — FastMCP-aware client; MCP
+  Catalog uses this for `tools/list` discovery per [ADR-033](../adrs/033-webui-visual-mcp-server-management.md).
+
+## Verification
+
+### Per-sub-phase
+
+**1d.0 (schema + scaffold):**
+1. `cargo build --release` succeeds; `aegis run --ui` opens 7777.
+2. `cargo test -p ledger-v2` passes (round-trip schema conformance).
+3. The placeholder SPA renders the runtime version pulled from the
+   server. WebSocket upgrade succeeds (manual test).
+
+**1d.1 (manifest builder + Model Library):**
+1. Create a manifest in the form, save, run `aegis run --manifest
+   <saved>` from the CLI; tool call succeeds.
+2. Pull a model via the UI; `aegis run --model <pulled>` works.
+3. Visual diff: dark mode, lucide icons render, Sonner toasts work.
+
+**1d.2 (chat + tool-call cards + MCP Catalog):**
+1. Chat round-trip: prompt → assistant response with one tool call;
+   the tool-call card shows the manifest decision.
+2. Click verifiable badge → F9 ledger entry opens with hash chain.
+3. MCP Catalog: add server, discover tools, save to manifest, run
+   the saved manifest, success.
+4. Stop button: clicking it during a turn truncates cleanly; partial
+   F9 ledger preserved (verify with `aegis ledger verify`).
+
+**1d.3 (trajectory + approvals + circuit breaker):**
+1. Trajectory DAG renders for a real session; cmd+click opens the
+   F9 entry. Side-by-side toggle works.
+2. Circuit breaker bar: token gauge drains as the model emits;
+   wallclock gauge advances; on cap-hit the bar pulses red.
+3. Approval card: trigger a write that requires F3 approval; card
+   slides in; keyboard `a` approves; chat resumes.
+
+### Pre-release v0.9.5 acceptance
+
+1. End-to-end demo recording (per [#136](https://github.com/tosin2013/aegis-node/issues/136)
+   Phase B) showing all four surfaces.
+2. WCAG 2.1 AA audit on the chat + approval card flows.
+3. `cargo install --locked --path crates/cli --features llama` ships
+   a single binary that opens the UI; no `npm`/`pnpm` required at
+   install time.
+4. Bundle size budget: gzipped SPA ≤ 250 KB. (Initial target;
+   adjustable if shadcn additions push it.)
+
+## Risks
+
+- **Ledger v2 schema churn during 1d.3.** If multi-turn engine work
+  surfaces a schema gap during v1.0.0 implementation that ledger v2
+  doesn't cover, the UI ships against a schema that has to evolve.
+  Mitigation: the schema PR in 1d.0 ships with conformance test
+  cases hand-crafted from the multi-turn ADR examples — ADR-026
+  isn't speculation, it's a design we've already worked through. If
+  drift happens, prefer additive schema changes (new optional
+  fields) over breaking renames.
+- **CMMC-window compression.** v0.9.5 due 2026-10-20, v1.0.0 due
+  2026-11-02 — 13 days for multi-turn engine work alone is tight.
+  Mitigation: 1d.3 is the most-deferrable sub-phase; if engine work
+  needs the air, ship v0.9.5 with 1d.0/1d.1/1d.2 only and slip 1d.3
+  to v0.9.6 (which exists implicitly between v0.9.5 and v1.0.0).
+  ADR-031 phasing table already anchors trajectory polish at v1.0.0,
+  so this is a documented degradation path.
+- **assistant-ui opinionation.** The library has shape opinions about
+  message threads. Our extensions (verifiable badge, tool-call card,
+  approval card) need to slot in without rewriting its primitives.
+  Mitigation: prototype the verifiable badge against assistant-ui's
+  `MessagePrimitive.Root` slot in 1d.2 before committing to it for
+  the rest of the wow surfaces. If it doesn't slot cleanly, fall
+  back to building from raw shadcn primitives — costs us one week
+  of chat-thread-management work.
+- **Bundle size creep.** Monaco alone is ~1 MB ungzipped. Mitigation:
+  lazy-load Monaco only on the manifest-builder route (Vite code
+  splitting); chat + trajectory must not load it. xyflow is ~80 KB;
+  affordable.
+- **`pnpm` requirement at build time.** Operators building from
+  source need pnpm installed. Mitigation: `build.rs` checks for
+  `ui/dist/` first and skips pnpm when present; release tarballs
+  ship a pre-built `ui/dist/` so source-installs from a release tag
+  don't need pnpm. Document the dev-build pnpm requirement in
+  CONTRIBUTING.md.
+
+## Out of scope (explicit)
+
+- **Multi-turn engine implementation.** That's [ADR-025](../adrs/025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md)
+  and v1.0.0 / [#134](https://github.com/tosin2013/aegis-node/issues/134).
+  v0.9.5 ships the UI on the existing single-pass engine; the UI is
+  multi-turn-aware so it lights up when the engine catches up.
+- **[ADR-027](../adrs/027-aggregate-quota-schema.md) quota
+  visualization.** Quota schema editor is v1.0.0 polish per ADR-031
+  phasing table; v0.9.5 ships the manifest builder without it.
+- **[ADR-029](../adrs/029-task-scoped-ephemeral-approval-grants.md)
+  TTL semantics in the approval card.** Card UI ships in 1d.3; TTL
+  countdown lights up when the engine emits the grant timestamps in
+  v1.0.0.
+- **i18n.** English only. `i18next` hooks are wired so future PRs
+  can add locales without rewriting components per ADR-031.
+- **[ADR-034](../adrs/034-enterprise-management-dashboard-and-rbac.md)
+  Enterprise dashboard.** That's v2.5.0, commercial-licensed,
+  separate codebase. The community UI provides no auth, no
+  multi-tenancy, no SSO.
+- **Live preview of demos.** Demo recordings against the new UI are
+  tracked in [#136](https://github.com/tosin2013/aegis-node/issues/136)
+  Phase B, scheduled for v0.9.5 release week.
+- **Server-side rendering.** SPA is client-rendered only. SSR adds
+  complexity (Node runtime in the binary) for negligible benefit on
+  localhost.


### PR DESCRIPTION
## Summary

- Amends ADR-031 with the wow-factor surface inventory across all four core surfaces and locks the UI stack (React + Vite + shadcn/ui + Tailwind + assistant-ui + xyflow + Monaco + cmdk + Sonner + lucide + TanStack Query). Bundle pipeline: rust-embed → tower-http ServeDir, `build.rs` invokes `pnpm build` when `ui/dist/` is absent or stale.
- Adds `docs/plans/v0.9.5-ui-implementation.md` — three sub-phases sequenced around ADR-026 ledger schema v2: lock schema first (1d.0), build no-ledger-dependency surfaces (1d.1: manifest builder + Model Library), chat against single-pass engine (1d.2), then trajectory + approvals + circuit breaker viz (1d.3). 1d.3 is the documented deferrable sub-phase if v1.0.0 multi-turn engine work needs the air before the CMMC 2026-11-02 deadline.

Tracking: #135.

## Test plan

- [ ] `git diff main` review confirms only `docs/adrs/031-*.md` is amended (additive — no removals from existing decision text) and `docs/plans/v0.9.5-ui-implementation.md` is the only new file
- [ ] Cross-references resolve: ADR-026/027/028/029 links from the wow-factor inventory; the plan's links to issues #134/#135/#136 and the milestone in `RELEASE_PLAN.md`
- [ ] No engineering implications until merge — pure documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)