### PR TITLE
feat(ui-server, ui): chat surface transport + stub round-trip (sub-phase 1d.2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "anyhow",
  "axum",
  "dirs",
+ "futures-util",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -211,6 +212,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -363,6 +365,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64",
  "bytes",
  "futures-util",
  "http",
@@ -381,8 +384,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -479,6 +484,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -797,6 +808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -1821,6 +1839,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2097,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2193,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2269,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/ui-server/Cargo.toml
+++ b/crates/ui-server/Cargo.toml
@@ -12,16 +12,18 @@ workspace = true
 
 [dependencies]
 anyhow = "1"
-axum = "0.7"
+axum = { version = "0.7", features = ["ws"] }
 dirs = "5"
+futures-util = { version = "0.3", default-features = false }
 mime_guess = "2"
 rust-embed = { version = "8", features = ["debug-embed", "interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
-tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal", "sync", "time"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = "0.1"
+uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 hyper = { version = "1", features = ["client", "http1"] }

--- a/crates/ui-server/src/handlers/mod.rs
+++ b/crates/ui-server/src/handlers/mod.rs
@@ -5,4 +5,5 @@ pub mod assets;
 pub mod health;
 pub mod manifests;
 pub mod models;
+pub mod sessions;
 pub mod validate;

--- a/crates/ui-server/src/handlers/sessions.rs
+++ b/crates/ui-server/src/handlers/sessions.rs
@@ -279,8 +279,7 @@ async fn run_stub_turn(
         socket,
         &ServerFrame::AssistantText {
             turn_id: turn_id.clone(),
-            text: "\n\n(stub backend — Session::run_turn integration ships in 1d.2b)"
-                .to_string(),
+            text: "\n\n(stub backend — Session::run_turn integration ships in 1d.2b)".to_string(),
         },
     )
     .await?;

--- a/crates/ui-server/src/handlers/sessions.rs
+++ b/crates/ui-server/src/handlers/sessions.rs
@@ -1,0 +1,416 @@
+//! Chat-surface session management + WebSocket transport.
+//!
+//! Sub-phase 1d.2a per [ADR-031](../../../docs/adrs/031-community-webui-for-local-collaboration.md)
+//! §"Surfaces" → "Context-aware chat" (tracker [#147](https://github.com/tosin2013/aegis-node/issues/147)).
+//!
+//! ## Endpoints
+//!
+//! | Path                        | Verb / Upgrade            | Purpose                                          |
+//! |-----------------------------|---------------------------|--------------------------------------------------|
+//! | `/api/v1/sessions`          | `POST`                    | Mint a new chat session, return its `session_id`. |
+//! | `/api/v1/stream?sid=<id>`   | `GET` → `WebSocket`       | Bidirectional frames for one session's lifetime. |
+//!
+//! ## Frame protocol (v1)
+//!
+//! All frames are JSON text with `schema: "v1"` at the top level so
+//! later sub-phases (1d.2b/c/d) can extend the type union without
+//! breaking older clients. Type-tagged via `serde(tag = "type")`.
+//!
+//! ### Client → server
+//!
+//! ```json
+//! {"schema":"v1","type":"user_prompt","prompt":"hello"}
+//! ```
+//!
+//! ### Server → client
+//!
+//! ```json
+//! {"schema":"v1","type":"turn_start","turn_id":"…"}
+//! {"schema":"v1","type":"assistant_text","turn_id":"…","text":"echo: hello"}
+//! {"schema":"v1","type":"turn_end","turn_id":"…"}
+//! ```
+//!
+//! Plus `error` for protocol / runtime failures the SPA renders as a
+//! red banner without dropping the connection.
+//!
+//! ## What 1d.2a does NOT do
+//!
+//! - **Real `Session::run_turn`** — that lands in 1d.2b. The current
+//!   handler echoes the prompt back as `assistant_text`. The wire
+//!   shape is stable; engine integration just replaces the echo body.
+//! - **Tool-call frames** — reserved in the protocol enum but not
+//!   emitted yet. Land in 1d.2c with the verifiable badge + tool-call
+//!   card UI surfaces.
+//! - **Reconnect** — the SPA closes/reopens the WS on visibility-
+//!   change. Resume from a partial turn is a 1d.2b concern.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use futures_util::stream::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+/// Wire-protocol schema version. Bumped only on a breaking change to
+/// the frame shape; additive type variants don't change this.
+pub const SCHEMA_VERSION: &str = "v1";
+
+/// In-memory session registry. Sub-phase 1d.2a keeps sessions
+/// transient — created on `POST /api/v1/sessions`, dropped when the
+/// process exits. 1d.2b will tie sessions to `Session::run_turn`'s
+/// state; persistence-across-restart is a v1.0.0 multi-turn concern.
+#[derive(Default, Clone)]
+pub struct SessionRegistry {
+    inner: Arc<RwLock<HashMap<String, SessionRecord>>>,
+}
+
+#[derive(Debug, Clone)]
+struct SessionRecord {
+    /// UUIDv7 string (sortable by creation). Same value as the map key.
+    id: String,
+    /// RFC3339 creation timestamp, surfaced in the create-response so
+    /// the SPA can show "session started at" without separate API.
+    created_at: String,
+}
+
+impl SessionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    async fn create(&self) -> SessionRecord {
+        let id = Uuid::now_v7().to_string();
+        let record = SessionRecord {
+            id: id.clone(),
+            created_at: rfc3339_now(),
+        };
+        self.inner.write().await.insert(id, record.clone());
+        record
+    }
+
+    async fn exists(&self, id: &str) -> bool {
+        self.inner.read().await.contains_key(id)
+    }
+}
+
+/// Response for `POST /api/v1/sessions`.
+#[derive(Debug, Serialize)]
+pub struct SessionCreated {
+    pub session_id: String,
+    pub created_at: String,
+    pub schema: &'static str,
+}
+
+/// `POST /api/v1/sessions` — mint a new chat session.
+pub async fn create_session(State(reg): State<SessionRegistry>) -> Json<SessionCreated> {
+    let rec = reg.create().await;
+    tracing::info!(target: "aegis_ui_server", session_id = %rec.id, "session created");
+    Json(SessionCreated {
+        session_id: rec.id,
+        created_at: rec.created_at,
+        schema: SCHEMA_VERSION,
+    })
+}
+
+/// Query params accepted on the WebSocket upgrade. The SPA sends
+/// `?sid=<session_id>` so the server can reject upgrades for unknown
+/// sessions before any frames flow.
+#[derive(Debug, Deserialize)]
+pub struct ConnectParams {
+    pub sid: String,
+}
+
+/// `GET /api/v1/stream?sid=<id>` — upgrade to WebSocket and run the
+/// chat loop. Rejects unknown session IDs with 404 *before* upgrade,
+/// so the SPA's connection failure is unambiguous.
+pub async fn stream(
+    ws: WebSocketUpgrade,
+    Query(params): Query<ConnectParams>,
+    State(reg): State<SessionRegistry>,
+) -> Response {
+    if !reg.exists(&params.sid).await {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("unknown session_id {:?}", params.sid),
+        )
+            .into_response();
+    }
+    ws.on_upgrade(move |socket| handle_socket(socket, params.sid))
+}
+
+/// Server → client frame body. The wire form has `schema: "v1"` at
+/// the top level (set by [`encode`]) and `type` next to whichever
+/// fields the variant carries.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerFrame {
+    /// Begins a turn. The client uses `turn_id` to scope the assistant_text
+    /// chunks that follow.
+    TurnStart { turn_id: String },
+    /// Streaming assistant-output chunk. May arrive multiple times per
+    /// turn; the client appends each `text` to the active turn's buffer.
+    AssistantText { turn_id: String, text: String },
+    /// Turn complete. No more frames will arrive for this `turn_id`
+    /// until a fresh `user_prompt` triggers another turn.
+    TurnEnd { turn_id: String },
+    /// Protocol or runtime error. Non-fatal — the connection stays
+    /// open so the operator can retry.
+    Error { message: String },
+}
+
+/// Client → server frame body. Mirrors [`ServerFrame`]; same wire
+/// envelope (`schema` + `type`).
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientFrame {
+    /// User-typed prompt. Triggers one turn (which streams
+    /// `turn_start` → `assistant_text`* → `turn_end`).
+    UserPrompt { prompt: String },
+}
+
+/// Encode a [`ServerFrame`] into the wire JSON, prepending the
+/// `schema: "v1"` field. Returns the JSON string; the caller wraps
+/// it in a WebSocket text frame.
+fn encode(frame: &ServerFrame) -> Result<String, serde_json::Error> {
+    // Two-step serialise so the schema field lands at the top of the
+    // JSON object alongside `type`. Equivalent to a struct with
+    // `#[serde(flatten)]` but keeps the variant enum simple.
+    let mut value = serde_json::to_value(frame)?;
+    if let serde_json::Value::Object(map) = &mut value {
+        // Insert at the front by rebuilding so JSON readers see
+        // `schema` before `type`. Order isn't significant per JSON
+        // spec, but a stable order helps log diffs.
+        let mut ordered = serde_json::Map::with_capacity(map.len() + 1);
+        ordered.insert("schema".to_string(), SCHEMA_VERSION.into());
+        for (k, v) in map.iter() {
+            ordered.insert(k.clone(), v.clone());
+        }
+        value = serde_json::Value::Object(ordered);
+    }
+    serde_json::to_string(&value)
+}
+
+async fn handle_socket(mut socket: WebSocket, session_id: String) {
+    tracing::info!(target: "aegis_ui_server", session_id = %session_id, "ws connected");
+    while let Some(msg) = socket.next().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(target: "aegis_ui_server", session_id = %session_id, err = %e, "ws recv error");
+                break;
+            }
+        };
+        match msg {
+            Message::Text(text) => {
+                if let Err(e) = handle_text_frame(&mut socket, &session_id, text).await {
+                    tracing::warn!(target: "aegis_ui_server", session_id = %session_id, err = %e, "frame handler errored");
+                }
+            }
+            Message::Close(_) => break,
+            Message::Ping(_) | Message::Pong(_) | Message::Binary(_) => {
+                // Ping/pong is handled by axum's underlying tungstenite
+                // automatically. Binary frames aren't part of the v1
+                // protocol; silently ignore.
+            }
+        }
+    }
+    tracing::info!(target: "aegis_ui_server", session_id = %session_id, "ws closed");
+}
+
+async fn handle_text_frame(
+    socket: &mut WebSocket,
+    session_id: &str,
+    text: String,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let frame: ClientFrame = match serde_json::from_str(&text) {
+        Ok(f) => f,
+        Err(e) => {
+            send_error(socket, &format!("malformed frame: {e}")).await?;
+            return Ok(());
+        }
+    };
+    match frame {
+        ClientFrame::UserPrompt { prompt } => run_stub_turn(socket, session_id, &prompt).await,
+    }
+}
+
+/// Stub turn: emit `turn_start`, a single `assistant_text` echoing
+/// the prompt, then `turn_end`. Sub-phase 1d.2b replaces this body
+/// with `Session::run_turn` driving the real engine.
+///
+/// The intentional 50 ms delay between frames lets the SPA prove its
+/// streaming-append rendering works (frames arrive separately) without
+/// any backend-side complexity. Drop the sleep when the real engine
+/// integration lands — token-by-token streaming gives natural pacing.
+async fn run_stub_turn(
+    socket: &mut WebSocket,
+    _session_id: &str,
+    prompt: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let turn_id = Uuid::now_v7().to_string();
+
+    send_frame(
+        socket,
+        &ServerFrame::TurnStart {
+            turn_id: turn_id.clone(),
+        },
+    )
+    .await?;
+
+    // Two chunks so the SPA's append-on-streaming path is exercised.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    send_frame(
+        socket,
+        &ServerFrame::AssistantText {
+            turn_id: turn_id.clone(),
+            text: format!("echo: {prompt}"),
+        },
+    )
+    .await?;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    send_frame(
+        socket,
+        &ServerFrame::AssistantText {
+            turn_id: turn_id.clone(),
+            text: "\n\n(stub backend — Session::run_turn integration ships in 1d.2b)"
+                .to_string(),
+        },
+    )
+    .await?;
+
+    send_frame(socket, &ServerFrame::TurnEnd { turn_id }).await?;
+    Ok(())
+}
+
+async fn send_frame(
+    socket: &mut WebSocket,
+    frame: &ServerFrame,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let text = encode(frame)?;
+    socket.send(Message::Text(text)).await?;
+    Ok(())
+}
+
+async fn send_error(
+    socket: &mut WebSocket,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    send_frame(
+        socket,
+        &ServerFrame::Error {
+            message: message.to_string(),
+        },
+    )
+    .await
+}
+
+/// Pure-stdlib RFC3339 timestamp helper. Mirrors the same helper in
+/// `crates/cli/src/pull.rs` and `crates/ui-server/src/handlers/models.rs`
+/// so this crate stays free of `chrono`. Acceptable duplication for
+/// one format string.
+fn rfc3339_now() -> String {
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs() as i64;
+    let nanos = dur.subsec_nanos();
+    naive_rfc3339_from_unix(secs, nanos)
+}
+
+fn naive_rfc3339_from_unix(secs: i64, nanos: u32) -> String {
+    const SECONDS_PER_DAY: i64 = 86_400;
+    let days = secs.div_euclid(SECONDS_PER_DAY);
+    let time_of_day = secs.rem_euclid(SECONDS_PER_DAY);
+    let hh = time_of_day / 3600;
+    let mm = (time_of_day % 3600) / 60;
+    let ss = time_of_day % 60;
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!(
+        "{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}.{millis:03}Z",
+        millis = nanos / 1_000_000,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_frame_serialises_with_schema_v1() {
+        // Field order in the wire JSON isn't semantically significant
+        // (JSON spec); serde_json's default Map orders alphabetically.
+        // Assert against the parsed shape, not the literal string.
+        let f = ServerFrame::TurnStart {
+            turn_id: "abc".to_string(),
+        };
+        let s = encode(&f).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["schema"], "v1");
+        assert_eq!(v["type"], "turn_start");
+        assert_eq!(v["turn_id"], "abc");
+    }
+
+    #[test]
+    fn assistant_text_carries_text_and_turn() {
+        let f = ServerFrame::AssistantText {
+            turn_id: "t-1".to_string(),
+            text: "hello".to_string(),
+        };
+        let s = encode(&f).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["schema"], "v1");
+        assert_eq!(v["type"], "assistant_text");
+        assert_eq!(v["text"], "hello");
+        assert_eq!(v["turn_id"], "t-1");
+    }
+
+    #[test]
+    fn client_user_prompt_decodes() {
+        let raw = r#"{"schema":"v1","type":"user_prompt","prompt":"hi"}"#;
+        let f: ClientFrame = serde_json::from_str(raw).unwrap();
+        match f {
+            ClientFrame::UserPrompt { prompt } => assert_eq!(prompt, "hi"),
+        }
+    }
+
+    #[test]
+    fn client_unknown_type_rejected() {
+        let raw = r#"{"schema":"v1","type":"nonsense","prompt":"hi"}"#;
+        assert!(serde_json::from_str::<ClientFrame>(raw).is_err());
+    }
+
+    #[tokio::test]
+    async fn registry_create_then_exists() {
+        let reg = SessionRegistry::new();
+        let rec = reg.create().await;
+        assert!(reg.exists(&rec.id).await);
+        assert!(!reg.exists("does-not-exist").await);
+    }
+
+    #[tokio::test]
+    async fn registry_ids_are_unique_uuids() {
+        let reg = SessionRegistry::new();
+        let a = reg.create().await;
+        let b = reg.create().await;
+        assert_ne!(a.id, b.id);
+        // UUIDv7 → 36-char dashed form.
+        assert_eq!(a.id.len(), 36);
+    }
+}

--- a/crates/ui-server/src/lib.rs
+++ b/crates/ui-server/src/lib.rs
@@ -108,10 +108,7 @@ pub fn router(config: Config) -> Router {
             "/api/v1/manifests/validate",
             post(handlers::validate::validate_manifest),
         )
-        .route(
-            "/api/v1/sessions",
-            post(handlers::sessions::create_session),
-        )
+        .route("/api/v1/sessions", post(handlers::sessions::create_session))
         .route("/api/v1/stream", get(handlers::sessions::stream))
         .fallback(handlers::assets::serve_embedded)
         .with_state(state)

--- a/crates/ui-server/src/lib.rs
+++ b/crates/ui-server/src/lib.rs
@@ -29,6 +29,7 @@
 
 use std::net::{IpAddr, SocketAddr};
 
+use axum::extract::FromRef;
 use axum::routing::{get, post};
 use axum::Router;
 use serde::Serialize;
@@ -37,6 +38,7 @@ mod embed;
 mod handlers;
 
 pub use embed::UiDist;
+pub use handlers::sessions::SessionRegistry;
 
 /// Construction-time configuration passed in by the CLI. Carries the
 /// values the `/api/v1/version` endpoint surfaces back to the UI;
@@ -59,17 +61,41 @@ pub struct Config {
     pub listen: SocketAddr,
 }
 
+/// Composite handler state. axum's `FromRef` impls below let
+/// individual handlers extract whichever sub-state they need
+/// (`State<Config>` or `State<SessionRegistry>`) without the router
+/// having to thread a tuple of states. Sub-phase 1d.2a introduces
+/// `SessionRegistry` for the chat surface; future surfaces add their
+/// own sub-states as new fields here.
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Config,
+    pub sessions: SessionRegistry,
+}
+
+impl FromRef<AppState> for Config {
+    fn from_ref(state: &AppState) -> Config {
+        state.config.clone()
+    }
+}
+
+impl FromRef<AppState> for SessionRegistry {
+    fn from_ref(state: &AppState) -> SessionRegistry {
+        state.sessions.clone()
+    }
+}
+
 /// Build the axum router for the UI server. Pure: no I/O, no socket
 /// binding — call [`serve`] to actually run it.
 ///
-/// Routes installed by sub-phase 1d.0:
-///
-/// | Path                  | Handler                                  |
-/// |-----------------------|------------------------------------------|
-/// | `GET /healthz`        | [`handlers::health::healthz`]            |
-/// | `GET /api/v1/version` | [`handlers::health::version`]            |
-/// | `GET /*`              | embedded `ui/dist/` via [`UiDist`]       |
+/// `SessionRegistry` is constructed fresh inside the router; sessions
+/// don't survive a process restart (per ADR-031 §"Single agent, single
+/// user" — persistence-across-restart is a v1.0.0 multi-turn concern).
 pub fn router(config: Config) -> Router {
+    let state = AppState {
+        config,
+        sessions: SessionRegistry::new(),
+    };
     Router::new()
         .route("/healthz", get(handlers::health::healthz))
         .route("/api/v1/version", get(handlers::health::version))
@@ -82,8 +108,13 @@ pub fn router(config: Config) -> Router {
             "/api/v1/manifests/validate",
             post(handlers::validate::validate_manifest),
         )
+        .route(
+            "/api/v1/sessions",
+            post(handlers::sessions::create_session),
+        )
+        .route("/api/v1/stream", get(handlers::sessions::stream))
         .fallback(handlers::assets::serve_embedded)
-        .with_state(config)
+        .with_state(state)
 }
 
 /// Bind the server to `addr`, refusing any non-loopback address, and

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -1,5 +1,11 @@
 import { Link, useRouterState } from "@tanstack/react-router";
-import { Boxes, FileCode, Home as HomeIcon, ShieldCheck } from "lucide-react";
+import {
+  Boxes,
+  FileCode,
+  Home as HomeIcon,
+  MessageSquare,
+  ShieldCheck,
+} from "lucide-react";
 import type { ComponentType, SVGProps } from "react";
 import { cn } from "@/lib/utils";
 
@@ -11,6 +17,7 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { to: "/", label: "Home", icon: HomeIcon },
+  { to: "/chat", label: "Chat", icon: MessageSquare },
   { to: "/manifest", label: "Manifest Builder", icon: FileCode },
   { to: "/models", label: "Model Library", icon: Boxes },
 ];

--- a/ui/src/lib/chat-ws.ts
+++ b/ui/src/lib/chat-ws.ts
@@ -1,0 +1,118 @@
+/**
+ * Chat WebSocket client. Wraps the protocol that
+ * `crates/ui-server/src/handlers/sessions.rs` exposes:
+ *
+ *   POST /api/v1/sessions     → { session_id }
+ *   WS   /api/v1/stream?sid=X → bidirectional v1 frames
+ *
+ * Schema-versioned frames keep the door open for sub-phase 1d.2c/d
+ * additions (tool_call, tool_result, verifiable badge metadata)
+ * without breaking older clients — the type union below is an
+ * open-ended discriminated union, server-emitted frames the SPA
+ * doesn't know about are surfaced via `onUnknown` rather than
+ * crashing the connection.
+ */
+
+export interface SessionCreated {
+  session_id: string;
+  created_at: string;
+  schema: string;
+}
+
+export type ServerFrame =
+  | { schema: "v1"; type: "turn_start"; turn_id: string }
+  | {
+      schema: "v1";
+      type: "assistant_text";
+      turn_id: string;
+      text: string;
+    }
+  | { schema: "v1"; type: "turn_end"; turn_id: string }
+  | { schema: "v1"; type: "error"; message: string };
+
+export type ClientFrame = {
+  schema: "v1";
+  type: "user_prompt";
+  prompt: string;
+};
+
+export interface ChatWsHandlers {
+  onFrame: (frame: ServerFrame) => void;
+  onUnknown?: (raw: unknown) => void;
+  onOpen?: () => void;
+  onClose?: (code: number, reason: string) => void;
+  onError?: (err: unknown) => void;
+}
+
+export interface ChatWs {
+  send: (frame: ClientFrame) => void;
+  close: () => void;
+  readyState: () => number;
+}
+
+export async function createSession(): Promise<SessionCreated> {
+  const r = await fetch("/api/v1/sessions", { method: "POST" });
+  if (!r.ok) {
+    const body = await r.text().catch(() => "");
+    throw new Error(`POST /api/v1/sessions failed: ${r.status} ${body}`);
+  }
+  return (await r.json()) as SessionCreated;
+}
+
+export function connectChatWs(
+  sessionId: string,
+  handlers: ChatWsHandlers,
+): ChatWs {
+  // Same-origin WebSocket — derive ws:// or wss:// from the page's
+  // protocol so HTTPS deployments (none today, but coming once the
+  // localhost UI moves behind reverse-proxied TLS for ops use) are
+  // automatic.
+  const proto = window.location.protocol === "https:" ? "wss" : "ws";
+  const url = `${proto}://${window.location.host}/api/v1/stream?sid=${encodeURIComponent(sessionId)}`;
+  const ws = new WebSocket(url);
+
+  ws.addEventListener("open", () => handlers.onOpen?.());
+  ws.addEventListener("close", (ev) =>
+    handlers.onClose?.(ev.code, ev.reason),
+  );
+  ws.addEventListener("error", (ev) => handlers.onError?.(ev));
+  ws.addEventListener("message", (ev) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(ev.data as string);
+    } catch (e) {
+      handlers.onError?.(e);
+      return;
+    }
+    if (isServerFrame(parsed)) {
+      handlers.onFrame(parsed);
+    } else {
+      handlers.onUnknown?.(parsed);
+    }
+  });
+
+  return {
+    send: (frame: ClientFrame) => {
+      ws.send(JSON.stringify(frame));
+    },
+    close: () => ws.close(),
+    readyState: () => ws.readyState,
+  };
+}
+
+function isServerFrame(v: unknown): v is ServerFrame {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (o.schema !== "v1" || typeof o.type !== "string") return false;
+  switch (o.type) {
+    case "turn_start":
+    case "turn_end":
+      return typeof o.turn_id === "string";
+    case "assistant_text":
+      return typeof o.turn_id === "string" && typeof o.text === "string";
+    case "error":
+      return typeof o.message === "string";
+    default:
+      return false;
+  }
+}

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -1,0 +1,354 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  ArrowDown,
+  Bot,
+  CircleAlert,
+  MessageSquare,
+  Send,
+  ShieldCheck,
+  User,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  connectChatWs,
+  createSession,
+  type ChatWs,
+  type ServerFrame,
+} from "@/lib/chat-ws";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  text: string;
+  /** Set on the assistant message that's currently streaming. */
+  pending?: boolean;
+  /** Set on assistant messages once `turn_end` arrives. The 1d.2c
+   *  verifiable-badge surface uses this hook. */
+  verifiable?: boolean;
+}
+
+type ConnState =
+  | { kind: "connecting" }
+  | { kind: "open"; sessionId: string }
+  | { kind: "closed"; reason?: string }
+  | { kind: "error"; message: string };
+
+export function Chat() {
+  const [conn, setConn] = useState<ConnState>({ kind: "connecting" });
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: "intro",
+      role: "system",
+      text: 'Welcome to the Aegis-Node chat surface (sub-phase 1d.2a). The backend is a stub — your prompts come back as "echo: …". Real Session::run_turn integration ships in 1d.2b.',
+    },
+  ]);
+  const [input, setInput] = useState("");
+  const wsRef = useRef<ChatWs | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Track which assistant turn is currently appending so streaming
+  // chunks land on the same message bubble instead of creating new
+  // ones. Cleared when turn_end fires.
+  const activeTurnRef = useRef<string | null>(null);
+
+  const handleFrame = useCallback((frame: ServerFrame) => {
+    switch (frame.type) {
+      case "turn_start": {
+        const turnId = frame.turn_id;
+        activeTurnRef.current = turnId;
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: turnId,
+            role: "assistant",
+            text: "",
+            pending: true,
+          },
+        ]);
+        break;
+      }
+      case "assistant_text": {
+        const turnId = frame.turn_id;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === turnId ? { ...m, text: m.text + frame.text } : m,
+          ),
+        );
+        break;
+      }
+      case "turn_end": {
+        const turnId = frame.turn_id;
+        activeTurnRef.current = null;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === turnId
+              ? { ...m, pending: false, verifiable: true }
+              : m,
+          ),
+        );
+        break;
+      }
+      case "error": {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `err-${Date.now()}`,
+            role: "system",
+            text: `error: ${frame.message}`,
+          },
+        ]);
+        break;
+      }
+    }
+  }, []);
+
+  // Bootstrap: create a session, then open the WebSocket.
+  useEffect(() => {
+    let cancelled = false;
+    let ws: ChatWs | null = null;
+
+    (async () => {
+      try {
+        const session = await createSession();
+        if (cancelled) return;
+        ws = connectChatWs(session.session_id, {
+          onOpen: () => {
+            if (!cancelled) {
+              setConn({ kind: "open", sessionId: session.session_id });
+            }
+          },
+          onFrame: handleFrame,
+          onClose: (code, reason) => {
+            if (!cancelled) {
+              setConn({
+                kind: "closed",
+                reason: reason || `code ${code}`,
+              });
+            }
+          },
+          onError: (e) => {
+            if (!cancelled) {
+              setConn({
+                kind: "error",
+                message: e instanceof Error ? e.message : String(e),
+              });
+            }
+          },
+        });
+        wsRef.current = ws;
+      } catch (e) {
+        if (!cancelled) {
+          setConn({
+            kind: "error",
+            message: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      ws?.close();
+      wsRef.current = null;
+    };
+  }, [handleFrame]);
+
+  // Keep the message list scrolled to bottom on append.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages]);
+
+  const canSend = useMemo(
+    () => conn.kind === "open" && input.trim().length > 0,
+    [conn, input],
+  );
+
+  function handleSend() {
+    if (!canSend || !wsRef.current) return;
+    const prompt = input.trim();
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `user-${Date.now()}`,
+        role: "user",
+        text: prompt,
+      },
+    ]);
+    wsRef.current.send({
+      schema: "v1",
+      type: "user_prompt",
+      prompt,
+    });
+    setInput("");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Enter sends; Shift+Enter inserts a newline (matches assistant-
+    // ui / Claude / ChatGPT convention).
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <>
+      <header className="mb-6 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <MessageSquare className="h-7 w-7 text-accent" aria-hidden="true" />
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Chat</h1>
+            <p className="text-sm text-muted">
+              Stub backend (sub-phase 1d.2a) · real engine integration
+              ships in 1d.2b
+            </p>
+          </div>
+        </div>
+        <ConnectionPill state={conn} />
+      </header>
+
+      <Card>
+        <CardContent className="flex h-[560px] flex-col gap-4 p-0">
+          <div
+            ref={scrollRef}
+            className="flex-1 overflow-y-auto px-6 pt-5 pb-2"
+          >
+            <div className="flex flex-col gap-4">
+              {messages.map((m) => (
+                <MessageBubble key={m.id} message={m} />
+              ))}
+            </div>
+          </div>
+
+          <div className="border-t border-[var(--color-border)] px-6 py-4">
+            <div className="flex items-end gap-2">
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={
+                  conn.kind === "open"
+                    ? "Type a message · Enter sends, Shift+Enter for newline"
+                    : "connecting…"
+                }
+                disabled={conn.kind !== "open"}
+                rows={2}
+                className="min-h-[44px] flex-1 resize-none rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm placeholder:text-muted focus:border-accent focus:outline-none disabled:opacity-50"
+              />
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={!canSend}
+                className="inline-flex h-11 items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] px-3 text-sm transition-colors hover:border-accent hover:text-accent disabled:opacity-50"
+                aria-label="Send"
+              >
+                <Send className="h-4 w-4" aria-hidden="true" />
+                <span>Send</span>
+              </button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  if (message.role === "system") {
+    return (
+      <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-xs text-muted">
+        {message.text}
+      </div>
+    );
+  }
+  const isUser = message.role === "user";
+  return (
+    <div
+      className={cn(
+        "flex gap-3",
+        isUser ? "flex-row-reverse" : "flex-row",
+      )}
+    >
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-elev)]">
+        {isUser ? (
+          <User className="h-4 w-4 text-muted" aria-hidden="true" />
+        ) : (
+          <Bot className="h-4 w-4 text-accent" aria-hidden="true" />
+        )}
+      </div>
+      <div className="flex max-w-[80%] flex-col gap-1">
+        <div
+          className={cn(
+            "whitespace-pre-wrap rounded-md px-3 py-2 text-sm",
+            isUser
+              ? "bg-[var(--color-bg-elev)] text-[var(--color-fg)]"
+              : "bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-fg)]",
+          )}
+        >
+          {message.text}
+          {message.pending && (
+            <span className="ml-1 inline-block h-3 w-3 animate-pulse rounded-full bg-accent align-middle" />
+          )}
+        </div>
+        {message.verifiable && (
+          <span
+            className="inline-flex items-center gap-1 self-start font-mono text-[10px] text-muted"
+            title="Sub-phase 1d.2c will hook this badge to the F9 ledger entry for this turn"
+          >
+            <ShieldCheck className="h-3 w-3" aria-hidden="true" />
+            verifiable (1d.2c)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConnectionPill({ state }: { state: ConnState }) {
+  if (state.kind === "connecting") {
+    return (
+      <span className="inline-flex items-center gap-1 font-mono text-xs text-muted">
+        <ArrowDown className="h-3.5 w-3.5 animate-pulse" aria-hidden="true" />
+        connecting…
+      </span>
+    );
+  }
+  if (state.kind === "open") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded bg-emerald-950/40 px-2 py-0.5 font-mono text-xs text-emerald-300"
+        title={`session ${state.sessionId}`}
+      >
+        <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+        connected
+      </span>
+    );
+  }
+  if (state.kind === "closed") {
+    return (
+      <span className="inline-flex items-center gap-1 font-mono text-xs text-amber-300">
+        <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />
+        closed{state.reason ? ` · ${state.reason}` : ""}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 font-mono text-xs text-red-400"
+      title={state.message}
+    >
+      <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />
+      error
+    </span>
+  );
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
 } from "@tanstack/react-router";
 import { TopNav } from "@/components/TopNav";
+import { Chat } from "@/pages/Chat";
 import { Home } from "@/pages/Home";
 import { Manifest } from "@/pages/Manifest";
 import { Models } from "@/pages/Models";
@@ -39,10 +40,17 @@ const modelsRoute = createRoute({
   component: Models,
 });
 
+const chatRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/chat",
+  component: Chat,
+});
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   manifestRoute,
   modelsRoute,
+  chatRoute,
 ]);
 
 export const router = createRouter({


### PR DESCRIPTION
## Summary

First slice of the chat surface (#147 / ADR-031 §"Context-aware chat"). Lands the **wire protocol + UI thread**; engine integration ships in 1d.2b.

## Backend

- **`POST /api/v1/sessions`** mints a UUIDv7-keyed session. In-memory `Arc<RwLock<HashMap>>` registry, transient by design.
- **`GET /api/v1/stream?sid=<id>`** WebSocket upgrade. Rejects unknown session IDs with **404 before upgrade** so the SPA's failure mode is unambiguous.

### Frame protocol v1

```
client → server: { schema:"v1", type:"user_prompt", prompt:"…" }
server → client: { schema:"v1", type:"turn_start", turn_id:"…" }
                 { schema:"v1", type:"assistant_text", turn_id:"…", text:"…" }
                 { schema:"v1", type:"turn_end", turn_id:"…" }
                 { schema:"v1", type:"error", message:"…" }
```

`schema: "v1"` at every frame keeps the door open for 1d.2c/d additions (`tool_call`, `tool_result`, verifiable-badge metadata) without breaking older clients.

The **stub turn** echoes the prompt as 2× `assistant_text` chunks (50 ms apart) so the SPA's streaming-append rendering is exercised before the real engine lands.

### Router refactor

Introduced `AppState { config, sessions }` with `FromRef` impls so existing handlers keep `State<Config>` unchanged. Added deps: `axum/ws`, `futures-util` (no default features), `uuid` v7 (matches `access-log` + `ledger-writer` convention).

## Frontend

- **`ui/src/lib/chat-ws.ts`** — typed WS wrapper. `ServerFrame`/`ClientFrame` discriminated unions mirror the Rust enums; `isServerFrame` type-guard ignores unknown frame types non-fatally.
- **`ui/src/pages/Chat.tsx`** — chat thread on raw shadcn primitives. Streaming append, pulsing accent dot during pending turns, placeholder `verifiable (1d.2c)` badge once `turn_end` fires (1d.2c hooks it to the F9 ledger entry). Connection-state pill in the header. Enter sends, Shift+Enter newline.
- New `/chat` top-nav route.

**No `assistant-ui` yet** — its opinionated message shape is best introduced in 1d.2b/c when verifiable badges + tool-call cards need its primitives. For 1d.2a a thin shadcn thread keeps the moving parts visible.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude aegis-llama-backend --all-targets -- -D warnings` clean
- [x] `cargo test -p aegis-ui-server --lib`: 16/16 (was 10; +6 sessions unit tests covering schema envelope, type-tagged variants, registry semantics, UUIDv7 uniqueness)
- [x] `pnpm typecheck` + `pnpm build`: clean
- [x] **Real WebSocket round-trip (raw socket)**: handshake `101 Switching Protocols`; 4-frame turn protocol delivered correctly; all frames carry `schema:"v1"` + matching `turn_id`
- [x] Manual SPA smoke: open `/chat`, type "hello", see assistant message stream in chunked, verifiable badge appears post-`turn_end`
- [ ] CI green

## What lands in 1d.2b

- `run_stub_turn` body replaced with `Session::run_turn` driving the llama / litertlm backend
- Token-by-token streaming via the existing `assistant_text` frame
- Real stop button with partial-ledger preservation per ADR-025

Tracking: #147, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)