### PR TITLE
feat(ui): Monaco airgap + manifest save flow + demos pnpm fix (sub-phase 1d.1c)

### DIFF
--- a/crates/ui-server/src/handlers/manifests.rs
+++ b/crates/ui-server/src/handlers/manifests.rs
@@ -1,0 +1,116 @@
+//! Manifest read/write handlers.
+//!
+//! Sub-phase 1d.1c ships the save side: the SPA's Manifest Builder
+//! posts the editor's current YAML buffer here, the handler writes
+//! it to a single draft slot under `~/.config/aegis/`, and the CLI
+//! consumes the same file via `aegis run --manifest …`.
+//!
+//! ## Why one draft slot?
+//!
+//! Multi-manifest management with a directory listing UI lands in a
+//! later sub-phase. For 1d.1c the workflow is "edit → save → run
+//! against the saved file" which is what operators do on the CLI
+//! today. A single well-known path keeps the surface tight.
+//!
+//! ## Validation gap
+//!
+//! This handler does **not** invoke `aegis validate` — the
+//! validator is implemented in the Go binary (`cmd/aegis/`, ADR-002
+//! split-language) and the cross-language plumbing is its own
+//! sub-phase 1d.1d work item. Until then, operators run
+//! `aegis validate ~/.config/aegis/manifests/draft.yaml` from the
+//! CLI after saving. A future amendment will add
+//! `POST /api/v1/manifests/validate` that shells out to the Go
+//! validator and returns line-level diagnostics for inline rendering
+//! in the Monaco editor.
+
+use std::path::PathBuf;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+
+const DRAFT_FILENAME: &str = "draft.yaml";
+const MAX_BODY_BYTES: usize = 1024 * 1024; // 1 MiB cap on the YAML body
+
+#[derive(Debug, Serialize)]
+pub struct SaveResponse {
+    /// True when the write completed successfully. Always true in
+    /// the OK path; included so the SPA can pattern-match on shape.
+    pub saved: bool,
+    /// Absolute path the YAML was written to. The SPA echoes this
+    /// back to the operator so they can copy it into
+    /// `aegis run --manifest …`.
+    pub path: String,
+    /// Number of bytes written. Lets the SPA show a "N bytes saved"
+    /// confirmation without re-reading the file.
+    pub bytes: usize,
+}
+
+/// `POST /api/v1/manifests` — save the request body as
+/// `~/.config/aegis/manifests/draft.yaml`.
+///
+/// The body is treated as opaque YAML text. Validation is out of
+/// scope for this handler (see module-level note); the operator
+/// runs `aegis validate` from the CLI to lint the saved file.
+pub async fn save_manifest(body: String) -> Response {
+    if body.len() > MAX_BODY_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "manifest body exceeds {} byte cap (got {} bytes)",
+                MAX_BODY_BYTES,
+                body.len()
+            ),
+        )
+            .into_response();
+    }
+
+    let path = match draft_path() {
+        Some(p) => p,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "could not resolve user config dir",
+            )
+                .into_response();
+        }
+    };
+
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("create_dir_all {}: {e}", parent.display()),
+            )
+                .into_response();
+        }
+    }
+
+    if let Err(e) = std::fs::write(&path, &body) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("write {}: {e}", path.display()),
+        )
+            .into_response();
+    }
+
+    let bytes = body.len();
+    Json(SaveResponse {
+        saved: true,
+        path: path.display().to_string(),
+        bytes,
+    })
+    .into_response()
+}
+
+/// Resolve `~/.config/aegis/manifests/draft.yaml` (or the
+/// platform-equivalent config dir on macOS / Windows). Mirrors the
+/// `dirs::config_dir` lookup used by `crates/cli/src/lib.rs::resolve_identity_dir`
+/// so the WebUI's draft co-locates with the runtime config tree the
+/// CLI already reads.
+fn draft_path() -> Option<PathBuf> {
+    let base = dirs::config_dir()?;
+    Some(base.join("aegis").join("manifests").join(DRAFT_FILENAME))
+}

--- a/crates/ui-server/src/handlers/mod.rs
+++ b/crates/ui-server/src/handlers/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod assets;
 pub mod health;
+pub mod manifests;
 pub mod models;

--- a/crates/ui-server/src/lib.rs
+++ b/crates/ui-server/src/lib.rs
@@ -74,7 +74,10 @@ pub fn router(config: Config) -> Router {
         .route("/healthz", get(handlers::health::healthz))
         .route("/api/v1/version", get(handlers::health::version))
         .route("/api/v1/models", get(handlers::models::list_models))
-        .route("/api/v1/manifests", post(handlers::manifests::save_manifest))
+        .route(
+            "/api/v1/manifests",
+            post(handlers::manifests::save_manifest),
+        )
         .fallback(handlers::assets::serve_embedded)
         .with_state(config)
 }

--- a/crates/ui-server/src/lib.rs
+++ b/crates/ui-server/src/lib.rs
@@ -29,7 +29,7 @@
 
 use std::net::{IpAddr, SocketAddr};
 
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 use serde::Serialize;
 
@@ -74,6 +74,7 @@ pub fn router(config: Config) -> Router {
         .route("/healthz", get(handlers::health::healthz))
         .route("/api/v1/version", get(handlers::health::version))
         .route("/api/v1/models", get(handlers::models::list_models))
+        .route("/api/v1/manifests", post(handlers::manifests::save_manifest))
         .fallback(handlers::assets::serve_embedded)
         .with_state(config)
 }

--- a/demos/Dockerfile
+++ b/demos/Dockerfile
@@ -93,5 +93,13 @@ RUN go install github.com/charmbracelet/vhs@v0.11.0
 RUN npm install -g @modelcontextprotocol/server-filesystem \
     && ln -sf /usr/local/bin/mcp-server-filesystem /usr/bin/mcp-server-filesystem
 
+# pnpm — required by `crates/ui-server`'s build.rs (per ADR-031). The
+# demo build path runs `cargo build --release -p aegis-cli --features
+# llama` inside this image, which transitively triggers the SPA
+# build script. Pinned to pnpm@10 to match `ui/package.json`'s
+# `packageManager` field. See #142 for the corresponding host-side
+# CI fixes (rust.yml / llama.yml / litertlm.yml).
+RUN npm install -g pnpm@10
+
 WORKDIR /work
 CMD ["/bin/bash"]

--- a/demos/Dockerfile
+++ b/demos/Dockerfile
@@ -28,16 +28,26 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Base toolchain. fonts-firacode is what the .tape files render with;
 # changing it changes every committed GIF SHA. ttyd + ffmpeg are vhs's
-# transitive dependencies. npm is needed for the upstream MCP file-
-# system server (Demo 1).
+# transitive dependencies. Node 20 (installed below from NodeSource)
+# is needed for the upstream MCP filesystem server (Demo 1) and for
+# the SPA build under `ui/` per ADR-031 — Ubuntu 24.04's apt `npm`
+# package pulls Node 18, which is too old for Vite 6 + Tailwind 4
+# (`@tailwindcss/oxide` native binding fails to load under Node 18).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl wget git \
+        ca-certificates curl wget git gnupg \
         build-essential cmake libclang-dev clang lld \
         pkg-config \
         ffmpeg ttyd fonts-firacode \
-        npm \
         jq \
         gdb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node 20 from NodeSource — Vite 6 + Tailwind 4 (per ADR-031's
+# locked UI stack) require Node >= 20, and Ubuntu 24.04's apt repo
+# only ships Node 18. The setup script adds NodeSource's apt source;
+# the subsequent install pulls a Node-20 + matching-npm bundle.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Chrome (vhs renders its terminal frames through headless chrome).
@@ -97,8 +107,11 @@ RUN npm install -g @modelcontextprotocol/server-filesystem \
 # demo build path runs `cargo build --release -p aegis-cli --features
 # llama` inside this image, which transitively triggers the SPA
 # build script. Pinned to pnpm@10 to match `ui/package.json`'s
-# `packageManager` field. See #142 for the corresponding host-side
-# CI fixes (rust.yml / llama.yml / litertlm.yml).
+# `packageManager` field. Runs against the Node 20 install above —
+# Tailwind 4's `@tailwindcss/oxide` native binding fails to resolve
+# under the bundled npm + Node 18 combination Ubuntu apt provides.
+# See #142 for the corresponding host-side CI fixes (rust.yml /
+# llama.yml / litertlm.yml).
 RUN npm install -g pnpm@10
 
 WORKDIR /work

--- a/demos/Dockerfile
+++ b/demos/Dockerfile
@@ -96,12 +96,26 @@ ENV PATH=/root/.cargo/bin:/usr/local/go/bin:/root/go/bin:/usr/local/bin:/usr/bin
 # encoding subtly; locking to v0.11.0 keeps GIF SHAs stable.
 RUN go install github.com/charmbracelet/vhs@v0.11.0
 
-# MCP filesystem server (Anthropic) — Demo 1 uses this. npm-global
-# default places the binary at /usr/local/bin/mcp-server-filesystem;
-# the demo manifests reference /usr/bin/mcp-server-filesystem, which
-# the symlink below resolves to the npm-global binary.
+# MCP filesystem server (Anthropic) — Demo 1 uses this. The
+# demo manifests reference /usr/bin/mcp-server-filesystem; the
+# install location depends on the npm distribution:
+#
+#   - NodeSource Node 20 (this image): npm prefix=/usr → binary
+#     at /usr/bin/mcp-server-filesystem (already at the expected
+#     location, no symlink needed)
+#   - Legacy apt npm: prefix=/usr/local → binary at
+#     /usr/local/bin/mcp-server-filesystem (symlink needed)
+#
+# The conditional symlink below handles both, and explicitly
+# avoids the `ln -sf` footgun that overwrote npm's working
+# /usr/bin link with a broken /usr/local target on Node 20.
 RUN npm install -g @modelcontextprotocol/server-filesystem \
-    && ln -sf /usr/local/bin/mcp-server-filesystem /usr/bin/mcp-server-filesystem
+    && actual="$(command -v mcp-server-filesystem)" \
+    && test -n "$actual" \
+    && if [ "$actual" != "/usr/bin/mcp-server-filesystem" ]; then \
+         ln -sf "$actual" /usr/bin/mcp-server-filesystem; \
+       fi \
+    && test -x /usr/bin/mcp-server-filesystem
 
 # pnpm — required by `crates/ui-server`'s build.rs (per ADR-031). The
 # demo build path runs `cargo build --release -p aegis-cli --features

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,8 +20,10 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",
+    "monaco-editor": "^0.55.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.5"
   },
   "devDependencies": {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -29,12 +29,18 @@ importers:
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.6)
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       react:
         specifier: ^19.0.0
         version: 19.2.6
       react-dom:
         specifier: ^19.0.0
         version: 19.2.6(react@19.2.6)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.1
@@ -883,6 +889,12 @@ packages:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1656,6 +1668,11 @@ snapshots:
       seroval: 1.5.4
 
   seroval@1.5.4: {}
+
+  sonner@2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   source-map-js@1.2.1: {}
 

--- a/ui/src/lib/monaco-setup.ts
+++ b/ui/src/lib/monaco-setup.ts
@@ -1,0 +1,49 @@
+/**
+ * Monaco airgap configuration. By default, `@monaco-editor/react`
+ * loads Monaco from the cdn.jsdelivr.net CDN at runtime — that
+ * works on internet-connected hosts but breaks airgap deployments
+ * (the v0.9.5 release target per ADR-031 §"Localhost-only" + the
+ * v1.0.0 CMMC posture).
+ *
+ * This module imports the `monaco-editor` ESM bundle and registers
+ * it with `@monaco-editor/react`'s loader so the editor uses the
+ * locally-bundled copy. Vite's `?worker` syntax inlines the Monaco
+ * web workers as code-split chunks, so they load from the
+ * Aegis-Node embedded assets, not a third-party origin.
+ *
+ * Sub-phase 1d.1d will add `monaco-yaml` for schema-aware
+ * autocomplete + diagnostics; for now we get Monaco's built-in
+ * YAML syntax highlighting plus the JSON worker (used by some
+ * Monaco internals).
+ *
+ * Calling `configureMonaco()` is idempotent — safe to invoke from
+ * multiple components if needed.
+ */
+import * as monaco from "monaco-editor";
+import { loader } from "@monaco-editor/react";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+
+let configured = false;
+
+interface MonacoEnvironment {
+  getWorker(_workerId: string, label: string): Worker;
+}
+
+interface WindowWithMonacoEnv extends Window {
+  MonacoEnvironment?: MonacoEnvironment;
+}
+
+export function configureMonaco() {
+  if (configured) return;
+  configured = true;
+
+  (self as unknown as WindowWithMonacoEnv).MonacoEnvironment = {
+    getWorker(_workerId: string, label: string): Worker {
+      if (label === "json") return new JsonWorker();
+      return new EditorWorker();
+    },
+  };
+
+  loader.config({ monaco });
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Toaster } from "sonner";
 import { router } from "./router";
 import "./index.css";
 
@@ -24,6 +25,17 @@ createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <Toaster
+        theme="dark"
+        position="bottom-right"
+        toastOptions={{
+          style: {
+            background: "var(--color-bg-elev)",
+            color: "var(--color-fg)",
+            border: "1px solid var(--color-border)",
+          },
+        }}
+      />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/ui/src/pages/Manifest.tsx
+++ b/ui/src/pages/Manifest.tsx
@@ -1,18 +1,28 @@
-import { lazy, Suspense } from "react";
-import { FileCode } from "lucide-react";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { FileCode, Save } from "lucide-react";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-// Monaco's bundle is ~1 MB. Lazy-load it on this route so Home and
-// Models stay light. Vite code-splits this dynamic import into its
-// own chunk fetched only when the operator navigates to /manifest.
+// Locally-bundled Monaco. The dynamic imports below — `monaco-setup`
+// (which pulls in `monaco-editor` + the worker `?worker` chunks) and
+// `@monaco-editor/react` — are deliberately deferred *inside* the
+// lazy boundary so Vite splits them into their own chunk. If
+// `monaco-setup` is imported at the top of this file, the entire
+// ~4 MB Monaco core leaks into the eager bundle and blows the
+// initial-route size budget. The current arrangement keeps Home +
+// Models bundles light; only /manifest pays Monaco's cost.
 const MonacoEditor = lazy(async () => {
+  const setup = await import("@/lib/monaco-setup");
+  setup.configureMonaco();
   const mod = await import("@monaco-editor/react");
   return { default: mod.default };
 });
 
-const SAMPLE_YAML = `# Sample Aegis-Node permission manifest (read-only preview).
-# Sub-phase 1d.1c wires this to a real save flow + live
-# \`aegis validate\` diagnostics per ADR-031 §"Visual manifest builder."
+const SAMPLE_YAML = `# Sample Aegis-Node permission manifest.
+# Sub-phase 1d.1d wires live \`aegis validate\` diagnostics into this
+# editor (ADR-031 §"Visual manifest builder"). For now it edits + saves;
+# validation runs against the saved file via \`aegis validate\` from the
+# CLI.
 
 identity:
   workload: example-agent
@@ -42,19 +52,73 @@ tools:
         - read_text_file
 `;
 
+interface SaveResponse {
+  saved: boolean;
+  path: string;
+  bytes: number;
+}
+
 export function Manifest() {
+  const [yaml, setYaml] = useState<string>(SAMPLE_YAML);
+  const [savedPath, setSavedPath] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    setDirty(yaml !== SAMPLE_YAML || savedPath !== null);
+  }, [yaml, savedPath]);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const r = await fetch("/api/v1/manifests", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-yaml" },
+        body: yaml,
+      });
+      if (!r.ok) {
+        const text = await r.text().catch(() => `HTTP ${r.status}`);
+        throw new Error(text || `HTTP ${r.status}`);
+      }
+      const data = (await r.json()) as SaveResponse;
+      setSavedPath(data.path);
+      setDirty(false);
+      toast.success("Manifest saved", {
+        description: `${data.bytes} bytes → ${data.path}`,
+      });
+    } catch (e) {
+      toast.error("Save failed", {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <>
-      <header className="mb-8 flex items-center gap-3">
-        <FileCode className="h-7 w-7 text-accent" aria-hidden="true" />
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">
-            Manifest Builder
-          </h1>
-          <p className="text-sm text-muted">
-            Preview only · live validate + save lands in sub-phase 1d.1c
-          </p>
+      <header className="mb-8 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <FileCode className="h-7 w-7 text-accent" aria-hidden="true" />
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Manifest Builder
+            </h1>
+            <p className="text-sm text-muted">
+              Edit + save · live validate diagnostics land in sub-phase 1d.1d
+            </p>
+          </div>
         </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] px-3 py-1.5 text-sm transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+          aria-label="Save manifest"
+        >
+          <Save className="h-4 w-4" aria-hidden="true" />
+          <span>{saving ? "Saving…" : dirty ? "Save" : "Saved"}</span>
+        </button>
       </header>
 
       <Card>
@@ -63,13 +127,23 @@ export function Manifest() {
         </CardHeader>
         <CardContent>
           <p className="mb-4 text-sm text-muted">
-            Monaco editor lazy-loaded — only fetched when this route is
-            visited. The full editor will integrate with{" "}
-            <code className="font-mono text-accent">aegis validate</code> for
-            inline diagnostics on overly broad paths, missing quotas
-            (ADR-027), and redundant <code className="font-mono">pre_validate</code>{" "}
-            clauses (ADR-024).
+            Monaco editor served from the embedded SPA bundle (no CDN). Save
+            writes to{" "}
+            <code className="font-mono text-accent">
+              ~/.config/aegis/manifests/draft.yaml
+            </code>{" "}
+            — load it with{" "}
+            <code className="font-mono text-accent">
+              aegis run --manifest …
+            </code>
+            .
           </p>
+
+          {savedPath && (
+            <p className="mb-4 font-mono text-xs text-muted">
+              last save → <span className="text-accent">{savedPath}</span>
+            </p>
+          )}
 
           <div className="overflow-hidden rounded-md border border-[var(--color-border)]">
             <Suspense
@@ -82,11 +156,11 @@ export function Manifest() {
               <MonacoEditor
                 height="480px"
                 defaultLanguage="yaml"
-                defaultValue={SAMPLE_YAML}
+                value={yaml}
+                onChange={(v) => setYaml(v ?? "")}
                 theme="vs-dark"
                 options={{
                   minimap: { enabled: false },
-                  readOnly: true,
                   fontSize: 13,
                   scrollBeyondLastLine: false,
                   renderWhitespace: "selection",


### PR DESCRIPTION
## Summary

Three changes that retire 1d.1b's known caveats and unblock the demos workflow.

### 1. Monaco airgap fix

`@monaco-editor/react` default-loads Monaco from `cdn.jsdelivr.net` at runtime, breaking airgap deployments that ADR-031 §"Localhost-only" + the v1.0.0 CMMC posture demand.

New **`ui/src/lib/monaco-setup.ts`** imports the `monaco-editor` ESM bundle locally + registers it via `loader.config({ monaco })`, and wires Vite's `?worker` syntax to bundle Monaco's web workers as code-split chunks served from the embedded SPA.

The setup module is **dynamic-imported inside `Manifest.tsx`'s `lazy()` boundary** so Monaco's ~4 MB core stays out of the initial chunk — only the `/manifest` route pays it. Static-import would have leaked Monaco into Home/Models bundles and blown the initial budget by 4×.

### 2. Manifest save flow

Editor switches from read-only to editable; a **Save button** posts the current YAML buffer to a new **`POST /api/v1/manifests`** handler that writes `~/.config/aegis/manifests/draft.yaml`. **Sonner toasts** confirm success with the absolute path.

Validation is deliberately deferred — `aegis validate` lives in the Go binary (`cmd/aegis/`, ADR-002 split-language) and the Go ↔ Rust shell-out plumbing is its own sub-phase (1d.1d). Operators run `aegis validate ~/.config/aegis/manifests/draft.yaml` from the CLI after saving until 1d.1d ships live diagnostics.

### 3. demos/Dockerfile pnpm — closes #142

`npm install -g pnpm@10` so the `cargo build` that runs inside the demo renderer image can drive `crates/ui-server`'s `build.rs` without panicking on missing pnpm.

## Bundle sizes (gzipped)

- **Initial route (Home / Models): 120 KB** — under 250 KB budget.
- `/manifest` lazy chunk: **971 KB** (Monaco core + editor + language workers). Paid once per session then cached. Per-route cumulative > budget by design — Monaco bundling is a deliberate airgap trade-off.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude aegis-llama-backend --all-targets -- -D warnings` clean
- [x] `cargo test` (default members) — 7/7 ui-server tests still green
- [x] `pnpm typecheck` clean; `pnpm build` clean; chunk split confirms Monaco's 971 KB chunk only on `/manifest`
- [x] Manual smoke: `POST /api/v1/manifests` with test YAML body writes `~/.config/aegis/manifests/draft.yaml`; `cat` confirms contents
- [x] Manual smoke (browser): editor editable; Save → toast success; "last save → /root/…" trail visible; DevTools Network panel shows no `cdn.jsdelivr.net` requests on `/manifest`
- [ ] CI green (rust.yml + llama.yml + litertlm.yml — last patched in #141)
- [ ] CI green on demos.yml (path-filtered to `demos/**`; this PR touches `demos/Dockerfile` so it triggers — image cache invalidates, ~5 min rebuild)

## 1d.1d (next sub-phase)

- `POST /api/v1/manifests/validate` shelling out to Go `aegis validate`
- `monaco-yaml` for schema-aware autocomplete + inline Monaco markers from validate diagnostics
- `provenance.json` sidecar so Models page surfaces OCI ref non-null

Closes #142. Tracking: #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)