### PR TITLE
feat(validate, ui): YAML AST positions on findings + GitHub link to templates dir

### DIFF
--- a/cmd/aegis/validate.go
+++ b/cmd/aegis/validate.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/tosin2013/aegis-node/pkg/manifest"
 	"github.com/tosin2013/aegis-node/pkg/validate"
@@ -65,7 +66,18 @@ Flags:
 	}
 
 	path := fs.Arg(0)
-	m, err := manifest.Load(path)
+	// Read the YAML bytes once so we can both pass them to manifest.Load
+	// (via Parse) AND, after Lint, look up source positions for each
+	// finding. Each Finding.Field is a dotted-with-brackets path; the
+	// LookupPosition helper walks the YAML AST to translate it to
+	// (line, col). Output formatters consume the populated Line/Col
+	// fields when present and fall back to (1,1) otherwise.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "load %s: %v\n", path, err)
+		return errExit(2)
+	}
+	m, err := manifest.Parse(path, data)
 	if err != nil {
 		fmt.Fprintf(stderr, "load %s: %v\n", path, err)
 		return errExit(2)
@@ -78,6 +90,12 @@ Flags:
 	}
 
 	findings := validate.Lint(m, opts)
+	for i := range findings {
+		line, col := manifest.LookupPosition(data, findings[i].Field)
+		findings[i].Line = line
+		findings[i].Col = col
+	}
+
 	if err := format.Render(stdout, path, findings, out); err != nil {
 		fmt.Fprintf(stderr, "render: %v\n", err)
 		return errExit(1)

--- a/crates/ui-server/src/handlers/validate.rs
+++ b/crates/ui-server/src/handlers/validate.rs
@@ -257,6 +257,16 @@ fn sort_findings(v: &mut [Finding]) {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes the env-var-touching tests below. `AEGIS_VALIDATE_BIN`
+    /// is process-global; without this lock, parallel test threads
+    /// can clobber each other's `set_var` / `remove_var` calls
+    /// (one test's cleanup `remove_var` runs between another test's
+    /// `set_var` and `resolve_validate_binary`, leaving the resolver
+    /// to fall through to the dev-path / PATH search and return None).
+    /// CI surfaced this race intermittently after enough re-runs.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     const SAMPLE_JSONL: &str = concat!(
         r#"{"file":"/tmp/m.yaml","rule_id":"AEGIS007","severity":"warn","field":"tools.filesystem.write","message":"broad write coverage","rationale":"explain"}"#,
@@ -308,6 +318,7 @@ mod tests {
 
     #[test]
     fn resolve_uses_env_var_when_set() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         // Real binary path that exists on the system, just to test
         // resolution logic. Use this binary itself.
         let me = std::env::current_exe().unwrap();
@@ -319,6 +330,7 @@ mod tests {
 
     #[test]
     fn resolve_falls_back_to_path_when_env_invalid() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         std::env::set_var(ENV_VALIDATE_BIN, "/this/path/does/not/exist");
         // The fallback chain may or may not find aegis-validate
         // depending on the test environment; we just assert that

--- a/pkg/manifest/positions.go
+++ b/pkg/manifest/positions.go
@@ -1,0 +1,120 @@
+package manifest
+
+import (
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LookupPosition returns the 1-indexed line + column of the YAML
+// node at the given dotted-with-brackets field path inside `yamlBytes`.
+// Returns `(0, 0)` if the path can't be resolved (caller treats this
+// as "no precise position, fall back to line 1").
+//
+// Path syntax matches what `pkg/validate.Finding.Field` produces:
+//
+//   - dotted segments traverse maps   ("agent.name", "tools.filesystem.write")
+//   - "[N]" suffixes traverse arrays  ("write_grants[0].resource")
+//   - "" or "/" returns the root position
+//
+// Used by `cmd/aegis/validate.go` after `validate.Lint` to attach
+// real source positions to each Finding so output formats (JSON,
+// GitHub Annotations, text) can produce `file:line:col` rather than
+// the placeholder `file:0:0` that pre-position-aware versions emit.
+func LookupPosition(yamlBytes []byte, fieldPath string) (line, col int) {
+	if fieldPath == "" {
+		return 1, 1
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(yamlBytes, &root); err != nil {
+		return 0, 0
+	}
+	docNode := &root
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		docNode = root.Content[0]
+	}
+	pointer := dottedPathToJSONPointer(fieldPath)
+	l, c := lineColAtJSONPointer(docNode, pointer)
+	// The yaml.v3 library uses 1-indexed line/col; translate the
+	// "couldn't resolve" sentinel (returns the root's position) into
+	// (0, 0) when the requested pointer didn't actually match a node.
+	// We can't distinguish "matched root" from "fell back to root"
+	// by return value alone; treat root-position as a failure when
+	// the original path was non-trivial. Acceptable trade-off — root
+	// is rarely the actual finding location.
+	if pointer != "" && pointer != "/" && (l == docNode.Line && c == docNode.Column) {
+		// Path didn't resolve to a deeper node. Surface as "unknown."
+		// Callers fall back to line 1.
+		return 0, 0
+	}
+	return l, c
+}
+
+// dottedPathToJSONPointer converts a path like "write_grants[0].resource"
+// into RFC 6901 form "/write_grants/0/resource" suitable for
+// lineColAtJSONPointer. Empty input → "".
+func dottedPathToJSONPointer(field string) string {
+	if field == "" {
+		return ""
+	}
+	var b strings.Builder
+	dotSegments := strings.Split(field, ".")
+	for _, seg := range dotSegments {
+		// Split off any "[N]" suffixes; a segment can carry zero,
+		// one, or several brackets (rare but supported).
+		key, indices := splitBrackets(seg)
+		if key != "" {
+			b.WriteByte('/')
+			b.WriteString(escapePointer(key))
+		}
+		for _, idx := range indices {
+			b.WriteByte('/')
+			b.WriteString(idx)
+		}
+	}
+	return b.String()
+}
+
+// splitBrackets parses a segment like "read[2]" or "write_grants[0]"
+// into ("read", ["2"]) / ("write_grants", ["0"]). Multi-bracket
+// segments like "matrix[1][2]" produce ("matrix", ["1", "2"]).
+func splitBrackets(seg string) (key string, indices []string) {
+	open := strings.Index(seg, "[")
+	if open == -1 {
+		return seg, nil
+	}
+	key = seg[:open]
+	rest := seg[open:]
+	for len(rest) > 0 {
+		if rest[0] != '[' {
+			break
+		}
+		close := strings.Index(rest, "]")
+		if close == -1 {
+			break
+		}
+		// Validate that the bracket content is a non-negative integer
+		// — silently skip non-numeric to avoid producing broken
+		// pointer segments. Validate-rule code uses this format
+		// consistently so non-numeric brackets never appear.
+		inner := rest[1:close]
+		if _, err := strconv.Atoi(inner); err == nil {
+			indices = append(indices, inner)
+		}
+		rest = rest[close+1:]
+	}
+	return key, indices
+}
+
+// escapePointer applies RFC 6901 escapes so map keys containing
+// `/` or `~` survive the round-trip. Manifest field names don't
+// usually contain either, but keep the function honest for
+// future-proofing.
+func escapePointer(s string) string {
+	if !strings.ContainsAny(s, "/~") {
+		return s
+	}
+	r := strings.NewReplacer("~", "~0", "/", "~1")
+	return r.Replace(s)
+}

--- a/pkg/manifest/positions_test.go
+++ b/pkg/manifest/positions_test.go
@@ -1,0 +1,102 @@
+package manifest
+
+import "testing"
+
+func TestDottedPathToJSONPointer(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"agent.name", "/agent/name"},
+		{"tools.filesystem.write", "/tools/filesystem/write"},
+		{"tools.filesystem.read[0]", "/tools/filesystem/read/0"},
+		{"write_grants[2].resource", "/write_grants/2/resource"},
+		{"matrix[1][2]", "/matrix/1/2"},
+	}
+	for _, c := range cases {
+		if got := dottedPathToJSONPointer(c.in); got != c.want {
+			t.Errorf("dottedPathToJSONPointer(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSplitBracketsRejectsNonNumeric(t *testing.T) {
+	key, idx := splitBrackets("matrix[abc]")
+	if key != "matrix" {
+		t.Errorf("key = %q, want %q", key, "matrix")
+	}
+	if len(idx) != 0 {
+		t.Errorf("non-numeric index should be skipped, got %v", idx)
+	}
+}
+
+func TestLookupPositionRootFallback(t *testing.T) {
+	// Empty field returns (1, 1) without parsing.
+	if l, c := LookupPosition([]byte("a: 1\n"), ""); l != 1 || c != 1 {
+		t.Errorf("empty field = (%d,%d), want (1,1)", l, c)
+	}
+}
+
+func TestLookupPositionOnRealFields(t *testing.T) {
+	yaml := `agent:
+  name: smoke-test
+  version: "1.0.0"
+identity:
+  spiffeId: spiffe://aegis-node.local/agent/smoke/inst-001
+tools:
+  filesystem:
+    read:
+      - /one/path
+      - /two/path
+    write:
+      - /tmp/out
+write_grants:
+  - resource: /tmp/out/file.txt
+    actions: [write]
+`
+	// Note: yaml.v3 returns the position of the VALUE node, not the
+	// key node. For sequence-valued keys (e.g. `write:` whose value
+	// is a multi-line list) that means the marker lands on the
+	// first list item, one line below the key. UX-wise this is
+	// fine — the squiggle highlights the offending content rather
+	// than the field name. Tests assert the actual yaml.v3
+	// behaviour; if we ever switch to key-position tracking, update
+	// here in lockstep.
+	cases := []struct {
+		field          string
+		wantLine       int
+		wantNonZeroCol bool
+	}{
+		// Map-key descent — value on same line as key.
+		{"agent.name", 2, true},
+		{"identity.spiffeId", 5, true},
+		// Sequence-valued key — value is the first element line.
+		{"tools.filesystem.write", 12, true},
+		// Array-index descent.
+		{"tools.filesystem.read[0]", 9, true},
+		{"tools.filesystem.read[1]", 10, true},
+		{"write_grants[0].resource", 14, true},
+	}
+	for _, c := range cases {
+		gotLine, gotCol := LookupPosition([]byte(yaml), c.field)
+		if gotLine != c.wantLine {
+			t.Errorf("LookupPosition(%q) line = %d, want %d", c.field, gotLine, c.wantLine)
+		}
+		if c.wantNonZeroCol && gotCol == 0 {
+			t.Errorf("LookupPosition(%q) col = 0, want non-zero", c.field)
+		}
+	}
+}
+
+func TestLookupPositionUnknownPath(t *testing.T) {
+	yaml := "agent:\n  name: x\n"
+	if l, c := LookupPosition([]byte(yaml), "tools.does_not_exist"); l != 0 || c != 0 {
+		t.Errorf("unknown path = (%d,%d), want (0,0)", l, c)
+	}
+}
+
+func TestLookupPositionMalformedYAML(t *testing.T) {
+	if l, c := LookupPosition([]byte("not: valid: yaml: ::\n"), "anything"); l != 0 || c != 0 {
+		t.Errorf("malformed yaml = (%d,%d), want (0,0)", l, c)
+	}
+}

--- a/pkg/validate/format/format.go
+++ b/pkg/validate/format/format.go
@@ -82,10 +82,14 @@ func renderText(w io.Writer, file string, findings []validate.Finding) error {
 		return err
 	}
 	for _, f := range findings {
-		// `path:line:col: severity rule message`. Line/col are 0 until
-		// the YAML AST hookup lands; the slot is reserved.
-		if _, err := fmt.Fprintf(w, "%s:0:0: %s %s %s — %s\n",
+		// `path:line:col: severity rule message`. Line/col come from
+		// the runner's pkg/manifest.LookupPosition lookup; 0 means
+		// the path didn't resolve (fall back to top-of-file in
+		// IDE markers).
+		line, col := positionFor(f)
+		if _, err := fmt.Fprintf(w, "%s:%d:%d: %s %s %s — %s\n",
 			filenameOr(file, "<stdin>"),
+			line, col,
 			f.SeverityName(),
 			f.RuleID,
 			f.Field,
@@ -116,8 +120,9 @@ func renderGitHub(w io.Writer, file string, findings []validate.Finding) error {
 		// Newlines in message must be %0A-encoded.
 		title := fmt.Sprintf("%s %s", f.RuleID, f.Field)
 		msg := encodeGHA(f.Message)
-		if _, err := fmt.Fprintf(w, "::%s file=%s,line=1,col=1,title=%s::%s\n",
-			level, file, encodeGHA(title), msg); err != nil {
+		line, col := positionFor(f)
+		if _, err := fmt.Fprintf(w, "::%s file=%s,line=%d,col=%d,title=%s::%s\n",
+			level, file, line, col, encodeGHA(title), msg); err != nil {
 			return err
 		}
 	}
@@ -215,6 +220,12 @@ func renderJUnit(w io.Writer, file string, findings []validate.Finding) error {
 // jsonRecord is the on-disk representation of one Finding. The JSON
 // schema for this type lives at schemas/validate/findings.schema.json
 // so consumers can build typed tooling (SIEM rules, CI dashboards).
+//
+// `line` / `col` are 1-indexed when the runner could resolve the
+// finding's Field to a YAML AST node; both are `0` (and the fields
+// are omitted from the JSON output) when the lookup failed —
+// downstream consumers fall back to `(1,1)` per the Marker spec
+// the SPA's Monaco renderer uses.
 type jsonRecord struct {
 	File      string `json:"file,omitempty"`
 	RuleID    string `json:"rule_id"`
@@ -222,6 +233,8 @@ type jsonRecord struct {
 	Field     string `json:"field"`
 	Message   string `json:"message"`
 	Rationale string `json:"rationale,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	Col       int    `json:"col,omitempty"`
 }
 
 func renderJSON(w io.Writer, file string, findings []validate.Finding) error {
@@ -235,6 +248,8 @@ func renderJSON(w io.Writer, file string, findings []validate.Finding) error {
 			Field:     f.Field,
 			Message:   f.Message,
 			Rationale: f.Rationale,
+			Line:      f.Line,
+			Col:       f.Col,
 		}
 		if err := enc.Encode(rec); err != nil {
 			return err
@@ -246,6 +261,22 @@ func renderJSON(w io.Writer, file string, findings []validate.Finding) error {
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
+
+// positionFor returns the (line, col) to display for a finding,
+// falling back to (1, 1) when the runner couldn't resolve the
+// Field path to a YAML AST node. Centralizes the fallback so each
+// formatter stays consistent.
+func positionFor(f validate.Finding) (line, col int) {
+	line = f.Line
+	col = f.Col
+	if line == 0 {
+		line = 1
+	}
+	if col == 0 {
+		col = 1
+	}
+	return
+}
 
 func tally(findings []validate.Finding) (errs, warns, infos int) {
 	for _, f := range findings {

--- a/pkg/validate/format/format_test.go
+++ b/pkg/validate/format/format_test.go
@@ -60,7 +60,10 @@ func TestRenderTextSummaryAndCounts(t *testing.T) {
 		"AEGIS001",
 		"AEGIS006",
 		"AEGIS010",
-		"manifest.yaml:0:0:",
+		// Fixture findings have Line/Col=0 (unresolved); positionFor
+		// falls back to 1,1 so the text format emits :1:1: rather
+		// than the legacy :0:0: placeholder.
+		"manifest.yaml:1:1:",
 		"1 error(s), 1 warning(s), 1 info",
 	} {
 		if !strings.Contains(got, want) {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -46,14 +46,22 @@ func (s Severity) String() string {
 // Finding is one lint result. Field is a JSON-pointer-ish path into the
 // manifest (e.g. "tools.filesystem.read[0]" or "write_grants[2].resource")
 // so output formatters can produce file:line:col when paired with the
-// raw YAML AST. The pkg/manifest schema validator owns line/column
-// extraction; this package emits paths only.
+// raw YAML AST. Lint rules emit Field; the runner (cmd/aegis/validate.go)
+// resolves Line+Col by feeding Field through pkg/manifest.LookupPosition
+// before format.Render. Both default to 0 when the runner can't resolve
+// a precise position (malformed YAML, unresolved field path) — formatters
+// fall back to (1,1) so the marker still appears at the top of the file.
 type Finding struct {
 	RuleID    string   `json:"rule_id"`
 	Severity  Severity `json:"-"`
 	Field     string   `json:"field"`
 	Message   string   `json:"message"`
 	Rationale string   `json:"rationale,omitempty"`
+	// Line is the 1-indexed source line of the YAML node Field
+	// resolves to, or 0 when no precise position is available.
+	Line int `json:"line,omitempty"`
+	// Col is the 1-indexed source column of the same node, or 0.
+	Col int `json:"col,omitempty"`
 }
 
 // SeverityName is the JSON form of Severity (for output formatters).

--- a/ui/src/pages/Manifest.tsx
+++ b/ui/src/pages/Manifest.tsx
@@ -201,10 +201,16 @@ export function Manifest() {
           <p className="mb-4 text-sm text-muted">
             Monaco editor served from the embedded SPA bundle (no CDN). Each
             curated template ships with a metadata block + pain-point citation
-            anchored in a documented incident; source files live at{" "}
-            <code className="font-mono text-accent">
+            anchored in a documented incident (CVE, postmortem, forum
+            thread); source files live at{" "}
+            <a
+              href="https://github.com/tosin2013/aegis-node/tree/main/examples/templates/manifests"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-accent underline-offset-2 hover:underline"
+            >
               examples/templates/manifests/
-            </code>
+            </a>
             . Save writes to{" "}
             <code className="font-mono text-accent">
               ~/.config/aegis/manifests/draft.yaml


### PR DESCRIPTION
## Summary

Two related polish items closing #146's loose ends:

### 1. Validator YAML AST hookup

#146's live-validate integration shipped Monaco markers but they all pointed at line 1 because the validator's JSON output had `line/col=0` (per the format.go comment about the AST hookup being a follow-up). This change wires real source positions through.

- **`pkg/manifest/positions.go`** — new public `LookupPosition(yamlBytes, fieldPath) → (line, col)`. Converts dotted-with-brackets paths (e.g. `write_grants[0].resource`) to JSON pointer, walks the `yaml.Node` tree via the existing `lineColAtJSONPointer` helper. Returns `(0, 0)` when unresolvable.
- **`pkg/validate.Finding`** — new `Line` + `Col` fields. Lint rules don't set them; `cmd/aegis/validate.go` populates them after `Lint` via `LookupPosition`.
- **`pkg/validate/format/format.go`** — text + github + json formats emit real line/col when available, falling back to `(1, 1)` via the new `positionFor` helper.
- **6 new tests** covering dotted→JSON-pointer conversion, real-field position lookup, unknown-path / malformed-YAML edge cases.

> **yaml.v3 semantics note:** positions are VALUE-node positions, not key-node. For sequence-valued keys (e.g. `write:` whose value is a multi-line list) markers land on the first list item one line below the key — fine UX, the squiggle highlights the offending content rather than the field name.

### 2. SPA: GitHub link to templates source

The Manifest Builder description mentions `examples/templates/manifests/`. Now it's a clickable link to the GitHub tree (`target=_blank rel=noopener noreferrer`).

## Verification

- [x] `gofmt -l pkg/manifest pkg/validate cmd/aegis`: clean
- [x] `go vet ./pkg/manifest/... ./pkg/validate/... ./cmd/aegis/...`: clean
- [x] `go test ./pkg/manifest/... ./pkg/validate/... ./cmd/aegis/...`: 4/4 packages pass
- [x] `pnpm typecheck` + `pnpm build`: clean
- [x] Manual smoke: `aegis-validate validate --format json /tmp/bad.yaml` emits `"line":10,"col":7` for an AEGIS007 finding on a manifest whose offending write block sits on line 10. With #146's Monaco markers wired (when both land) the squiggle moves off line 1 onto the right line.
- [ ] CI green

## Sequencing

This PR's Go-side changes are **independent of #146** (live-validate handler) and **#148** (provenance.json). When all three land, #146's frontend `Finding` type already has `line`/`col` fields — the integration is automatic; no further frontend changes needed.

Tracking: #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)