### PR TITLE
docs(templates): seed 5 evidence-anchored manifest templates for the Builder dropdown

### DIFF
--- a/examples/templates/manifests/README.md
+++ b/examples/templates/manifests/README.md
@@ -1,0 +1,122 @@
+# Manifest Builder Templates
+
+Curated starter manifests for the Phase 1d Community UI Manifest
+Builder ([ADR-031](../../../docs/adrs/031-community-webui-for-local-collaboration.md)).
+Each template is anchored in a documented operator pain point — public
+CVE, postmortem, or recurring forum complaint — and demonstrates how
+Aegis-Node's manifest schema closes that specific gap.
+
+## Why this directory exists
+
+Operators authoring a permission manifest from a blank YAML file is a
+recipe for misconfiguration. The community templates ship as concrete
+starting points: copy one, edit the paths and identity blocks, save.
+The Web UI's Manifest Builder reads this directory at build time and
+exposes the templates as a categorized dropdown.
+
+User-added templates live separately at
+`~/.config/aegis/manifests/templates/*.yaml` and are read at request
+time by `GET /api/v1/templates`. Same metadata convention, no special
+handling — drop a YAML file, the dropdown picks it up. To share a
+local template upstream, PR it into this directory.
+
+## Template metadata convention
+
+Each template starts with a structured comment block that the SPA
+parses into the dropdown card:
+
+```yaml
+# === Aegis-Node Manifest Template ===
+# id: <kebab-case-stable-id>
+# title: <human-readable name>
+# category: <Filesystem | Network/egress | Approval & destructive ops |
+#            MCP integrity | Database & SQL | Cost / runaway |
+#            Compliance | Multi-tenancy | Browser / RAG |
+#            Supply chain | Workflow>
+# difficulty: <starter | intermediate | advanced>
+# pain: <one-line problem statement + URL to source>
+# adrs: [<ADR numbers>]
+# ====================================
+#
+# <freeform docs about when an operator reaches for this template>
+
+schemaVersion: "1"
+# ...rest of the manifest...
+```
+
+The `=== Aegis-Node Manifest Template ===` delimiter is the
+parser's signal. Everything between it and the closing `===` line
+is structured metadata; below the closing delimiter is freeform
+documentation that the dropdown shows in a tooltip.
+
+The metadata fields are YAML comments only — they don't appear in
+the parsed manifest, so `aegis validate` ignores them. Operators
+who copy the YAML out of the editor get the full file (delimiters
+included); the comment block survives as inline documentation in
+their working copy.
+
+## Adding a template
+
+1. Copy an existing template that's closest to your scenario.
+2. Update the metadata block: new `id`, `title`, `category`,
+   `difficulty`, `pain` (with URL), and the relevant `adrs` list.
+3. Edit the manifest body — paths, MCP servers, write grants, etc.
+4. Run `aegis validate <your-template>.yaml` to confirm the
+   manifest parses and lints clean.
+5. PR the file to this directory.
+
+The pain-point citation is required, not optional. A template
+without a documented pain isn't a template — it's an example. The
+distinction matters because the dropdown's value is "here's a
+shape that defends against a real attack you've heard of." If
+the pain point is weak, ship it under [`examples/`](../../) as a
+full demo program instead.
+
+## Categories
+
+| Category | What it covers |
+|---|---|
+| Filesystem | `tools.filesystem.read` / `write` patterns; pre-validation against path traversal |
+| Network/egress | `tools.network.outbound` allowlists; egress quotas; SSRF defenses |
+| Approval & destructive ops | F3 approval gate + F7 write grants + exec wrappers for risky verbs |
+| MCP integrity | Defenses against MCP rug-pulls, tool poisoning, cross-tenant leaks |
+| Database & SQL | Read-only DB access via SQLite/Postgres MCP with verb-level allowlists |
+| Cost / runaway | Token/wallclock circuit breakers, quota schemas |
+| Compliance | CMMC / NIST 800-171 / FedRAMP-aligned manifest shapes |
+| Multi-tenancy | Tenant-scoped retrieval; per-tenant identity binding |
+| Browser / RAG | Web-automation agents; vector-store-aware authz |
+| Supply chain | Defenses against package hallucination, MCP supply-chain attacks |
+| Workflow | Session-forking, multi-model patterns |
+
+## Difficulty tiers
+
+- **starter** — a sane default for the most common shape; minimal
+  surface, deny-by-default, no advanced features. Ideal for an
+  operator's first manifest.
+- **intermediate** — composes 2–3 manifest features (e.g. MCP +
+  `pre_validate` + targeted network allowlist). Assumes familiarity
+  with the [F1–F10 control set](../../../docs/adrs/004-declarative-yaml-permission-manifest.md).
+- **advanced** — uses features at the boundary of v1.0.0 scope
+  (ADR-027 quotas, ADR-029 task-scoped grants, multi-turn caps).
+  May reference manifest fields that haven't shipped yet — mark
+  them clearly in the YAML and operators will see "not yet
+  implemented" warnings from `aegis validate`.
+
+## Phase 1d.1d UI integration
+
+The dropdown UI ships in sub-phase 1d.1d alongside the live
+`aegis validate` integration ([Phase 1d implementation
+plan](../../../docs/plans/v0.9.5-ui-implementation.md)). Until
+then, this directory is a reviewable artifact for operators —
+copy a template into your editor of choice and pair it with
+`aegis validate` from the CLI.
+
+## Related
+
+- [examples/](../../) — full demo programs (manifest + setup.sh +
+  README) for end-to-end scenarios. A template gets promoted to a
+  full example when it includes a runnable program.
+- [ADR-031](../../../docs/adrs/031-community-webui-for-local-collaboration.md)
+  — Community UI design including the templates dropdown
+- [ADR-024](../../../docs/adrs/024-mcp-args-prevalidation.md) —
+  `pre_validate` schema referenced by several templates

--- a/examples/templates/manifests/db-readonly-sql-explorer.yaml
+++ b/examples/templates/manifests/db-readonly-sql-explorer.yaml
@@ -1,0 +1,58 @@
+# === Aegis-Node Manifest Template ===
+# id: db-readonly-sql-explorer
+# title: Read-only SQL agent over SQLite MCP
+# category: Database & SQL
+# difficulty: starter
+# pain: Natural-language-to-SQL agents have caused production data
+#       loss when prompt-injected. LangChain's SQLDatabaseChain
+#       actually executed `DROP TABLE` from a user prompt
+#       (https://github.com/langchain-ai/langchain/issues/5923);
+#       resolution acknowledged that prompt-level guardrails alone
+#       are insufficient — the constraint must be enforced at the
+#       connection layer. Aegis enforces it at the MCP allowlist.
+# adrs: [018, 024]
+# ====================================
+#
+# Two layers, both deny-by-default:
+#   1. tools.mcp[].allowed_tools restricts the SQLite MCP to
+#      SELECT-shape verbs only. write_query, create_table,
+#      drop_table are deliberately omitted; closed-by-default
+#      denies them at the protocol layer regardless of what the
+#      upstream server advertises in its tools/list.
+#   2. tools.filesystem.write is absent — even if a write tool
+#      somehow leaked through, no path is grantable.
+#
+# Fork this for Postgres MCP, MySQL MCP, etc. The integrity
+# property (no DDL/DML) holds across SQL backends.
+
+schemaVersion: "1"
+agent:
+  name: "sql-explorer"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/sql-explorer/inst-001"
+tools:
+  filesystem:
+    read:
+      - "/path/to/your/database/dir"
+  network:
+    outbound: deny
+    inbound: deny
+  mcp:
+    - server_name: "sqlite"
+      server_uri: "stdio:uvx mcp-server-sqlite --db-path /path/to/your/database/data.db"
+      allowed_tools:
+        - "read_query"
+        - "list_tables"
+        - "describe_table"
+      # write_query / create_table / drop_table deliberately omitted.
+      # Closed-by-default at the MCP allowlist denies them regardless
+      # of what mcp-server-sqlite reports in its tools/list response.
+
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/examples/templates/manifests/destructive-shell-blocker.yaml
+++ b/examples/templates/manifests/destructive-shell-blocker.yaml
@@ -1,0 +1,69 @@
+# === Aegis-Node Manifest Template ===
+# id: destructive-shell-blocker
+# title: Shell-using agent with destructive-verb screening
+# category: Approval & destructive ops
+# difficulty: starter
+# pain: The Replit incident (July 2025) deleted a production
+#       database during an explicit code freeze
+#       (AI Incident DB #1152, Fortune coverage:
+#       https://fortune.com/2025/07/23/ai-coding-tool-replit-wiped-database-called-it-a-catastrophic-failure/).
+#       Cursor users have repeatedly reported the agent issuing
+#       `rm -rf ~`
+#       (https://forum.cursor.com/t/cursor-ai-executes-destructive-command-rm-rf-during-development-session/129401).
+#       This template scopes exec to a single operator-owned wrapper
+#       that screens argv before forwarding to the real shell.
+# adrs: [005, 009, 011]
+# ====================================
+#
+# The agent can call exactly ONE program: a wrapper script the
+# operator owns. The wrapper's job is to inspect argv for
+# destructive verbs (rm -rf, git reset --hard, DROP, TRUNCATE,
+# sudo, etc.) and refuse them before any real shell sees them.
+#
+# Sample wrapper implementations live under examples/ — fork
+# them, harden them, and pin the absolute path here. AEGIS003
+# refuses bare basenames precisely so a stray "/bin/rm" on PATH
+# can't accidentally match.
+#
+# Approval-gated writes catch any attempt to modify the wrapper
+# itself or scripts in the agent's workdir.
+
+schemaVersion: "1"
+agent:
+  name: "shell-agent"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/shell-agent/inst-001"
+tools:
+  filesystem:
+    read:
+      - "/path/to/your/workdir"
+    write:
+      - "/path/to/your/workdir/output"
+  network:
+    outbound: deny
+    inbound: deny
+
+# Single program. Absolute path binds to a specific binary;
+# AEGIS003 refuses bare basenames. The wrapper at this path is
+# operator-owned and screens argv for destructive verbs before
+# forwarding to the real shell.
+exec_grants:
+  - program: "/usr/local/bin/aegis-shell-wrapper"
+
+# F3 approval gate on writes. Even if the wrapper is somehow
+# tricked, modifying it (or any script in the workdir) requires
+# explicit human sign-off via the file or web channel.
+write_grants:
+  - resource: "/path/to/your/workdir/output"
+    actions: ["write"]
+    duration: "PT1H"
+    approval_required: true
+
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/examples/templates/manifests/github-scoped-token-agent.yaml
+++ b/examples/templates/manifests/github-scoped-token-agent.yaml
@@ -1,0 +1,69 @@
+# === Aegis-Node Manifest Template ===
+# id: github-scoped-token-agent
+# title: GitHub MCP agent with cross-repo read denied
+# category: MCP integrity
+# difficulty: intermediate
+# pain: Invariant Labs (May 2025) showed a malicious public-repo
+#       issue could prompt-inject the GitHub MCP into exfiltrating
+#       a private repo because the GitHub token spanned both
+#       (https://invariantlabs.ai/blog/mcp-github-vulnerability,
+#       Simon Willison summary
+#       https://simonwillison.net/2025/May/26/github-mcp-exploited/).
+# adrs: [018, 024]
+# ====================================
+#
+# Two-layer scope:
+#
+#   1. tools.mcp[].allowed_tools restricts the GitHub MCP to
+#      issue/PR comment operations only. Even if the attached
+#      token has private-repo scope, the agent literally cannot
+#      request the file-read or content-fetch tools — they're
+#      not in the allowlist.
+#
+#   2. tools.network.outbound pins egress to api.github.com. The
+#      agent can't be tricked into an out-of-band exfiltration
+#      to attacker.tld even via a tool that accidentally accepts
+#      arbitrary URLs.
+#
+# Pair with F3 approval gates on issue creation if the agent runs
+# in an environment where comment spam would be a concern. For
+# private-repo workflows, narrow the allowlist further.
+
+schemaVersion: "1"
+agent:
+  name: "github-issue-agent"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/github-issue-agent/inst-001"
+tools:
+  filesystem:
+    read: []
+  network:
+    outbound:
+      allowlist:
+        - host: "api.github.com"
+          port: 443
+          protocol: https
+    inbound: deny
+  mcp:
+    - server_name: "github"
+      server_uri: "stdio:npx -y @modelcontextprotocol/server-github"
+      # Read access to issues + PRs and the ability to comment.
+      # Critically: no get_file_contents, no list_branches, no
+      # clone. If the token attached to this MCP has broader
+      # scope (private repos, org secrets), this allowlist is
+      # the actual security boundary.
+      allowed_tools:
+        - "list_issues"
+        - "get_issue"
+        - "list_pull_requests"
+        - "get_pull_request"
+        - "add_issue_comment"
+
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/examples/templates/manifests/mcp-fs-traversal-hardened.yaml
+++ b/examples/templates/manifests/mcp-fs-traversal-hardened.yaml
@@ -1,0 +1,70 @@
+# === Aegis-Node Manifest Template ===
+# id: mcp-fs-traversal-hardened
+# title: MCP filesystem with traversal + symlink containment
+# category: MCP integrity
+# difficulty: intermediate
+# pain: CVE-2025-53109 — the official MCP filesystem server didn't
+#       resolve symlinks before its containment check, allowing
+#       escape from the allowlisted directory. Chained with
+#       mcp-server-git CVEs (68143/68144/68145) to reach RCE via a
+#       malicious .git/config
+#       (https://www.sentinelone.com/vulnerability-database/cve-2025-53109/,
+#       https://authzed.com/blog/timeline-mcp-breaches).
+# adrs: [018, 024]
+# ====================================
+#
+# Two independent layers protect the filesystem boundary:
+#
+#   1. tools.filesystem.read narrows the host-side view to one
+#      directory. Aegis canonicalizes the requested path and
+#      compares against this allowlist before any file open —
+#      symlinks pointing outside the prefix are rejected.
+#
+#   2. tools.mcp[].allowed_tools restricts which MCP verbs are
+#      callable. ADR-024 pre_validate then rewrites the call so
+#      the path arg is checked against tools.filesystem.read
+#      *before* the MCP server sees it.
+#
+# Combined effect: a malicious or tampered MCP server that
+# returns a misleading tools/list cannot reach files outside the
+# allowlist even if the operator forgot to update allowed_tools
+# after the server changed.
+
+schemaVersion: "1"
+agent:
+  name: "fs-agent-hardened"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/fs-agent-hardened/inst-001"
+tools:
+  filesystem:
+    read:
+      - "/path/to/your/data"
+  network:
+    outbound: deny
+    inbound: deny
+  mcp:
+    - server_name: "fs"
+      server_uri: "stdio:npx -y @modelcontextprotocol/server-filesystem /path/to/your/data"
+      allowed_tools:
+        - name: "read_text_file"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - name: "read_multiple_files"
+          pre_validate:
+            - kind: filesystem_read
+              arg_array: paths
+        - name: "list_directory"
+          pre_validate:
+            - kind: filesystem_read
+              arg: path
+        - "list_allowed_directories"
+
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0

--- a/examples/templates/manifests/read-only-file-analyzer.yaml
+++ b/examples/templates/manifests/read-only-file-analyzer.yaml
@@ -1,0 +1,41 @@
+# === Aegis-Node Manifest Template ===
+# id: read-only-file-analyzer
+# title: Read-only file analyzer
+# category: Filesystem
+# difficulty: starter
+# pain: An agent that needs to read files but never write them. Most
+#       common shape; baseline against which other patterns layer.
+#       Closed-by-default keeps everything else denied.
+# adrs: [007, 011]
+# ====================================
+#
+# Use this when an agent needs to summarize, extract, or answer
+# questions about files on disk and produce its output in the chat
+# reply (not by writing to disk). The single read path is the only
+# host-side capability the agent has — every write, every network
+# call, every exec is denied at the F2 enforcement layer.
+
+schemaVersion: "1"
+agent:
+  name: "file-analyzer"
+  version: "1.0.0"
+identity:
+  spiffeId: "spiffe://aegis-node.local/agent/file-analyzer/inst-001"
+tools:
+  filesystem:
+    read:
+      - "/path/to/your/data"
+    # No write block — closed-by-default per ADR-009 keeps every
+    # write denied. Add a write_grants block below if the agent
+    # needs to produce a file artifact.
+  network:
+    outbound: deny
+    inbound: deny
+
+inference:
+  determinism:
+    seed: 42
+    temperature: 0.0
+    top_p: 1.0
+    top_k: 0
+    repeat_penalty: 1.0


### PR DESCRIPTION
## Summary

First batch of curated starter manifests for the v0.9.5 Manifest Builder UI (ADR-031). Each template is anchored in a **documented operator pain point** — public CVE, postmortem, or recurring forum complaint — and demonstrates how Aegis-Node's manifest schema closes that specific gap.

Operators copy a template, edit the paths + identity blocks, save. The 1d.1d UI work renders these in a categorized dropdown.

## Templates (5)

| ID | Category | Difficulty | Pain anchor |
|---|---|---|---|
| `read-only-file-analyzer` | Filesystem | starter | — (baseline shape) |
| `db-readonly-sql-explorer` | Database & SQL | starter | [LangChain SQLDatabaseChain DROP TABLE](https://github.com/langchain-ai/langchain/issues/5923) |
| `destructive-shell-blocker` | Approval & destructive ops | starter | [Replit prod-DB wipe](https://incidentdatabase.ai/cite/1152/) + [Cursor `rm -rf ~`](https://forum.cursor.com/t/cursor-ai-executes-destructive-command-rm-rf-during-development-session/129401) |
| `mcp-fs-traversal-hardened` | MCP integrity | intermediate | [CVE-2025-53109](https://www.sentinelone.com/vulnerability-database/cve-2025-53109/) |
| `github-scoped-token-agent` | MCP integrity | intermediate | [Invariant Labs cross-repo leak](https://invariantlabs.ai/blog/mcp-github-vulnerability) |

## Convention (see `README.md`)

Each template starts with a structured comment block parseable by the SPA loader:

```yaml
# === Aegis-Node Manifest Template ===
# id: <kebab-case-id>
# title: <human-readable name>
# category: <Filesystem | Network/egress | …>
# difficulty: <starter | intermediate | advanced>
# pain: <one-liner + URL to public source>
# adrs: [<ADR numbers>]
# ====================================
```

Pain-point citation is **required**. A template without a documented pain isn't a template — it's an example. The distinction matters: the dropdown's value is "here's a shape that defends against a real attack you've heard of."

User-added templates live separately at `~/.config/aegis/manifests/templates/*.yaml` and read at request time by `GET /api/v1/templates`. Same convention, no special handling — drop a YAML file, the dropdown picks it up. To share upstream, PR it into this directory.

## Test plan

- [x] `aegis validate <each template>` returns 0 findings
- [x] Metadata block follows the documented convention consistently
- [x] Pain citations resolve to active URLs (CVE database, GitHub issue, blog post, Incident DB)
- [ ] Reviewer eyeballs each template's manifest body for correctness vs. the cited pain

## What's next

12 more evidence-anchored templates queued from external research — SSRF/IMDS, slopsquat, RAG cross-tenant leakage, browser credential passthrough, MCP rug-pull (`mcp-pinned-tool-digest`), LangGrinch CVE-2025-68664, runaway loop quotas, CMMC AU compliance. They land as follow-up PRs once this batch's metadata convention is reviewed.

The dropdown UI itself ships in 1d.1d alongside the live `aegis validate` integration.

Tracking: #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)