### PR TITLE
feat(ui, validate): live aegis validate integration with Monaco markers (sub-phase 1d.1d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower-http",
  "tracing",

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,20 @@ help: ## Show available targets
 
 build: build-go build-rust ## Build everything (Go + Rust)
 
-build-go:
+build-go: build-go-validate ## Build all Go binaries (writes bin/aegis-validate)
 	$(GO) build ./...
+
+# Build the Go control-plane CLI as `bin/aegis-validate` to avoid a
+# binary-name collision with the Rust `aegis` runtime CLI (per ADR-002,
+# both are called `aegis` from the source perspective). The Phase 1d
+# Manifest Builder UI (ADR-031) shells out to this binary for its
+# live `aegis validate` integration; the env var
+# `AEGIS_VALIDATE_BIN` overrides the lookup. Operators packaging
+# Aegis-Node should ship both binaries — the Rust runtime and the
+# Go validator — under their canonical names.
+build-go-validate: ## Build the Go validator as bin/aegis-validate
+	@mkdir -p bin
+	$(GO) build -o bin/aegis-validate ./cmd/aegis
 
 build-rust:
 	$(CARGO) build --workspace

--- a/crates/ui-server/Cargo.toml
+++ b/crates/ui-server/Cargo.toml
@@ -18,6 +18,7 @@ mime_guess = "2"
 rust-embed = { version = "8", features = ["debug-embed", "interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = "0.1"

--- a/crates/ui-server/src/handlers/mod.rs
+++ b/crates/ui-server/src/handlers/mod.rs
@@ -5,3 +5,4 @@ pub mod assets;
 pub mod health;
 pub mod manifests;
 pub mod models;
+pub mod validate;

--- a/crates/ui-server/src/handlers/validate.rs
+++ b/crates/ui-server/src/handlers/validate.rs
@@ -157,10 +157,7 @@ pub async fn validate_manifest(body: String) -> Response {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!(
-                "validator usage error (exit 2): {}",
-                stderr.trim()
-            ),
+            format!("validator usage error (exit 2): {}", stderr.trim()),
         )
             .into_response();
     }

--- a/crates/ui-server/src/handlers/validate.rs
+++ b/crates/ui-server/src/handlers/validate.rs
@@ -1,0 +1,337 @@
+//! `POST /api/v1/manifests/validate` — live `aegis validate` integration.
+//!
+//! Per [ADR-031](../../../docs/adrs/031-community-webui-for-local-collaboration.md)
+//! §"Visual manifest builder" the editor surfaces validate findings
+//! inline as the operator types. The validator itself lives in the
+//! Go binary (`cmd/aegis/`, ADR-002 split-language) — this handler
+//! is the cross-language bridge: it writes the request body to a
+//! tempfile, invokes the validator with `--format json`, parses the
+//! JSONL output, and returns a structured findings array the SPA
+//! renders as Monaco markers.
+//!
+//! ## Binary resolution
+//!
+//! Three strategies in order, first hit wins:
+//!
+//! 1. `AEGIS_VALIDATE_BIN` env var — absolute path. For test
+//!    fixtures + non-standard installs.
+//! 2. `./bin/aegis-validate` relative to the cwd — the workspace
+//!    development path that the `make build-go-validate` target
+//!    produces.
+//! 3. `aegis-validate` on `PATH` — the operator-installed name.
+//!
+//! Both Go and Rust source CLIs are named `aegis`; the
+//! `build-go-validate` Makefile target renames the Go output to
+//! `aegis-validate` so the ui-server can disambiguate without
+//! risking a recursive invocation of itself.
+//!
+//! ## Schema
+//!
+//! Validator JSON output (newline-delimited per `pkg/validate/format`):
+//!
+//! ```text
+//! {"file":"…","rule_id":"AEGIS007","severity":"warn","field":"tools.filesystem.write","message":"…","rationale":"…"}
+//! ```
+//!
+//! Line/col are 0 today — the validator's YAML AST hookup is a
+//! follow-up. The handler reserves `line` and `col` fields on the
+//! response anyway so the SPA's marker code Just Works once the
+//! validator emits them.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+const ENV_VALIDATE_BIN: &str = "AEGIS_VALIDATE_BIN";
+const DEV_BIN_PATH: &str = "bin/aegis-validate";
+const PATH_BIN_NAME: &str = "aegis-validate";
+
+/// One validator finding. Mirrors the on-disk JSONL record from
+/// `pkg/validate/format/format.go::jsonRecord` plus reserved
+/// `line` / `col` fields for the future YAML-AST hookup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Finding {
+    pub rule_id: String,
+    pub severity: String,
+    pub field: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rationale: Option<String>,
+    /// One-based line index in the validated YAML. Currently always
+    /// `0` until the validator's YAML AST hookup lands.
+    #[serde(default)]
+    pub line: u32,
+    /// One-based column index. Currently always `0`.
+    #[serde(default)]
+    pub col: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ValidateResponse {
+    /// True when the validator returned exit 0 — meaning no
+    /// `error`-severity findings. Warnings + info are non-fatal.
+    pub ok: bool,
+    /// All findings emitted by the validator. Deduplicated and
+    /// stable-sorted by `(severity, rule_id, field)`.
+    pub findings: Vec<Finding>,
+    /// Absolute path of the validator binary that produced these
+    /// findings. Surfaced in the SPA's "About" panel for
+    /// debuggability.
+    pub binary: String,
+}
+
+/// `POST /api/v1/manifests/validate` — body is YAML, returns
+/// validator findings.
+pub async fn validate_manifest(body: String) -> Response {
+    if body.is_empty() {
+        return (StatusCode::BAD_REQUEST, "empty body").into_response();
+    }
+
+    let bin = match resolve_validate_binary() {
+        Some(p) => p,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "validator not found. Install via `make build-go-validate` \
+                     (writes ./bin/aegis-validate), put `aegis-validate` on PATH, \
+                     or set the {ENV_VALIDATE_BIN} env var to an absolute binary path.",
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    let temp = match write_tempfile(&body) {
+        Ok(t) => t,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("staging tempfile: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    let output = match Command::new(&bin)
+        .args(["validate", "--format", "json"])
+        .arg(temp.path())
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invoking {}: {e}", bin.display()),
+            )
+                .into_response();
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let mut findings = match parse_findings(&stdout) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                target: "aegis_ui_server",
+                err = %e,
+                stdout_len = stdout.len(),
+                "validator output didn't parse as JSONL; returning empty findings",
+            );
+            Vec::new()
+        }
+    };
+    sort_findings(&mut findings);
+
+    // Validator exit codes (per cmd/aegis/validate.go):
+    //   0  no findings, or only info/warn findings
+    //   1  one or more SeverityError findings
+    //   2  usage error (we treat as 503 since it implies a bug
+    //      we mis-invoked the binary).
+    let exit_code = output.status.code().unwrap_or(-1);
+    if exit_code == 2 {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!(
+                "validator usage error (exit 2): {}",
+                stderr.trim()
+            ),
+        )
+            .into_response();
+    }
+
+    Json(ValidateResponse {
+        ok: exit_code == 0,
+        findings,
+        binary: bin.display().to_string(),
+    })
+    .into_response()
+}
+
+fn resolve_validate_binary() -> Option<PathBuf> {
+    if let Ok(env_path) = std::env::var(ENV_VALIDATE_BIN) {
+        let p = PathBuf::from(env_path);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+
+    if let Ok(cwd) = std::env::current_dir() {
+        let p = cwd.join(DEV_BIN_PATH);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+
+    which(PATH_BIN_NAME)
+}
+
+/// Walk `$PATH`, returning the first existing executable named
+/// `tool`. Mirrors `crates/cli/src/pull.rs::which` so the lookup
+/// semantics are consistent across the runtime.
+fn which(tool: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(tool);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn write_tempfile(body: &str) -> std::io::Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+    let mut f = tempfile::Builder::new()
+        .prefix("aegis-validate-")
+        .suffix(".yaml")
+        .tempfile()?;
+    f.write_all(body.as_bytes())?;
+    f.flush()?;
+    Ok(f)
+}
+
+/// Parse the validator's JSONL stdout into a `Vec<Finding>`. Empty
+/// input → empty vec. Per-line parse failures are collected into an
+/// error so callers can decide whether to surface a 500 or fall back
+/// to an empty list (the handler chooses the latter — a malformed
+/// finding shouldn't break the editor's live-validate loop).
+pub(crate) fn parse_findings(stdout: &str) -> Result<Vec<Finding>, String> {
+    let mut out = Vec::new();
+    for (n, line) in stdout.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<Finding>(trimmed) {
+            Ok(f) => out.push(f),
+            Err(e) => {
+                return Err(format!("line {}: {e} — raw: {trimmed}", n + 1));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn severity_rank(s: &str) -> u8 {
+    match s {
+        "error" => 0,
+        "warn" => 1,
+        "info" => 2,
+        _ => 3,
+    }
+}
+
+fn sort_findings(v: &mut [Finding]) {
+    v.sort_by(|a, b| {
+        severity_rank(&a.severity)
+            .cmp(&severity_rank(&b.severity))
+            .then_with(|| a.rule_id.cmp(&b.rule_id))
+            .then_with(|| a.field.cmp(&b.field))
+    });
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_JSONL: &str = concat!(
+        r#"{"file":"/tmp/m.yaml","rule_id":"AEGIS007","severity":"warn","field":"tools.filesystem.write","message":"broad write coverage","rationale":"explain"}"#,
+        "\n",
+        r#"{"file":"/tmp/m.yaml","rule_id":"AEGIS001","severity":"error","field":"identity","message":"missing spiffe id"}"#,
+        "\n",
+    );
+
+    #[test]
+    fn parses_jsonl_into_findings() {
+        let v = parse_findings(SAMPLE_JSONL).unwrap();
+        assert_eq!(v.len(), 2);
+        assert_eq!(v[0].rule_id, "AEGIS007");
+        assert_eq!(v[0].severity, "warn");
+        assert_eq!(v[1].rule_id, "AEGIS001");
+        assert_eq!(v[1].severity, "error");
+        assert!(v[0].rationale.is_some());
+        assert!(v[1].rationale.is_none());
+    }
+
+    #[test]
+    fn empty_stdout_is_empty_vec() {
+        assert!(parse_findings("").unwrap().is_empty());
+        assert!(parse_findings("\n\n").unwrap().is_empty());
+    }
+
+    #[test]
+    fn malformed_line_returns_error() {
+        let bad = "not json\n";
+        let err = parse_findings(bad).expect_err("must reject");
+        assert!(err.contains("line 1"));
+    }
+
+    #[test]
+    fn sorts_errors_before_warnings_before_info() {
+        let mut v = parse_findings(SAMPLE_JSONL).unwrap();
+        sort_findings(&mut v);
+        assert_eq!(v[0].severity, "error");
+        assert_eq!(v[1].severity, "warn");
+    }
+
+    #[test]
+    fn line_col_default_to_zero() {
+        let json = r#"{"rule_id":"X","severity":"warn","field":"f","message":"m"}"#;
+        let v = parse_findings(json).unwrap();
+        assert_eq!(v[0].line, 0);
+        assert_eq!(v[0].col, 0);
+    }
+
+    #[test]
+    fn resolve_uses_env_var_when_set() {
+        // Real binary path that exists on the system, just to test
+        // resolution logic. Use this binary itself.
+        let me = std::env::current_exe().unwrap();
+        std::env::set_var(ENV_VALIDATE_BIN, &me);
+        let resolved = resolve_validate_binary().expect("env path resolves");
+        assert_eq!(resolved, me);
+        std::env::remove_var(ENV_VALIDATE_BIN);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_path_when_env_invalid() {
+        std::env::set_var(ENV_VALIDATE_BIN, "/this/path/does/not/exist");
+        // The fallback chain may or may not find aegis-validate
+        // depending on the test environment; we just assert that
+        // setting an invalid env var doesn't return that invalid
+        // path.
+        let resolved = resolve_validate_binary();
+        if let Some(p) = resolved {
+            assert!(p.is_file(), "fallback returned non-file path: {p:?}");
+            assert_ne!(p, std::path::Path::new("/this/path/does/not/exist"));
+        }
+        std::env::remove_var(ENV_VALIDATE_BIN);
+    }
+}

--- a/crates/ui-server/src/lib.rs
+++ b/crates/ui-server/src/lib.rs
@@ -78,6 +78,10 @@ pub fn router(config: Config) -> Router {
             "/api/v1/manifests",
             post(handlers::manifests::save_manifest),
         )
+        .route(
+            "/api/v1/manifests/validate",
+            post(handlers::validate::validate_manifest),
+        )
         .fallback(handlers::assets::serve_embedded)
         .with_state(config)
 }

--- a/ui/src/lib/validate.ts
+++ b/ui/src/lib/validate.ts
@@ -1,0 +1,135 @@
+/**
+ * Live `aegis validate` integration for the Manifest Builder.
+ *
+ * Posts the editor's YAML buffer to `POST /api/v1/manifests/validate`,
+ * which shells out to the Go validator binary (per ADR-002 split-
+ * language) and returns a structured findings array. The hook
+ * defined here debounces edits, cancels in-flight requests when a
+ * newer edit arrives, and exposes a `findings` + `summary` shape
+ * the editor renders as Monaco markers.
+ *
+ * Validator semantics worth knowing:
+ *
+ *   - `severity` values: `"error"` | `"warn"` | `"info"`. Only
+ *     `error` causes `ok=false`; warnings + info are advisory.
+ *   - `line` and `col` are 0 today (the validator's YAML AST
+ *     hookup is a follow-up). Markers fall back to line 1 col 1
+ *     until the validator emits real positions.
+ *   - The `binary` field tells the operator which validator
+ *     produced the findings (env var override / dev path / PATH).
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+export type FindingSeverity = "error" | "warn" | "info" | string;
+
+export interface Finding {
+  rule_id: string;
+  severity: FindingSeverity;
+  field: string;
+  message: string;
+  rationale?: string;
+  line: number;
+  col: number;
+}
+
+export interface ValidateResponse {
+  ok: boolean;
+  findings: Finding[];
+  binary: string;
+}
+
+export interface ValidateSummary {
+  errors: number;
+  warnings: number;
+  infos: number;
+}
+
+export type ValidateState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; response: ValidateResponse; summary: ValidateSummary }
+  | { kind: "error"; message: string };
+
+export function tally(findings: Finding[]): ValidateSummary {
+  const out: ValidateSummary = { errors: 0, warnings: 0, infos: 0 };
+  for (const f of findings) {
+    if (f.severity === "error") out.errors++;
+    else if (f.severity === "warn") out.warnings++;
+    else if (f.severity === "info") out.infos++;
+  }
+  return out;
+}
+
+const DEFAULT_DEBOUNCE_MS = 400;
+
+/**
+ * React hook: validate `yaml` after the operator stops typing for
+ * `debounceMs` (default 400 ms). In-flight requests are cancelled
+ * when a newer edit arrives, preventing race conditions where a
+ * stale validate response overwrites the markers for current YAML.
+ */
+export function useValidate(
+  yaml: string,
+  options?: { debounceMs?: number; enabled?: boolean },
+): ValidateState {
+  const [state, setState] = useState<ValidateState>({ kind: "idle" });
+  const debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const enabled = options?.enabled ?? true;
+
+  const inflightRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (yaml.trim().length === 0) {
+      setState({ kind: "idle" });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      // Cancel any prior request before starting the next one.
+      inflightRef.current?.abort();
+      const controller = new AbortController();
+      inflightRef.current = controller;
+
+      setState({ kind: "loading" });
+
+      fetch("/api/v1/manifests/validate", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-yaml" },
+        body: yaml,
+        signal: controller.signal,
+      })
+        .then(async (r) => {
+          if (!r.ok) {
+            const text = await r.text().catch(() => `HTTP ${r.status}`);
+            throw new Error(text || `HTTP ${r.status}`);
+          }
+          return (await r.json()) as ValidateResponse;
+        })
+        .then((response) => {
+          if (controller.signal.aborted) return;
+          setState({
+            kind: "ready",
+            response,
+            summary: tally(response.findings),
+          });
+        })
+        .catch((e: unknown) => {
+          if (controller.signal.aborted) return;
+          // AbortError surfaces here too; ignore those.
+          if (e instanceof DOMException && e.name === "AbortError") return;
+          setState({
+            kind: "error",
+            message: e instanceof Error ? e.message : String(e),
+          });
+        });
+    }, debounceMs);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [yaml, debounceMs, enabled]);
+
+  return state;
+}

--- a/ui/src/pages/Manifest.tsx
+++ b/ui/src/pages/Manifest.tsx
@@ -1,9 +1,11 @@
-import { lazy, Suspense, useEffect, useState } from "react";
-import { FileCode, Save } from "lucide-react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
+import type * as Monaco from "monaco-editor";
+import { CircleAlert, FileCode, Info, Save, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { TemplatePicker } from "@/components/TemplatePicker";
 import type { Template } from "@/templates/types";
+import { useValidate, type ValidateState } from "@/lib/validate";
 
 // Locally-bundled Monaco. The dynamic imports below — `monaco-setup`
 // (which pulls in `monaco-editor` + the worker `?worker` chunks) and
@@ -23,7 +25,7 @@ const MonacoEditor = lazy(async () => {
 const FALLBACK_YAML = `# Aegis-Node permission manifest.
 # Load a curated template from the dropdown above to get started, or
 # hand-author here. Save writes the file the CLI consumes; live
-# \`aegis validate\` diagnostics land in sub-phase 1d.1d.
+# \`aegis validate\` diagnostics render inline as you type.
 
 schemaVersion: "1"
 agent:
@@ -54,6 +56,13 @@ interface SaveResponse {
   bytes: number;
 }
 
+/**
+ * Diagnostic owner string — Monaco scopes markers per (model URI,
+ * owner). Using a stable owner means subsequent validate runs
+ * REPLACE prior markers cleanly rather than accumulating.
+ */
+const VALIDATE_MARKER_OWNER = "aegis-validate";
+
 export function Manifest() {
   const [yaml, setYaml] = useState<string>(FALLBACK_YAML);
   const [activeTemplateId, setActiveTemplateId] = useState<string | null>(
@@ -63,9 +72,54 @@ export function Manifest() {
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
 
+  const validateState = useValidate(yaml);
+
+  // Hold a ref to the underlying Monaco editor instance so the
+  // marker-applying effect can call setModelMarkers on the active
+  // model. The ref is set in onMount; it stays stable across re-
+  // renders and survives hot-reload during dev.
+  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
+  const monacoRef = useRef<typeof Monaco | null>(null);
+
   useEffect(() => {
     setDirty(yaml !== FALLBACK_YAML || savedPath !== null);
   }, [yaml, savedPath]);
+
+  // Apply the latest validate findings as Monaco markers. Runs
+  // every time validateState transitions; clears markers on idle
+  // / loading / error so stale diagnostics don't linger when the
+  // operator's still typing.
+  useEffect(() => {
+    const editor = editorRef.current;
+    const monaco = monacoRef.current;
+    if (!editor || !monaco) return;
+    const model = editor.getModel();
+    if (!model) return;
+
+    if (validateState.kind !== "ready") {
+      monaco.editor.setModelMarkers(model, VALIDATE_MARKER_OWNER, []);
+      return;
+    }
+
+    const markers = validateState.response.findings.map((f) => {
+      // Validator emits 0/0 today; fall back to highlighting line 1
+      // until the YAML AST hookup ships precise positions.
+      const startLine = f.line > 0 ? f.line : 1;
+      const startCol = f.col > 0 ? f.col : 1;
+      return {
+        severity: monacoSeverity(monaco, f.severity),
+        startLineNumber: startLine,
+        startColumn: startCol,
+        endLineNumber: startLine,
+        endColumn: startCol + Math.max(f.field.length, 1),
+        message: `[${f.rule_id}] ${f.message}${
+          f.rationale ? `\n\n${f.rationale}` : ""
+        }`,
+        source: "aegis validate",
+      };
+    });
+    monaco.editor.setModelMarkers(model, VALIDATE_MARKER_OWNER, markers);
+  }, [validateState]);
 
   function handleTemplateSelect(t: Template) {
     setYaml(t.yaml);
@@ -111,11 +165,12 @@ export function Manifest() {
             <p className="text-sm text-muted">
               Pick a curated starter, edit, save · live{" "}
               <code className="font-mono text-accent">aegis validate</code>{" "}
-              diagnostics land in 1d.1d
+              diagnostics render as you type
             </p>
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <ValidateStatus state={validateState} />
           <TemplatePicker onSelect={handleTemplateSelect} />
           <button
             type="button"
@@ -146,8 +201,7 @@ export function Manifest() {
           <p className="mb-4 text-sm text-muted">
             Monaco editor served from the embedded SPA bundle (no CDN). Each
             curated template ships with a metadata block + pain-point citation
-            anchored in a documented incident (CVE, postmortem, forum
-            thread); source files live at{" "}
+            anchored in a documented incident; source files live at{" "}
             <code className="font-mono text-accent">
               examples/templates/manifests/
             </code>
@@ -181,6 +235,10 @@ export function Manifest() {
                 defaultLanguage="yaml"
                 value={yaml}
                 onChange={(v) => setYaml(v ?? "")}
+                onMount={(editor, monaco) => {
+                  editorRef.current = editor;
+                  monacoRef.current = monaco;
+                }}
                 theme="vs-dark"
                 options={{
                   minimap: { enabled: false },
@@ -191,8 +249,136 @@ export function Manifest() {
               />
             </Suspense>
           </div>
+
+          <ValidateFindings state={validateState} />
         </CardContent>
       </Card>
     </>
+  );
+}
+
+function monacoSeverity(
+  monaco: typeof Monaco,
+  severity: string,
+): Monaco.MarkerSeverity {
+  switch (severity) {
+    case "error":
+      return monaco.MarkerSeverity.Error;
+    case "warn":
+      return monaco.MarkerSeverity.Warning;
+    case "info":
+      return monaco.MarkerSeverity.Info;
+    default:
+      return monaco.MarkerSeverity.Hint;
+  }
+}
+
+function ValidateStatus({ state }: { state: ValidateState }) {
+  if (state.kind === "idle") {
+    return (
+      <span className="inline-flex items-center font-mono text-xs text-muted">
+        validate idle
+      </span>
+    );
+  }
+  if (state.kind === "loading") {
+    return (
+      <span className="inline-flex items-center font-mono text-xs text-muted">
+        validating…
+      </span>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 font-mono text-xs text-red-400"
+        title={state.message}
+      >
+        <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />
+        validator error
+      </span>
+    );
+  }
+  const { errors, warnings, infos } = state.summary;
+  if (errors === 0 && warnings === 0 && infos === 0) {
+    return (
+      <span className="inline-flex items-center font-mono text-xs text-emerald-400">
+        ✓ clean
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-2 font-mono text-xs">
+      {errors > 0 && (
+        <span className="inline-flex items-center gap-1 text-red-400">
+          <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />
+          {errors} error{errors === 1 ? "" : "s"}
+        </span>
+      )}
+      {warnings > 0 && (
+        <span className="inline-flex items-center gap-1 text-amber-300">
+          <TriangleAlert className="h-3.5 w-3.5" aria-hidden="true" />
+          {warnings} warn{warnings === 1 ? "" : "s"}
+        </span>
+      )}
+      {infos > 0 && (
+        <span className="inline-flex items-center gap-1 text-sky-300">
+          <Info className="h-3.5 w-3.5" aria-hidden="true" />
+          {infos} info
+        </span>
+      )}
+    </span>
+  );
+}
+
+function ValidateFindings({ state }: { state: ValidateState }) {
+  if (state.kind === "error") {
+    return (
+      <div className="mt-4 rounded-md border border-amber-700 bg-amber-950/40 p-3 text-xs">
+        <p className="mb-1 font-semibold text-amber-200">
+          Live validate unavailable
+        </p>
+        <p className="font-mono text-amber-200/70">{state.message}</p>
+        <p className="mt-2 text-amber-200/70">
+          Install via{" "}
+          <code className="font-mono">make build-go-validate</code>, put{" "}
+          <code className="font-mono">aegis-validate</code> on PATH, or set the{" "}
+          <code className="font-mono">AEGIS_VALIDATE_BIN</code> env var.
+        </p>
+      </div>
+    );
+  }
+  if (state.kind !== "ready" || state.response.findings.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="mt-4 space-y-2">
+      {state.response.findings.map((f, i) => (
+        <li
+          key={`${f.rule_id}-${f.field}-${i}`}
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-3 text-xs"
+        >
+          <div className="mb-1 flex items-baseline gap-2">
+            <span
+              className={
+                f.severity === "error"
+                  ? "font-mono text-red-400"
+                  : f.severity === "warn"
+                    ? "font-mono text-amber-300"
+                    : "font-mono text-sky-300"
+              }
+            >
+              {f.severity}
+            </span>
+            <span className="font-mono text-accent">{f.rule_id}</span>
+            <span className="font-mono text-muted">{f.field}</span>
+          </div>
+          <p className="text-[var(--color-fg)]">{f.message}</p>
+          {f.rationale && (
+            <p className="mt-1 text-muted">{f.rationale}</p>
+          )}
+        </li>
+      ))}
+    </ul>
   );
 }


### PR DESCRIPTION
## Summary

Closes the loop on **ADR-031 §"Visual manifest builder"** — operators edit YAML in the Manifest Builder, the editor shows linter findings inline as red/yellow/blue squiggles with full rule + rationale on hover. Header shows per-severity counts (`✓ clean` / `N errors` / `N warns` / `N info`).

## Architecture: Go ↔ Rust shell-out

The validator lives in the Go binary (`cmd/aegis/`, ADR-002 split-language); the ui-server is the Rust runtime CLI. Both source trees produce binaries called `aegis`. New `make build-go-validate` target renames the Go output to `bin/aegis-validate` so the ui-server can disambiguate without recursive invocation of itself.

Binary resolution order:
1. `$AEGIS_VALIDATE_BIN` env var (absolute path; for tests + non-standard installs)
2. `./bin/aegis-validate` relative to cwd (dev workflow)
3. `aegis-validate` on `PATH` (operator install)

Returns **503 with an actionable install hint** if none resolves.

## Backend changes

- `crates/ui-server/src/handlers/validate.rs` — `POST /api/v1/manifests/validate`. Writes body to tempfile, runs `aegis-validate validate --format json <path>`, parses JSONL stdout into `Vec<Finding>`, sorts by severity → rule_id → field, returns `{ ok, findings, binary }`. `ok=true` means exit 0 (no error-severity findings).
- 6 new unit tests: JSONL parser, severity sort, empty/malformed input, env-var resolution, PATH fallback. **`cargo test -p aegis-ui-server`: 14/14 pass.**
- Reserves `line` + `col` fields for when the validator's YAML AST hookup ships precise positions; today both default to 0 and the SPA falls back to highlighting line 1.

## Frontend changes

- `ui/src/lib/validate.ts` — `useValidate(yaml)` React hook. 400ms debounce, `AbortController`-based cancellation when newer edits arrive, `ValidateState` union (idle/loading/ready/error).
- `ui/src/pages/Manifest.tsx` — `onMount` captures the Monaco instance into a ref; an effect syncs findings → `monaco.editor.setModelMarkers` with stable owner so prior markers replace cleanly. Header gets a `ValidateStatus` pill, below the editor a `ValidateFindings` list with full rationale.
- Graceful fallback: validator unavailable → amber banner with install hint, no blocking.

## Verification

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude aegis-llama-backend --all-targets -- -D warnings` clean
- [x] `cargo test -p aegis-ui-server`: 14/14 (10 unit + 4 integration)
- [x] `pnpm typecheck` + `pnpm build` clean; bundle 130 KB gzipped (was 128 KB; +2 KB for the validate hook + status UI)
- [x] Manual smoke: clean YAML returns 0 findings; broad-write YAML returns AEGIS007 warning; editor renders yellow squiggles inline; header shows "1 warn"
- [ ] CI green

## What's next (1d.1e queued)

- `monaco-yaml` for schema-aware autocomplete (needs generating a JSON Schema from `crates/policy::manifest`)
- `provenance.json` sidecar so Models page surfaces non-null `oci_ref`
- Validator YAML AST hookup so `line`/`col` emit real positions (then markers point at the offending field, not just line 1)

Tracking: #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)