### PR TITLE
feat(ui): routing + Manifest/Models pages + GET /api/v1/models (sub-phase 1d.1b)

### DIFF
--- a/.github/workflows/litertlm.yml
+++ b/.github/workflows/litertlm.yml
@@ -72,6 +72,20 @@ jobs:
       - name: Install oras
         uses: oras-project/setup-oras@v1
 
+      # Node + pnpm are required by `crates/ui-server`'s build.rs (per
+      # ADR-031). Building `aegis-cli` transitively triggers it. See
+      # `rust.yml` / `llama.yml` / `demos.yml` for the matching setup.
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: litertlm-backend

--- a/.github/workflows/llama.yml
+++ b/.github/workflows/llama.yml
@@ -55,6 +55,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake libclang-dev clang
 
+      # Node + pnpm are required by `crates/ui-server`'s build.rs (per
+      # ADR-031) which runs `pnpm install --frozen-lockfile && pnpm build`
+      # in `ui/` to produce the static SPA assets that `rust-embed`
+      # bakes into the binary. Any workflow that touches `aegis-cli`
+      # transitively triggers this build script — see the matching
+      # setup in `rust.yml`, `litertlm.yml`, and `demos.yml`.
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+
       - uses: Swatinem/rust-cache@v2
         with:
           # The llama.cpp build artifacts live under target/; cache them

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "axum",
+ "dirs",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/crates/ui-server/Cargo.toml
+++ b/crates/ui-server/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 anyhow = "1"
 axum = "0.7"
+dirs = "5"
 mime_guess = "2"
 rust-embed = { version = "8", features = ["debug-embed", "interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/ui-server/src/handlers/mod.rs
+++ b/crates/ui-server/src/handlers/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod assets;
 pub mod health;
+pub mod models;

--- a/crates/ui-server/src/handlers/models.rs
+++ b/crates/ui-server/src/handlers/models.rs
@@ -1,0 +1,204 @@
+//! `GET /api/v1/models` — enumerate the local model cache.
+//!
+//! Per [ADR-032](../../../docs/adrs/032-webui-model-library-and-session-forking.md)
+//! the WebUI's Model Library wraps `aegis pull`; this handler is
+//! the read-side counterpart that the SPA calls on the `/models`
+//! route to render the list of locally-cached artifacts.
+//!
+//! Cache layout (per `crates/cli/src/pull.rs::default_cache_dir`):
+//!
+//! ```text
+//! ~/.cache/aegis/models/
+//!   <sha256_hex>/
+//!     <model artifact files>
+//!     chat_template.sha256.txt   (optional sidecar)
+//! ```
+//!
+//! Sub-phase 1d.1b ships read-only enumeration only. The "Add model"
+//! flow that wraps `pull::pull` over WebSocket lands in 1d.1c.
+//!
+//! ### Future-work notes
+//!
+//! - The OCI ref the operator originally pulled with isn't preserved
+//!   in the cache today (only the digest is). 1d.1c will add a
+//!   `provenance.json` sidecar capturing the source ref + cosign
+//!   verification result so this handler can surface
+//!   `oci_ref` non-null. Until then, `oci_ref` is always null.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct Model {
+    /// Directory name in the model cache — the SHA-256 of the
+    /// artifact's manifest. Stable for the lifetime of the cached
+    /// copy.
+    pub digest: String,
+    /// Original OCI reference the artifact was pulled with. Always
+    /// `null` in 1d.1b; 1d.1c populates this from a `provenance.json`
+    /// sidecar.
+    pub oci_ref: Option<String>,
+    /// Total size of all files under the model's cache directory,
+    /// in bytes.
+    pub size_bytes: u64,
+    /// RFC3339 timestamp of the cache directory's last-modified
+    /// time. Approximates "last used" until we add explicit
+    /// access-tracking sidecars.
+    pub last_used: Option<String>,
+    /// Whether a `chat_template.sha256.txt` sidecar is present
+    /// (per ADR-022 / OCI-B). Indicates the F1 chat-template-binding
+    /// extension is available for sessions booted against this model.
+    pub has_chat_template: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ModelsResponse {
+    /// Absolute path of the model cache root. Surfaced so the SPA
+    /// can show operators where the artifacts live (and recognise
+    /// when an override has been set).
+    pub cache_dir: String,
+    /// Cached models, ordered by digest for determinism.
+    pub models: Vec<Model>,
+}
+
+/// `GET /api/v1/models`
+pub async fn list_models() -> Json<ModelsResponse> {
+    let cache_dir = match resolve_cache_dir() {
+        Some(p) => p,
+        None => {
+            return Json(ModelsResponse {
+                cache_dir: "(unresolvable)".to_string(),
+                models: Vec::new(),
+            });
+        }
+    };
+
+    let mut models = match enumerate_cache(&cache_dir) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                target: "aegis_ui_server",
+                err = %e,
+                cache_dir = %cache_dir.display(),
+                "failed to enumerate model cache; returning empty list",
+            );
+            Vec::new()
+        }
+    };
+    models.sort_by(|a, b| a.digest.cmp(&b.digest));
+
+    Json(ModelsResponse {
+        cache_dir: cache_dir.display().to_string(),
+        models,
+    })
+}
+
+/// Mirrors `crates/cli/src/pull.rs::default_cache_dir` without the
+/// dep cycle. Returns `None` when the OS doesn't expose a cache
+/// dir (rare; treated as "no models cached").
+fn resolve_cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir().map(|d| d.join("aegis").join("models"))
+}
+
+fn enumerate_cache(cache_dir: &Path) -> std::io::Result<Vec<Model>> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(cache_dir) {
+        Ok(it) => it,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => return Err(e),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(digest) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Cache subdirs are named by 64-char hex SHA-256; skip
+        // anything else so stray files / non-cache directories
+        // don't show up in the listing.
+        if digest.len() != 64 || !digest.chars().all(|c| c.is_ascii_hexdigit()) {
+            continue;
+        }
+
+        let size_bytes = dir_size_bytes(&path).unwrap_or(0);
+        let last_used = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(format_rfc3339);
+        let has_chat_template = path.join("chat_template.sha256.txt").is_file();
+
+        out.push(Model {
+            digest: format!("sha256:{digest}"),
+            oci_ref: None,
+            size_bytes,
+            last_used,
+            has_chat_template,
+        });
+    }
+    Ok(out)
+}
+
+fn dir_size_bytes(dir: &Path) -> std::io::Result<u64> {
+    let mut total = 0u64;
+    let mut stack: Vec<PathBuf> = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        for entry in std::fs::read_dir(&current)?.flatten() {
+            let meta = entry.metadata()?;
+            if meta.is_dir() {
+                stack.push(entry.path());
+            } else {
+                total = total.saturating_add(meta.len());
+            }
+        }
+    }
+    Ok(total)
+}
+
+/// Format a `SystemTime` as an RFC3339 timestamp without pulling in
+/// the `chrono` crate. ui-server stays light on dependencies; the
+/// SPA reformats the timestamp client-side anyway.
+fn format_rfc3339(t: SystemTime) -> Option<String> {
+    let dur = t.duration_since(SystemTime::UNIX_EPOCH).ok()?;
+    let secs = dur.as_secs() as i64;
+    let nanos = dur.subsec_nanos();
+    Some(naive_rfc3339_from_unix(secs, nanos))
+}
+
+/// Pure-stdlib UNIX-seconds → RFC3339 (`YYYY-MM-DDTHH:MM:SS.fffZ`).
+/// Calendar arithmetic uses the proleptic Gregorian calendar so
+/// dates after 1970 map cleanly. Adequate for "last modified"
+/// timestamps; the SPA does its own locale-aware rendering.
+fn naive_rfc3339_from_unix(secs: i64, nanos: u32) -> String {
+    const SECONDS_PER_DAY: i64 = 86_400;
+    let days = secs.div_euclid(SECONDS_PER_DAY);
+    let time_of_day = secs.rem_euclid(SECONDS_PER_DAY);
+    let hh = time_of_day / 3600;
+    let mm = (time_of_day % 3600) / 60;
+    let ss = time_of_day % 60;
+
+    // Convert days-since-1970 to (year, month, day) via Howard
+    // Hinnant's algorithm — see http://howardhinnant.github.io/date_algorithms.html
+    // (`civil_from_days`). Public domain.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!(
+        "{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}.{millis:03}Z",
+        millis = nanos / 1_000_000,
+    )
+}

--- a/crates/ui-server/src/lib.rs
+++ b/crates/ui-server/src/lib.rs
@@ -73,6 +73,7 @@ pub fn router(config: Config) -> Router {
     Router::new()
         .route("/healthz", get(handlers::health::healthz))
         .route("/api/v1/version", get(handlers::health::version))
+        .route("/api/v1/models", get(handlers::models::list_models))
         .fallback(handlers::assets::serve_embedded)
         .with_state(config)
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,10 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@tanstack/react-query": "^5.100.9",
+    "@tanstack/react-router": "^1.169.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.4(@types/react@19.2.14)(react@19.2.6)
+      '@tanstack/react-query':
+        specifier: ^5.100.9
+        version: 5.100.9(react@19.2.6)
+      '@tanstack/react-router':
+        specifier: ^1.169.2
+        version: 1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -312,6 +321,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -548,6 +567,38 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/history@1.161.6':
+    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.100.9':
+    resolution: {integrity: sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==}
+
+  '@tanstack/react-query@5.100.9':
+    resolution: {integrity: sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-router@1.169.2':
+    resolution: {integrity: sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.169.2':
+    resolution: {integrity: sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -573,6 +624,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -603,6 +657,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -618,6 +675,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   electron-to-chromium@1.5.352:
     resolution: {integrity: sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==}
@@ -655,6 +715,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  isbot@5.1.40:
+    resolution: {integrity: sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==}
+    engines: {node: '>=18'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -754,6 +818,14 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -801,9 +873,22 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
@@ -832,6 +917,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -1087,6 +1177,17 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.55.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -1245,6 +1346,40 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)
 
+  '@tanstack/history@1.161.6': {}
+
+  '@tanstack/query-core@5.100.9': {}
+
+  '@tanstack/react-query@5.100.9(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.9
+      react: 19.2.6
+
+  '@tanstack/react-router@1.169.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.169.2
+      isbot: 5.1.40
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
+  '@tanstack/router-core@1.169.2':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.3
@@ -1280,6 +1415,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -1312,6 +1450,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   csstype@3.2.3: {}
 
   debug@4.4.3:
@@ -1319,6 +1459,10 @@ snapshots:
       ms: 2.1.3
 
   detect-libc@2.1.2: {}
+
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.352: {}
 
@@ -1368,6 +1512,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   graceful-fs@4.2.11: {}
+
+  isbot@5.1.40: {}
 
   jiti@2.7.0: {}
 
@@ -1438,6 +1584,13 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked@14.0.0: {}
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
@@ -1498,7 +1651,15 @@ snapshots:
 
   semver@6.3.1: {}
 
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
   source-map-js@1.2.1: {}
+
+  state-local@1.0.7: {}
 
   tailwind-merge@2.6.1: {}
 
@@ -1520,6 +1681,10 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -1,0 +1,63 @@
+import { Link, useRouterState } from "@tanstack/react-router";
+import { Boxes, FileCode, Home as HomeIcon, ShieldCheck } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+import { cn } from "@/lib/utils";
+
+interface NavItem {
+  to: string;
+  label: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { to: "/", label: "Home", icon: HomeIcon },
+  { to: "/manifest", label: "Manifest Builder", icon: FileCode },
+  { to: "/models", label: "Model Library", icon: Boxes },
+];
+
+export function TopNav() {
+  const router = useRouterState();
+  const currentPath = router.location.pathname;
+
+  return (
+    <nav className="border-b border-[var(--color-border)] bg-[var(--color-bg)]">
+      <div className="mx-auto flex max-w-3xl items-center justify-between px-6 py-3">
+        <Link
+          to="/"
+          className="flex items-center gap-2 text-sm font-semibold tracking-tight transition-colors hover:text-accent"
+        >
+          <ShieldCheck className="h-5 w-5 text-accent" aria-hidden="true" />
+          <span>Aegis-Node</span>
+        </Link>
+        <ul className="flex items-center gap-1">
+          {NAV_ITEMS.map((item) => {
+            const active =
+              item.to === "/"
+                ? currentPath === "/"
+                : currentPath.startsWith(item.to);
+            return (
+              <li key={item.to}>
+                <Link
+                  to={item.to}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors",
+                    active
+                      ? "bg-[var(--color-bg-elev)] text-accent"
+                      : "text-muted hover:text-fg",
+                  )}
+                  aria-current={active ? "page" : undefined}
+                >
+                  <item.icon
+                    className="h-4 w-4"
+                    aria-hidden="true"
+                  />
+                  <span>{item.label}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
+import { RouterProvider } from "@tanstack/react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { router } from "./router";
 import "./index.css";
 
 const rootElement = document.getElementById("root");
@@ -8,8 +10,20 @@ if (!rootElement) {
   throw new Error("missing #root element in index.html");
 }
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 createRoot(rootElement).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -13,7 +13,7 @@ type LoadState =
   | { kind: "ready"; data: VersionResponse }
   | { kind: "error"; message: string };
 
-export default function App() {
+export function Home() {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
 
   useEffect(() => {
@@ -40,7 +40,7 @@ export default function App() {
   }, []);
 
   return (
-    <main className="mx-auto max-w-2xl px-6 pt-16 pb-12">
+    <>
       <header className="mb-8 flex items-center gap-3">
         <ShieldCheck className="h-7 w-7 text-accent" aria-hidden="true" />
         <div>
@@ -87,15 +87,6 @@ export default function App() {
           )}
         </CardContent>
       </Card>
-
-      <footer className="mt-8 text-center">
-        <a
-          href="https://github.com/tosin2013/aegis-node"
-          className="font-mono text-xs text-muted hover:text-accent"
-        >
-          github.com/tosin2013/aegis-node
-        </a>
-      </footer>
-    </main>
+    </>
   );
 }

--- a/ui/src/pages/Manifest.tsx
+++ b/ui/src/pages/Manifest.tsx
@@ -1,0 +1,101 @@
+import { lazy, Suspense } from "react";
+import { FileCode } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+// Monaco's bundle is ~1 MB. Lazy-load it on this route so Home and
+// Models stay light. Vite code-splits this dynamic import into its
+// own chunk fetched only when the operator navigates to /manifest.
+const MonacoEditor = lazy(async () => {
+  const mod = await import("@monaco-editor/react");
+  return { default: mod.default };
+});
+
+const SAMPLE_YAML = `# Sample Aegis-Node permission manifest (read-only preview).
+# Sub-phase 1d.1c wires this to a real save flow + live
+# \`aegis validate\` diagnostics per ADR-031 §"Visual manifest builder."
+
+identity:
+  workload: example-agent
+  instance: dev-1
+
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+
+tools:
+  filesystem:
+    read:
+      - /home/agent/data
+    write:
+      - path: /home/agent/out
+        ttl: PT1H
+  network:
+    outbound:
+      - host: api.example.com
+        port: 443
+        protocol: tcp
+  mcp:
+    - server_name: fs-mcp
+      server_uri: stdio:npx -y @modelcontextprotocol/server-filesystem /tmp
+      allowed_tools:
+        - read_text_file
+`;
+
+export function Manifest() {
+  return (
+    <>
+      <header className="mb-8 flex items-center gap-3">
+        <FileCode className="h-7 w-7 text-accent" aria-hidden="true" />
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Manifest Builder
+          </h1>
+          <p className="text-sm text-muted">
+            Preview only · live validate + save lands in sub-phase 1d.1c
+          </p>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>manifest.yaml</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-4 text-sm text-muted">
+            Monaco editor lazy-loaded — only fetched when this route is
+            visited. The full editor will integrate with{" "}
+            <code className="font-mono text-accent">aegis validate</code> for
+            inline diagnostics on overly broad paths, missing quotas
+            (ADR-027), and redundant <code className="font-mono">pre_validate</code>{" "}
+            clauses (ADR-024).
+          </p>
+
+          <div className="overflow-hidden rounded-md border border-[var(--color-border)]">
+            <Suspense
+              fallback={
+                <div className="flex h-[480px] items-center justify-center font-mono text-sm text-muted">
+                  loading editor…
+                </div>
+              }
+            >
+              <MonacoEditor
+                height="480px"
+                defaultLanguage="yaml"
+                defaultValue={SAMPLE_YAML}
+                theme="vs-dark"
+                options={{
+                  minimap: { enabled: false },
+                  readOnly: true,
+                  fontSize: 13,
+                  scrollBeyondLastLine: false,
+                  renderWhitespace: "selection",
+                }}
+              />
+            </Suspense>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/ui/src/pages/Models.tsx
+++ b/ui/src/pages/Models.tsx
@@ -1,0 +1,135 @@
+import { useQuery } from "@tanstack/react-query";
+import { Boxes, Hash } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface Model {
+  digest: string;
+  oci_ref: string | null;
+  size_bytes: number;
+  last_used: string | null;
+  has_chat_template: boolean;
+}
+
+interface ModelsResponse {
+  cache_dir: string;
+  models: Model[];
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)} MB`;
+  return `${(n / 1024 ** 3).toFixed(2)} GB`;
+}
+
+function shortDigest(digest: string): string {
+  // sha256:<64 hex> → sha256:abcd1234…cdef
+  if (digest.length <= 24) return digest;
+  return `${digest.slice(0, 18)}…${digest.slice(-8)}`;
+}
+
+export function Models() {
+  const { data, error, isLoading } = useQuery<ModelsResponse>({
+    queryKey: ["models"],
+    queryFn: async () => {
+      const r = await fetch("/api/v1/models");
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r.json();
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  return (
+    <>
+      <header className="mb-8 flex items-center gap-3">
+        <Boxes className="h-7 w-7 text-accent" aria-hidden="true" />
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Model Library
+          </h1>
+          <p className="text-sm text-muted">
+            Locally cached models · pull/verify lands in sub-phase 1d.1c
+          </p>
+        </div>
+      </header>
+
+      {isLoading && (
+        <p className="font-mono text-sm text-muted">loading model cache…</p>
+      )}
+
+      {error && (
+        <p className="font-mono text-sm text-red-400">
+          error: {error instanceof Error ? error.message : String(error)}
+        </p>
+      )}
+
+      {data && (
+        <>
+          <p className="mb-4 text-xs text-muted">
+            Cache:{" "}
+            <span className="font-mono text-accent">{data.cache_dir}</span>
+          </p>
+
+          {data.models.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-sm text-muted">
+                <p className="mb-2">No models cached yet.</p>
+                <p>
+                  Pull one from a registry via{" "}
+                  <code className="font-mono text-accent">
+                    aegis pull &lt;ref&gt;
+                  </code>
+                  . Visual pull lands in 1d.1c per ADR-032.
+                </p>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {data.models.map((m) => (
+                <Card key={m.digest}>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="flex items-center gap-2 text-sm">
+                      <Hash
+                        className="h-4 w-4 text-muted"
+                        aria-hidden="true"
+                      />
+                      <span className="font-mono text-accent">
+                        {shortDigest(m.digest)}
+                      </span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <dl className="grid grid-cols-[max-content_1fr] gap-x-5 gap-y-1.5 text-sm">
+                      {m.oci_ref && (
+                        <>
+                          <dt className="text-muted">OCI ref</dt>
+                          <dd className="truncate font-mono text-accent">
+                            {m.oci_ref}
+                          </dd>
+                        </>
+                      )}
+                      <dt className="text-muted">Size</dt>
+                      <dd className="font-mono">{formatBytes(m.size_bytes)}</dd>
+                      <dt className="text-muted">Chat template</dt>
+                      <dd className="font-mono">
+                        {m.has_chat_template ? "✓ present" : "—"}
+                      </dd>
+                      {m.last_used && (
+                        <>
+                          <dt className="text-muted">Last used</dt>
+                          <dd className="font-mono">
+                            {new Date(m.last_used).toLocaleString()}
+                          </dd>
+                        </>
+                      )}
+                    </dl>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,0 +1,68 @@
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+} from "@tanstack/react-router";
+import { TopNav } from "@/components/TopNav";
+import { Home } from "@/pages/Home";
+import { Manifest } from "@/pages/Manifest";
+import { Models } from "@/pages/Models";
+
+/**
+ * Code-based TanStack Router setup. File-based routing (with the
+ * `@tanstack/router-plugin` Vite plugin) is the canonical approach
+ * but adds a build-time codegen step; for sub-phase 1d.1b's three
+ * routes the code-based pattern is leaner. Revisit when the
+ * route count grows past ~6–8 (likely v1.0.0 polish).
+ */
+
+const rootRoute = createRootRoute({
+  component: RootLayout,
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: Home,
+});
+
+const manifestRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/manifest",
+  component: Manifest,
+});
+
+const modelsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/models",
+  component: Models,
+});
+
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  manifestRoute,
+  modelsRoute,
+]);
+
+export const router = createRouter({
+  routeTree,
+  defaultPreload: "intent",
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+function RootLayout() {
+  return (
+    <>
+      <TopNav />
+      <main className="mx-auto max-w-3xl px-6 pt-12 pb-12">
+        <Outlet />
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

First user-navigable surfaces on top of the Vite + React + Tailwind + shadcn scaffold from #140. The flat `App.tsx` becomes a routed layout with three pages — Home, Manifest Builder, Model Library — plus the read-side handler that lists the local model cache.

**Stacks on #140** (base = `phase-1d/vite-scaffold-v2`). Once #140 squash-merges into `main`, retarget this PR's base to `main` and the diff will collapse to just this PR's changes.

## What lands

- **TanStack Router** (code-based, three routes: `/`, `/manifest`, `/models`) + **TanStack Query** baseline. Defaults: 30s `staleTime`, `retry: 1`, no `refetchOnWindowFocus`.
- **Top nav** (`ui/src/components/TopNav.tsx`) — three nav items with shadcn-style active-route highlighting, lucide icons, hover transitions.
- **Manifest Builder** page lazy-loads `@monaco-editor/react` via React's `Suspense` boundary so Monaco's bundle is only fetched when the operator visits `/manifest`. Sample manifest YAML rendered read-only; full validate + save round-trip lands in 1d.1c per ADR-031.
- **Model Library** page uses TanStack Query against `/api/v1/models`. List cards show short digest, OCI ref (always null until 1d.1c sidecar lands), formatted size, chat-template-present indicator, and last-used timestamp. Clean empty-state when cache is empty.
- **`GET /api/v1/models`** in `crates/ui-server/src/handlers/models.rs` — enumerates `~/.cache/aegis/models/` following the layout established by `crates/cli/src/pull.rs::default_cache_dir`. Validates each entry name as a 64-char hex digest, sums sizes recursively, serializes a stable list ordered by digest. Pure-stdlib RFC3339 timestamps so we don't pull `chrono` into ui-server for one format call.

## 1d.1c follow-up notes (captured inline)

- `oci_ref` needs a `provenance.json` sidecar — today the cache only stores the digest.
- `@monaco-editor/react` default-loads from CDN which breaks airgap deployments. Fix is to bundle Monaco locally (~ 1 MB extra).

## Bundle (gzipped)

- Main JS **110 KB**, lazy chunk **5 KB**, CSS **3 KB** — total **118 KB**, well under the 250 KB budget per `docs/plans/v0.9.5-ui-implementation.md`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude aegis-llama-backend --all-targets -- -D warnings` clean
- [x] `cargo test` (default members) green
- [x] `pnpm typecheck` clean; `pnpm build` clean
- [x] Manual smoke: all three SPA routes render; `/api/v1/models` returns the actual local cache (3 cached models in this dev env)
- [x] User eyeballed via SSH-tunnel reproduction
- [ ] CI green

Tracking: #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)