### PR TITLE
feat(pull, ui): provenance.json sidecar + cosign verification in Model Library (sub-phase 1d.1e)

### DIFF
--- a/crates/cli/src/pull.rs
+++ b/crates/cli/src/pull.rs
@@ -573,8 +573,7 @@ pub fn write_provenance(dir: &Path, prov: &Provenance) -> Result<()> {
     use std::io::Write;
     tmp.write_all(&json)?;
     tmp.flush()?;
-    tmp.persist(&target)
-        .map_err(|e| PullError::Io(e.error))?;
+    tmp.persist(&target).map_err(|e| PullError::Io(e.error))?;
     Ok(())
 }
 
@@ -937,9 +936,7 @@ mod tests {
             pulled_at: "2026-05-07T00:00:00.000Z".to_string(),
         };
         write_provenance(dir.path(), &prov).expect("write");
-        let read_back = read_provenance(dir.path())
-            .expect("read")
-            .expect("present");
+        let read_back = read_provenance(dir.path()).expect("read").expect("present");
         assert_eq!(read_back, prov);
     }
 

--- a/crates/cli/src/pull.rs
+++ b/crates/cli/src/pull.rs
@@ -54,9 +54,93 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::SystemTime;
 
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+/// Filename of the per-pull provenance sidecar written into the
+/// model cache directory by [`pull`]. Captures the OCI ref + cosign
+/// verification configuration + pull timestamp so the WebUI's Model
+/// Library (per [ADR-032](../../docs/adrs/032-webui-model-library-and-session-forking.md))
+/// can surface "verified by …" for each cached model without
+/// re-running cosign or re-parsing the registry manifest. Cache
+/// entries from before this sidecar was introduced fall back to
+/// the older `ref.txt` for `oci_ref` only — no cosign metadata.
+pub const PROVENANCE_FILENAME: &str = "provenance.json";
+
+/// Schema version for [`Provenance`]. Bumped when the on-disk format
+/// changes incompatibly. Readers (the ui-server's Models handler)
+/// MUST reject unknown major versions rather than silently misread.
+pub const PROVENANCE_SCHEMA_VERSION: u32 = 1;
+
+/// On-disk record written next to each cached model's `blob.bin`.
+/// Persists the verification context [`pull`] established so that
+/// downstream consumers — the WebUI Model Library, future evidence-
+/// pack generators — don't need to re-run cosign or contact the
+/// registry to know how the blob got here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Provenance {
+    /// Format version. Currently always [`PROVENANCE_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Canonical OCI reference the operator pulled (with `@sha256:` pin).
+    pub oci_ref: String,
+    /// Manifest digest extracted from the reference. Same value as
+    /// the cache subdirectory name; included here so the file is
+    /// self-describing without requiring path-context to read.
+    pub manifest_digest: String,
+    /// SHA-256 of `blob.bin`, lowercase hex. Equals
+    /// [`PulledArtifact::sha256_hex`] at write time.
+    pub blob_sha256: String,
+    /// Optional chat-template hash extracted from the cosign-covered
+    /// manifest annotation `dev.aegis-node.chat-template.sha256`.
+    /// `None` for non-model artifacts.
+    pub chat_template_sha256: Option<String>,
+    /// How cosign verified the manifest signature.
+    pub cosign: CosignVerification,
+    /// RFC3339 UTC timestamp at which the pull completed. Useful for
+    /// the Model Library's "last used" / "pulled at" columns and for
+    /// evidence-pack generation later.
+    pub pulled_at: String,
+}
+
+/// The cosign-verification configuration that succeeded at pull
+/// time. `verified` is always `true` in a written provenance file —
+/// [`pull`] only writes the sidecar after cosign returned exit 0.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CosignVerification {
+    /// Whether cosign verification succeeded. Always `true` in a
+    /// written sidecar (failed pulls never reach the persist step).
+    /// Kept as a field so future consumers can pattern-match
+    /// without inferring from the file's mere existence.
+    pub verified: bool,
+    /// Verification mode used: keyed (operator-supplied public key)
+    /// or keyless (Sigstore Fulcio + Rekor).
+    pub mode: CosignMode,
+    /// Path to the operator-supplied public key, if the keyed mode
+    /// was used. `None` for keyless.
+    pub key_path: Option<String>,
+    /// Identity-regex constraint passed to cosign in keyless mode
+    /// (`--certificate-identity-regexp`). `None` for keyed.
+    pub keyless_identity_pattern: Option<String>,
+    /// OIDC-issuer-regex constraint passed to cosign in keyless mode
+    /// (`--certificate-oidc-issuer-regexp`). `None` for keyed.
+    pub keyless_oidc_issuer_pattern: Option<String>,
+}
+
+/// Cosign verification mode. Kept as a separate enum (rather than an
+/// `Option<KeyPath>` union) so the JSON shape names the choice
+/// explicitly — auditors reading the sidecar see "keyless" rather
+/// than inferring it from a missing field.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CosignMode {
+    /// Keyed verification — `--cosign-key <path>` was supplied.
+    Key,
+    /// Keyless verification — Sigstore Fulcio + Rekor (the default).
+    Keyless,
+}
 
 /// OCI media type for a single-blob GGUF model artifact published by
 /// Aegis-Node's `models-publish.yml` (per ADR-021). Publishers that use
@@ -416,12 +500,146 @@ pub fn pull(reference: &str, cfg: &PullConfig) -> Result<PulledArtifact> {
     }
     std::fs::rename(&blob, &target_blob)?;
 
+    // Persist provenance LAST — its presence implies the blob and
+    // every other sidecar are in place. Downstream readers (the
+    // ui-server's Models handler per ADR-032) treat a missing
+    // provenance.json as "legacy cache entry" and fall back to
+    // ref.txt; partial-write recovery scans treat its absence as
+    // "incomplete pull, needs cleanup."
+    let provenance = Provenance {
+        schema_version: PROVENANCE_SCHEMA_VERSION,
+        oci_ref: parsed.canonical(),
+        manifest_digest: parsed.sha256_hex.clone(),
+        blob_sha256: blob_sha256_hex.clone(),
+        chat_template_sha256: chat_template_sha256_hex.clone(),
+        cosign: cosign_record(cfg),
+        pulled_at: rfc3339_now(),
+    };
+    write_provenance(&target_dir, &provenance)?;
+
     Ok(PulledArtifact {
         reference: parsed.clone(),
         blob_path: target_blob,
         sha256_hex: blob_sha256_hex,
         chat_template_sha256_hex,
     })
+}
+
+/// Build the [`CosignVerification`] record from the operator's
+/// [`PullConfig`]. Verified is hardcoded to `true` because we only
+/// reach this code path after [`run_cosign_verify`] returned exit 0.
+fn cosign_record(cfg: &PullConfig) -> CosignVerification {
+    if let Some(key) = &cfg.cosign_key {
+        CosignVerification {
+            verified: true,
+            mode: CosignMode::Key,
+            key_path: Some(key.display().to_string()),
+            keyless_identity_pattern: None,
+            keyless_oidc_issuer_pattern: None,
+        }
+    } else {
+        CosignVerification {
+            verified: true,
+            mode: CosignMode::Keyless,
+            key_path: None,
+            // Match the regex-default fallbacks used in
+            // `run_cosign_verify` so the recorded values reflect
+            // exactly what cosign was told.
+            keyless_identity_pattern: Some(
+                cfg.keyless_identity
+                    .clone()
+                    .unwrap_or_else(|| ".*".to_string()),
+            ),
+            keyless_oidc_issuer_pattern: Some(
+                cfg.keyless_oidc_issuer
+                    .clone()
+                    .unwrap_or_else(|| ".*".to_string()),
+            ),
+        }
+    }
+}
+
+/// Atomically write a [`Provenance`] record into the cache dir.
+/// Uses a temp-file-and-rename so a partial write never produces a
+/// truncated `provenance.json`.
+pub fn write_provenance(dir: &Path, prov: &Provenance) -> Result<()> {
+    let target = dir.join(PROVENANCE_FILENAME);
+    let json = serde_json::to_vec_pretty(prov)
+        .map_err(|e| PullError::Io(std::io::Error::other(format!("serialize provenance: {e}"))))?;
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".provenance.")
+        .suffix(".tmp")
+        .tempfile_in(dir)?;
+    use std::io::Write;
+    tmp.write_all(&json)?;
+    tmp.flush()?;
+    tmp.persist(&target)
+        .map_err(|e| PullError::Io(e.error))?;
+    Ok(())
+}
+
+/// Read + validate the provenance sidecar from a cache dir. Returns
+/// `Ok(None)` for a legacy entry that doesn't have one, `Err` only
+/// for genuine I/O / parse failures. Schema-version mismatch is an
+/// error — readers shouldn't try to interpret an unknown major.
+pub fn read_provenance(dir: &Path) -> Result<Option<Provenance>> {
+    let path = dir.join(PROVENANCE_FILENAME);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(PullError::Io(e)),
+    };
+    let prov: Provenance = serde_json::from_slice(&bytes).map_err(|e| {
+        PullError::Io(std::io::Error::other(format!(
+            "parsing {}: {e}",
+            path.display(),
+        )))
+    })?;
+    if prov.schema_version != PROVENANCE_SCHEMA_VERSION {
+        return Err(PullError::Io(std::io::Error::other(format!(
+            "{} schema_version={} unsupported (expected {})",
+            path.display(),
+            prov.schema_version,
+            PROVENANCE_SCHEMA_VERSION,
+        ))));
+    }
+    Ok(Some(prov))
+}
+
+/// RFC3339 timestamp without pulling in `chrono`. Uses the same
+/// pure-stdlib civil-from-days conversion that
+/// `crates/ui-server/src/handlers/models.rs` uses; kept independent
+/// here so pull.rs has no cross-crate timestamp dep.
+fn rfc3339_now() -> String {
+    let dur = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs() as i64;
+    let nanos = dur.subsec_nanos();
+    naive_rfc3339_from_unix(secs, nanos)
+}
+
+fn naive_rfc3339_from_unix(secs: i64, nanos: u32) -> String {
+    const SECONDS_PER_DAY: i64 = 86_400;
+    let days = secs.div_euclid(SECONDS_PER_DAY);
+    let time_of_day = secs.rem_euclid(SECONDS_PER_DAY);
+    let hh = time_of_day / 3600;
+    let mm = (time_of_day % 3600) / 60;
+    let ss = time_of_day % 60;
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!(
+        "{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}.{millis:03}Z",
+        millis = nanos / 1_000_000,
+    )
 }
 
 /// Read the chat-template sidecar from a populated cache dir, if it
@@ -698,6 +916,91 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, PullError::BadRef { .. }), "{err}");
+    }
+
+    #[test]
+    fn provenance_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let prov = Provenance {
+            schema_version: PROVENANCE_SCHEMA_VERSION,
+            oci_ref: "ghcr.io/x/m@sha256:abc".to_string(),
+            manifest_digest: "abc".to_string(),
+            blob_sha256: "deadbeef".to_string(),
+            chat_template_sha256: Some("cafef00d".to_string()),
+            cosign: CosignVerification {
+                verified: true,
+                mode: CosignMode::Keyless,
+                key_path: None,
+                keyless_identity_pattern: Some(".*".to_string()),
+                keyless_oidc_issuer_pattern: Some(".*".to_string()),
+            },
+            pulled_at: "2026-05-07T00:00:00.000Z".to_string(),
+        };
+        write_provenance(dir.path(), &prov).expect("write");
+        let read_back = read_provenance(dir.path())
+            .expect("read")
+            .expect("present");
+        assert_eq!(read_back, prov);
+    }
+
+    #[test]
+    fn read_provenance_returns_none_for_legacy_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        // No file written — simulates a cache entry from before the
+        // sidecar was introduced.
+        assert!(read_provenance(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_provenance_rejects_unknown_schema_version() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(PROVENANCE_FILENAME),
+            r#"{"schema_version":99,"oci_ref":"x","manifest_digest":"x","blob_sha256":"x","chat_template_sha256":null,"cosign":{"verified":true,"mode":"keyless","key_path":null,"keyless_identity_pattern":".*","keyless_oidc_issuer_pattern":".*"},"pulled_at":"2026-05-07T00:00:00.000Z"}"#,
+        )
+        .unwrap();
+        let err = read_provenance(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("schema_version=99"));
+    }
+
+    #[test]
+    fn cosign_record_keyless_defaults_to_dotstar_patterns() {
+        let cfg = PullConfig {
+            cache_dir: PathBuf::from("/tmp"),
+            cosign_key: None,
+            keyless_identity: None,
+            keyless_oidc_issuer: None,
+        };
+        let rec = cosign_record(&cfg);
+        assert!(rec.verified);
+        assert_eq!(rec.mode, CosignMode::Keyless);
+        assert_eq!(rec.keyless_identity_pattern.as_deref(), Some(".*"));
+        assert_eq!(rec.keyless_oidc_issuer_pattern.as_deref(), Some(".*"));
+        assert!(rec.key_path.is_none());
+    }
+
+    #[test]
+    fn cosign_record_keyed_passes_through_key_path() {
+        let cfg = PullConfig {
+            cache_dir: PathBuf::from("/tmp"),
+            cosign_key: Some(PathBuf::from("/etc/cosign/team.pub")),
+            keyless_identity: None,
+            keyless_oidc_issuer: None,
+        };
+        let rec = cosign_record(&cfg);
+        assert_eq!(rec.mode, CosignMode::Key);
+        assert_eq!(rec.key_path.as_deref(), Some("/etc/cosign/team.pub"));
+        assert!(rec.keyless_identity_pattern.is_none());
+        assert!(rec.keyless_oidc_issuer_pattern.is_none());
+    }
+
+    #[test]
+    fn rfc3339_now_has_canonical_shape() {
+        let s = rfc3339_now();
+        // YYYY-MM-DDTHH:MM:SS.mmmZ → 24 chars, ends with Z, has T at index 10.
+        assert_eq!(s.len(), 24, "got: {s}");
+        assert!(s.ends_with('Z'));
+        assert_eq!(&s[10..11], "T");
     }
 
     #[test]

--- a/crates/ui-server/src/handlers/models.rs
+++ b/crates/ui-server/src/handlers/models.rs
@@ -10,26 +10,90 @@
 //! ```text
 //! ~/.cache/aegis/models/
 //!   <sha256_hex>/
-//!     <model artifact files>
-//!     chat_template.sha256.txt   (optional sidecar)
+//!     blob.bin
+//!     ref.txt                    (canonical OCI ref)
+//!     sha256.txt                 (blob's actual SHA-256)
+//!     chat_template.sha256.txt   (optional)
+//!     provenance.json            (optional — present for pulls
+//!                                 from sub-phase 1d.1e onward)
 //! ```
 //!
-//! Sub-phase 1d.1b ships read-only enumeration only. The "Add model"
-//! flow that wraps `pull::pull` over WebSocket lands in 1d.1c.
+//! ### `oci_ref` resolution
 //!
-//! ### Future-work notes
+//! Two-tier fallback so the Models page surfaces a usable ref for
+//! every cached model regardless of when it was pulled:
 //!
-//! - The OCI ref the operator originally pulled with isn't preserved
-//!   in the cache today (only the digest is). 1d.1c will add a
-//!   `provenance.json` sidecar capturing the source ref + cosign
-//!   verification result so this handler can surface
-//!   `oci_ref` non-null. Until then, `oci_ref` is always null.
+//! 1. **`provenance.json`** — full record (oci_ref + cosign config +
+//!    pulled_at timestamp). Written by `crates/cli/src/pull.rs::pull`
+//!    after a successful pull.
+//! 2. **`ref.txt`** — canonical OCI ref only. Predates the
+//!    provenance sidecar; legacy cache entries always have it.
+//!
+//! If neither is present, the model is reported with `oci_ref: null`
+//! (an unusual cache state — manually staged blob without sidecars).
 
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use axum::Json;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+/// Schema version for the `provenance.json` sidecar this handler
+/// reads. Mirrors `crates/cli/src/pull.rs::PROVENANCE_SCHEMA_VERSION`
+/// — the format is the cross-crate contract. Bumping requires editing
+/// both files in lockstep.
+const PROVENANCE_SCHEMA_VERSION: u32 = 1;
+
+/// Read-side mirror of `crates/cli/src/pull.rs::Provenance`. The two
+/// types are intentionally duplicated rather than shared via a
+/// crate dep — `aegis-cli` already depends on `aegis-ui-server`,
+/// so the reverse would be a circular dep. The JSON schema is the
+/// contract; field names + serde renames must match.
+#[derive(Debug, Deserialize)]
+struct ProvenanceFile {
+    schema_version: u32,
+    oci_ref: String,
+    #[serde(default)]
+    cosign: Option<CosignFile>,
+    #[serde(default)]
+    pulled_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CosignFile {
+    verified: bool,
+    mode: String,
+    #[serde(default)]
+    keyless_identity_pattern: Option<String>,
+    #[serde(default)]
+    keyless_oidc_issuer_pattern: Option<String>,
+    #[serde(default)]
+    key_path: Option<String>,
+}
+
+/// Cosign verification context surfaced to the SPA. Distilled from
+/// the on-disk `provenance.json::cosign` block; the SPA renders
+/// "verified · keyless ⟨pattern⟩" / "verified · key ⟨path⟩" badges.
+#[derive(Debug, Serialize)]
+pub struct ModelCosign {
+    /// Always `true` when present — failed verifications never get
+    /// written. Surfaced as a field so the SPA can pattern-match
+    /// without inferring from absence.
+    pub verified: bool,
+    /// `"key"` or `"keyless"` per the validator's enum.
+    pub mode: String,
+    /// Identity-regex pattern that cosign accepted (keyless mode
+    /// only). For operators reading the Model Library to confirm
+    /// the constraint they configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keyless_identity_pattern: Option<String>,
+    /// OIDC-issuer regex pattern (keyless mode only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keyless_oidc_issuer_pattern: Option<String>,
+    /// Operator-supplied public key path (keyed mode only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_path: Option<String>,
+}
 
 #[derive(Debug, Serialize)]
 pub struct Model {
@@ -37,10 +101,15 @@ pub struct Model {
     /// artifact's manifest. Stable for the lifetime of the cached
     /// copy.
     pub digest: String,
-    /// Original OCI reference the artifact was pulled with. Always
-    /// `null` in 1d.1b; 1d.1c populates this from a `provenance.json`
-    /// sidecar.
+    /// Original OCI reference the artifact was pulled with. Sourced
+    /// from `provenance.json` when present, falling back to
+    /// `ref.txt` for legacy cache entries. `null` only if neither
+    /// sidecar exists (an unusual manually-staged-blob case).
     pub oci_ref: Option<String>,
+    /// Cosign verification details from `provenance.json`. `None`
+    /// for legacy cache entries that predate the sidecar.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cosign: Option<ModelCosign>,
     /// Total size of all files under the model's cache directory,
     /// in bytes.
     pub size_bytes: u64,
@@ -48,6 +117,13 @@ pub struct Model {
     /// time. Approximates "last used" until we add explicit
     /// access-tracking sidecars.
     pub last_used: Option<String>,
+    /// RFC3339 timestamp recorded in `provenance.json::pulled_at`,
+    /// set by `aegis pull` at the moment cosign verification
+    /// succeeded. Distinct from `last_used`: pulled_at is the
+    /// supply-chain-relevant timestamp; last_used is the local
+    /// access timestamp. `None` for legacy cache entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pulled_at: Option<String>,
     /// Whether a `chat_template.sha256.txt` sidecar is present
     /// (per ADR-022 / OCI-B). Indicates the F1 chat-template-binding
     /// extension is available for sessions booted against this model.
@@ -133,16 +209,92 @@ fn enumerate_cache(cache_dir: &Path) -> std::io::Result<Vec<Model>> {
             .ok()
             .and_then(format_rfc3339);
         let has_chat_template = path.join("chat_template.sha256.txt").is_file();
+        let provenance = read_provenance(&path);
+        let oci_ref = provenance
+            .as_ref()
+            .map(|p| p.oci_ref.clone())
+            .or_else(|| read_ref_txt(&path));
+        let pulled_at = provenance.as_ref().and_then(|p| p.pulled_at.clone());
+        let cosign = provenance.and_then(|p| p.cosign.map(into_model_cosign));
 
         out.push(Model {
             digest: format!("sha256:{digest}"),
-            oci_ref: None,
+            oci_ref,
+            cosign,
             size_bytes,
             last_used,
+            pulled_at,
             has_chat_template,
         });
     }
     Ok(out)
+}
+
+/// Read + parse `provenance.json` from a cache subdir. Returns
+/// `None` for legacy entries that don't have one OR for parse
+/// failures (logged but non-fatal — a malformed sidecar shouldn't
+/// hide the model from the listing). Schema-version mismatch
+/// is also treated as "ignore"; the read-side type accepts only
+/// the version it knows.
+fn read_provenance(dir: &Path) -> Option<ProvenanceFile> {
+    let path = dir.join("provenance.json");
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                target: "aegis_ui_server",
+                err = %e,
+                path = %path.display(),
+                "reading provenance.json failed; falling back to ref.txt",
+            );
+            return None;
+        }
+    };
+    let parsed: ProvenanceFile = match serde_json::from_slice(&bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                target: "aegis_ui_server",
+                err = %e,
+                path = %path.display(),
+                "provenance.json malformed; falling back to ref.txt",
+            );
+            return None;
+        }
+    };
+    if parsed.schema_version != PROVENANCE_SCHEMA_VERSION {
+        tracing::warn!(
+            target: "aegis_ui_server",
+            got = parsed.schema_version,
+            expected = PROVENANCE_SCHEMA_VERSION,
+            path = %path.display(),
+            "provenance.json schema_version mismatch; falling back to ref.txt",
+        );
+        return None;
+    }
+    Some(parsed)
+}
+
+/// Read the legacy `ref.txt` sidecar — present on every cache entry
+/// pulled via `aegis pull` regardless of when. Returns `None` if
+/// the file is missing or unreadable.
+fn read_ref_txt(dir: &Path) -> Option<String> {
+    let path = dir.join("ref.txt");
+    std::fs::read_to_string(&path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn into_model_cosign(c: CosignFile) -> ModelCosign {
+    ModelCosign {
+        verified: c.verified,
+        mode: c.mode,
+        keyless_identity_pattern: c.keyless_identity_pattern,
+        keyless_oidc_issuer_pattern: c.keyless_oidc_issuer_pattern,
+        key_path: c.key_path,
+    }
 }
 
 fn dir_size_bytes(dir: &Path) -> std::io::Result<u64> {

--- a/ui/src/pages/Models.tsx
+++ b/ui/src/pages/Models.tsx
@@ -1,12 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
-import { Boxes, Hash } from "lucide-react";
+import { Boxes, Hash, ShieldCheck } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface ModelCosign {
+  verified: boolean;
+  mode: string;
+  keyless_identity_pattern?: string;
+  keyless_oidc_issuer_pattern?: string;
+  key_path?: string;
+}
 
 interface Model {
   digest: string;
   oci_ref: string | null;
+  cosign?: ModelCosign;
   size_bytes: number;
   last_used: string | null;
+  pulled_at?: string;
   has_chat_template: boolean;
 }
 
@@ -26,6 +36,14 @@ function shortDigest(digest: string): string {
   // sha256:<64 hex> → sha256:abcd1234…cdef
   if (digest.length <= 24) return digest;
   return `${digest.slice(0, 18)}…${digest.slice(-8)}`;
+}
+
+function shortRef(ref: string): string {
+  // Trim the @sha256:<64> tail to just the digest's first 8 chars
+  // for compactness; the full ref is still in the title attribute.
+  const idx = ref.indexOf("@sha256:");
+  if (idx === -1) return ref;
+  return `${ref.slice(0, idx)}@sha256:${ref.slice(idx + 8, idx + 16)}…`;
 }
 
 export function Models() {
@@ -96,6 +114,9 @@ export function Models() {
                       <span className="font-mono text-accent">
                         {shortDigest(m.digest)}
                       </span>
+                      {m.cosign?.verified && (
+                        <CosignBadge cosign={m.cosign} />
+                      )}
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
@@ -103,8 +124,11 @@ export function Models() {
                       {m.oci_ref && (
                         <>
                           <dt className="text-muted">OCI ref</dt>
-                          <dd className="truncate font-mono text-accent">
-                            {m.oci_ref}
+                          <dd
+                            className="truncate font-mono text-accent"
+                            title={m.oci_ref}
+                          >
+                            {shortRef(m.oci_ref)}
                           </dd>
                         </>
                       )}
@@ -114,6 +138,22 @@ export function Models() {
                       <dd className="font-mono">
                         {m.has_chat_template ? "✓ present" : "—"}
                       </dd>
+                      {m.cosign && (
+                        <>
+                          <dt className="text-muted">Cosign</dt>
+                          <dd className="font-mono">
+                            <CosignDetails cosign={m.cosign} />
+                          </dd>
+                        </>
+                      )}
+                      {m.pulled_at && (
+                        <>
+                          <dt className="text-muted">Pulled at</dt>
+                          <dd className="font-mono">
+                            {new Date(m.pulled_at).toLocaleString()}
+                          </dd>
+                        </>
+                      )}
                       {m.last_used && (
                         <>
                           <dt className="text-muted">Last used</dt>
@@ -131,5 +171,45 @@ export function Models() {
         </>
       )}
     </>
+  );
+}
+
+function CosignBadge({ cosign }: { cosign: ModelCosign }) {
+  const tooltip =
+    cosign.mode === "keyless"
+      ? `verified · keyless · identity ${cosign.keyless_identity_pattern ?? "*"}`
+      : `verified · key ${cosign.key_path ?? "*"}`;
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded bg-emerald-950/40 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300"
+      title={tooltip}
+    >
+      <ShieldCheck className="h-3 w-3" aria-hidden="true" />
+      verified
+    </span>
+  );
+}
+
+function CosignDetails({ cosign }: { cosign: ModelCosign }) {
+  if (cosign.mode === "key") {
+    return (
+      <span>
+        <span className="text-emerald-300">✓ keyed</span> ·{" "}
+        <span className="text-muted">key:</span>{" "}
+        {cosign.key_path ?? "(unknown)"}
+      </span>
+    );
+  }
+  return (
+    <span>
+      <span className="text-emerald-300">✓ keyless</span>
+      {cosign.keyless_identity_pattern && (
+        <>
+          {" "}
+          · <span className="text-muted">identity:</span>{" "}
+          <span className="break-all">{cosign.keyless_identity_pattern}</span>
+        </>
+      )}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

Closes the always-null `oci_ref` caveat from #141. The Model Library now surfaces the **OCI ref** the operator pulled with + the **cosign verification configuration** that signed off on the pull.

## Backend changes

**`crates/cli/src/pull.rs`** writes `provenance.json` as the pull's completion marker (after cosign exit 0 + blob renamed into the cache):

```json
{
  "schema_version": 1,
  "oci_ref": "ghcr.io/.../m@sha256:...",
  "manifest_digest": "...",
  "blob_sha256": "...",
  "chat_template_sha256": "...",
  "cosign": {
    "verified": true,
    "mode": "keyless",
    "keyless_identity_pattern": "https://github.com/tosin2013/.*",
    "keyless_oidc_issuer_pattern": "https://token.actions.githubusercontent.com"
  },
  "pulled_at": "2026-05-07T01:30:00.000Z"
}
```

Atomic write via tempfile-and-rename. `read_provenance` returns `Ok(None)` for legacy cache entries (no sidecar present) and rejects unknown major schema versions.

**5 new unit tests:** round-trip, legacy fallback, version rejection, cosign-record keyed/keyless, RFC3339 timestamp shape. **`cargo test -p aegis-cli --lib`: 15/15 pass.**

## Read-side changes

**`crates/ui-server/src/handlers/models.rs`** — two-tier `oci_ref` resolution:

1. `provenance.json` (full record: `oci_ref` + `cosign` + `pulled_at`)
2. `ref.txt` (canonical OCI ref only — legacy fallback)

Read-side types are **duplicated mirrors** of the pull.rs types because `aegis-cli` already depends on `aegis-ui-server` (circular dep prevents the reverse). JSON schema is the cross-crate contract.

Malformed sidecars + version mismatches log a `tracing::warn` and fall back to `ref.txt` — a busted sidecar must never hide the model from the listing.

## SPA changes

**`ui/src/pages/Models.tsx`** gains:
- Cosign-verified badge next to the digest (green ✓ + tooltip with full identity pattern)
- Cosign details row (`✓ keyless · identity: ...`)
- Pulled-at row distinct from last-used (supply-chain vs local-access timestamps)
- `shortRef()` helper trims `@sha256:<64>` to 8 chars for card display; full ref in title attribute

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude aegis-llama-backend --all-targets -- -D warnings` clean
- [x] `cargo test -p aegis-cli --lib`: 15/15 (5 new + 10 existing)
- [x] `cargo test -p aegis-ui-server`: 14/14
- [x] `pnpm typecheck` + `pnpm build`: clean; bundle 129 KB gzipped (+1 KB for cosign UI)
- [x] Manual smoke (3 cached models in this env): 2 legacy entries fall back to ref.txt; 1 manually-staged provenance.json surfaces full cosign + pulled_at
- [ ] CI green

## What's left for 1d.1e

- monaco-yaml schema-aware autocomplete (needs JSON Schema generated from `crates/policy::manifest`)
- Validator YAML AST hookup so #146's markers point at the offending field rather than line 1

Tracking: #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)