### PR TITLE
feat(ui-server, cli): real Session::run_turn integration in chat surface (sub-phase 1d.2b)

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -530,6 +530,71 @@ fn default_identity_dir() -> Result<PathBuf> {
     Ok(base.join("aegis").join("identity"))
 }
 
+/// Boot a [`Session`] for the chat surface (sub-phase 1d.2b) using
+/// the same path `aegis run --prompt` takes: `BootConfig` →
+/// `Session::boot` → optional approval/MCP wiring → load backend →
+/// `set_loaded_model`. The returned session is ready for any number
+/// of `run_turn` calls.
+///
+/// Why a dedicated function rather than reusing [`execute`]:
+/// `execute` runs exactly one turn and shuts down; the chat surface
+/// keeps the session alive for the lifetime of the `aegis ui`
+/// process. This split keeps both code paths legible without
+/// branching `execute` on a "don't shut down" flag.
+#[allow(clippy::too_many_arguments)]
+pub fn boot_session_for_ui(
+    manifest_path: PathBuf,
+    model_path: PathBuf,
+    config_path: Option<PathBuf>,
+    chat_template_sidecar: Option<PathBuf>,
+    identity_dir: Option<PathBuf>,
+    workload: String,
+    instance: String,
+    ledger_path: Option<PathBuf>,
+    backend: BackendKind,
+) -> Result<Session> {
+    let session_id = format!("session-ui-{}", uuid_v7_like());
+    let ledger_path = ledger_path
+        .unwrap_or_else(|| PathBuf::from(format!("ledger-ui-{session_id}.jsonl")));
+    let identity_dir = match identity_dir {
+        Some(p) => p,
+        None => default_identity_dir()?,
+    };
+
+    let cfg = BootConfig {
+        session_id,
+        manifest_path,
+        model_path: model_path.clone(),
+        config_path,
+        chat_template_sidecar,
+        identity_dir,
+        workload_name: workload,
+        instance,
+        ledger_path,
+    };
+    let mut session = Session::boot(cfg).context("boot")?;
+
+    // Mirror `execute`'s optional wiring so the chat surface picks
+    // up F3 file approvals + MCP servers when configured the same
+    // way operators configure them for `aegis run --prompt`.
+    if let Ok(approval_path) = std::env::var("AEGIS_APPROVAL_FILE") {
+        let channel = aegis_approval_gate::FileApprovalChannel::new(approval_path);
+        session = session.with_approval_channel(Box::new(channel));
+    }
+    if !session.policy().manifest().tools.mcp.is_empty() {
+        let mcp_client = aegis_mcp_client::StdioMcpClient::new();
+        session = session.with_mcp_client(Box::new(mcp_client));
+    }
+
+    let loaded = match backend {
+        BackendKind::Llama => load_llama_backend(&session, &model_path)?,
+        BackendKind::Litertlm => load_litertlm_backend(&session, &model_path)?,
+    };
+    session.set_loaded_model(loaded);
+
+    Ok(session)
+}
+
 /// Tiny v7-shaped session-id generator without pulling the `uuid`
 /// crate into `crates/cli` (it's already a transitive dep but adding
 /// it directly is unnecessary churn). Format: hex of an `u128`

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -554,8 +554,8 @@ pub fn boot_session_for_ui(
     backend: BackendKind,
 ) -> Result<Session> {
     let session_id = format!("session-ui-{}", uuid_v7_like());
-    let ledger_path = ledger_path
-        .unwrap_or_else(|| PathBuf::from(format!("ledger-ui-{session_id}.jsonl")));
+    let ledger_path =
+        ledger_path.unwrap_or_else(|| PathBuf::from(format!("ledger-ui-{session_id}.jsonl")));
     let identity_dir = match identity_dir {
         Some(p) => p,
         None => default_identity_dir()?,

--- a/crates/cli/src/ui.rs
+++ b/crates/cli/src/ui.rs
@@ -2,23 +2,26 @@
 //!
 //! Per [ADR-031](../../../docs/adrs/031-community-webui-for-local-collaboration.md)
 //! the UI is a static SPA bundled into the binary, served by an
-//! axum process bound to a loopback address. This subcommand is the
-//! sub-phase 1d.0 entry point — it boots the server and serves the
-//! placeholder `ui/dist/` payload.
-//!
-//! Sub-phase 1d.2 ([docs/plans/v0.9.5-ui-implementation.md](../../../docs/plans/v0.9.5-ui-implementation.md))
-//! will fold this into `aegis run --ui` once the chat surface ties
-//! to a `Session::run_turn` loop. Until then `aegis ui` runs
-//! standalone — no manifest, no model required, only the static
-//! placeholder + `/api/v1/version`.
+//! axum process bound to a loopback address. Sub-phase 1d.2b adds
+//! optional `--manifest` / `--model` / `--backend` flags so the
+//! chat surface drives a real `Session::run_turn` against a loaded
+//! inference engine. Without those flags the server still runs and
+//! the chat surface falls back to a stub-echo backend (per
+//! [`aegis_ui_server::StubBackend`]) that explains how to attach a
+//! model.
 //!
 //! Ctrl-C cleanly shuts the server down.
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
-use aegis_ui_server::Config;
+use aegis_inference_engine::Session;
+use aegis_ui_server::{ChatBackend, ChatBackendError, Config, StubBackend, TurnResult};
 use anyhow::{Context, Result};
 use clap::Args;
+
+use crate::run::{boot_session_for_ui, BackendKind};
 
 #[derive(Debug, Args)]
 pub struct UiArgs {
@@ -27,6 +30,53 @@ pub struct UiArgs {
     /// non-loopback values are refused at bind time, not just here.
     #[arg(long, default_value = "127.0.0.1:7777")]
     pub listen: SocketAddr,
+
+    /// Path to the manifest YAML the chat surface should bind to.
+    /// When provided alongside `--model`, `aegis ui` boots a
+    /// `Session` at startup and the chat surface drives a real
+    /// `Session::run_turn`. Omitting either value keeps the chat
+    /// surface on [`StubBackend`] echo with an operator hint.
+    #[arg(long)]
+    pub manifest: Option<PathBuf>,
+
+    /// Path to the model artifact (per `aegis pull`'s cache layout
+    /// — typically `~/.cache/aegis/models/<digest>/blob.bin`).
+    #[arg(long)]
+    pub model: Option<PathBuf>,
+
+    /// Which inference backend powers the chat surface. Mirrors
+    /// `aegis run --backend`. Each requires the matching Cargo
+    /// feature at build time.
+    #[arg(long, default_value = "llama")]
+    pub backend: BackendKind,
+
+    /// Optional runtime config file (digest source) — same role as
+    /// `aegis run --config`.
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Optional `chat_template.sha256.txt` sidecar produced by
+    /// `aegis pull` (per ADR-022 / OCI-B).
+    #[arg(long)]
+    pub chat_template_sidecar: Option<PathBuf>,
+
+    /// Where the local CA's `ca.crt`/`ca.key` live. Default:
+    /// `$XDG_CONFIG_HOME/aegis/identity`.
+    #[arg(long)]
+    pub identity_dir: Option<PathBuf>,
+
+    /// SPIFFE workload-name segment.
+    #[arg(long, default_value = "ui")]
+    pub workload: String,
+
+    /// SPIFFE instance segment.
+    #[arg(long, default_value = "inst-1")]
+    pub instance: String,
+
+    /// Output JSONL ledger path. Defaults to
+    /// `./ledger-ui-<session-id>.jsonl`.
+    #[arg(long)]
+    pub ledger: Option<PathBuf>,
 }
 
 /// Entry-point invoked from `aegis_cli::run`.
@@ -42,6 +92,8 @@ pub fn execute(args: UiArgs) -> Result<()> {
             args.listen,
         );
     }
+
+    let chat_backend = build_chat_backend(&args)?;
 
     let config = Config {
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -62,13 +114,59 @@ pub fn execute(args: UiArgs) -> Result<()> {
 
     runtime.block_on(async move {
         tokio::select! {
-            res = aegis_ui_server::serve(config) => res,
+            res = aegis_ui_server::serve_with_backend(config, chat_backend) => res,
             _ = tokio::signal::ctrl_c() => {
                 eprintln!("\nshutting down");
                 Ok(())
             }
         }
     })
+}
+
+/// Resolve the chat backend based on the CLI args. Returns the real
+/// [`SessionBackend`] when both `--manifest` and `--model` are
+/// provided AND the matching Cargo feature is built; otherwise a
+/// [`StubBackend`] so the chat surface stays visibly functional with
+/// an operator hint.
+///
+/// Half-set inputs (one of `--manifest`/`--model` provided but not
+/// the other) are a usage error — the operator clearly meant to
+/// attach a Session, so failing fast is friendlier than silently
+/// falling back to the stub.
+fn build_chat_backend(args: &UiArgs) -> Result<Arc<dyn ChatBackend>> {
+    match (&args.manifest, &args.model) {
+        (Some(manifest), Some(model)) => {
+            eprintln!(
+                "booting Session against manifest={} model={} backend={:?}",
+                manifest.display(),
+                model.display(),
+                args.backend,
+            );
+            let session = boot_session_for_ui(
+                manifest.clone(),
+                model.clone(),
+                args.config.clone(),
+                args.chat_template_sidecar.clone(),
+                args.identity_dir.clone(),
+                args.workload.clone(),
+                args.instance.clone(),
+                args.ledger.clone(),
+                args.backend,
+            )
+            .context("booting Session for chat surface")?;
+            Ok(Arc::new(SessionBackend::new(session)))
+        }
+        (None, None) => {
+            eprintln!(
+                "no --manifest/--model provided — chat surface uses StubBackend (echo + hint)",
+            );
+            Ok(Arc::new(StubBackend))
+        }
+        (Some(_), None) | (None, Some(_)) => anyhow::bail!(
+            "--manifest and --model must be provided together. Omit both for the stub backend, \
+             or pass both for real Session::run_turn integration.",
+        ),
+    }
 }
 
 /// Names of the optional Cargo features the CLI was compiled with.
@@ -83,4 +181,69 @@ fn compiled_features() -> Vec<String> {
         v.push("litertlm".to_string());
     }
     v
+}
+
+/// `ChatBackend` impl that wraps a real
+/// [`aegis_inference_engine::Session`]. The Session is held behind a
+/// `Mutex` because `Session::run_turn` needs `&mut self` and multiple
+/// WebSocket connections may share the chat surface — the Mutex
+/// serializes turns, which is fine for v0.9.5's single-user posture
+/// (one operator at the keyboard at a time per ADR-031).
+///
+/// Future v1.0.0 multi-turn work (ADRs 025–030) brings per-turn
+/// circuit breakers and aggregate quotas; both compose cleanly with
+/// the lock-around-Session pattern.
+struct SessionBackend {
+    inner: Arc<Mutex<Session>>,
+}
+
+impl SessionBackend {
+    fn new(session: Session) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(session)),
+        }
+    }
+}
+
+impl ChatBackend for SessionBackend {
+    fn run_turn(&self, prompt: &str) -> Result<TurnResult, ChatBackendError> {
+        let mut session = self
+            .inner
+            .lock()
+            .map_err(|e| ChatBackendError::new(format!("session mutex poisoned: {e}")))?;
+
+        let outcome = session
+            .run_turn(prompt)
+            .map_err(|e| ChatBackendError::new(format!("Session::run_turn: {e}")))?;
+
+        let summaries = outcome
+            .tool_calls
+            .iter()
+            .map(|call| format_tool_call_summary(&call.name, &call.result))
+            .collect();
+
+        Ok(TurnResult {
+            assistant_text: outcome.assistant_text,
+            tool_call_summaries: summaries,
+        })
+    }
+}
+
+/// Render one tool-call outcome as a human-readable single line.
+/// Mirrors the rendering logic in `aegis run --prompt`; sub-phase
+/// 1d.2c will replace this with structured frames the SPA renders
+/// as inline cards with the gate decision.
+fn format_tool_call_summary(
+    name: &str,
+    result: &aegis_inference_engine::ToolCallResult,
+) -> String {
+    use aegis_inference_engine::ToolCallResult;
+    match result {
+        ToolCallResult::Success(_) => format!("{name} → success"),
+        ToolCallResult::Denied(reason) => format!("{name} → DENIED: {reason}"),
+        ToolCallResult::RequiresApproval(reason) => {
+            format!("{name} → REQUIRES_APPROVAL: {reason}")
+        }
+        ToolCallResult::Unroutable(reason) => format!("{name} → UNROUTABLE: {reason}"),
+    }
 }

--- a/crates/cli/src/ui.rs
+++ b/crates/cli/src/ui.rs
@@ -233,10 +233,7 @@ impl ChatBackend for SessionBackend {
 /// Mirrors the rendering logic in `aegis run --prompt`; sub-phase
 /// 1d.2c will replace this with structured frames the SPA renders
 /// as inline cards with the gate decision.
-fn format_tool_call_summary(
-    name: &str,
-    result: &aegis_inference_engine::ToolCallResult,
-) -> String {
+fn format_tool_call_summary(name: &str, result: &aegis_inference_engine::ToolCallResult) -> String {
     use aegis_inference_engine::ToolCallResult;
     match result {
         ToolCallResult::Success(_) => format!("{name} → success"),

--- a/crates/ui-server/src/chat.rs
+++ b/crates/ui-server/src/chat.rs
@@ -1,0 +1,170 @@
+//! Chat backend abstraction — the seam between the WebSocket
+//! transport (in `handlers/sessions.rs`) and the inference engine
+//! (in `aegis-cli` / `aegis-inference-engine`).
+//!
+//! Sub-phase 1d.2b decouples the two so `crates/ui-server` stays
+//! free of `aegis-inference-engine` (which would pull in the
+//! llama.cpp / LiteRT-LM C++ build trees, balloon compile times,
+//! and tangle the feature-flag matrix). Instead the trait below
+//! is the contract: `aegis-cli` provides an implementation that
+//! wraps a real `Session` when booted with `--manifest` + `--model`,
+//! or the [`StubBackend`] default for operators who want the chat
+//! UI without a model attached.
+//!
+//! ## Why a trait, not a concrete type
+//!
+//! - **Crate-graph tidiness**: ui-server depends on `dirs`,
+//!   `axum`, `serde_json`. It MUST NOT pull in
+//!   `aegis-inference-engine` — that crate's dep graph touches
+//!   `aegis-llama-backend` (cmake + bindgen + llama.cpp) and
+//!   `aegis-litertlm-backend` (Bazel-prebuilt `.so` from OCI).
+//!   A direct dep would force every workspace build path to pay
+//!   that cost.
+//! - **Test substitutability**: a [`MockBackend`] (in tests) lets
+//!   us exercise the WS handler's frame protocol against a known
+//!   response without booting a real model.
+//!
+//! ## Threading model
+//!
+//! `ChatBackend::run_turn` is **synchronous** because the
+//! underlying `Session::run_turn` is. The WebSocket handler
+//! invokes it via `tokio::task::spawn_blocking` so the inference
+//! step doesn't stall the executor. Callers don't need to be
+//! `async`; they MUST be `Send + Sync` so the trait object can
+//! live behind an `Arc` shared across connections.
+
+use std::fmt;
+
+/// Result of one chat turn — what the trait impl returns to the
+/// WebSocket handler. Strips the inference-engine types so this
+/// crate stays leaf-level on the dep graph.
+#[derive(Debug, Clone)]
+pub struct TurnResult {
+    /// Assistant text the model produced. `None` when the model
+    /// emitted only tool calls (the chat surface still needs to
+    /// render *something*; the WS handler synthesizes a placeholder
+    /// in that case).
+    pub assistant_text: Option<String>,
+    /// Per-tool-call summary lines, one per call in emission order.
+    /// 1d.2b renders these as plain text appended to the assistant
+    /// reply; 1d.2c introduces structured tool-call frames per
+    /// ADR-031 §"Inline tool-call cards."
+    pub tool_call_summaries: Vec<String>,
+}
+
+/// Failure mode for a chat turn. Plain message — the WS handler
+/// surfaces it as an `error` frame the SPA renders inline without
+/// dropping the connection.
+#[derive(Debug, Clone)]
+pub struct ChatBackendError {
+    pub message: String,
+}
+
+impl fmt::Display for ChatBackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ChatBackendError {}
+
+impl ChatBackendError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// The chat surface's backend boundary. Implementations:
+///
+/// - [`StubBackend`] — built into this crate; returns an "operator
+///   hint" message explaining how to enable real inference.
+/// - `aegis-cli`'s `SessionBackend` — wraps an `Arc<Mutex<Session>>`,
+///   plumbed in when `aegis ui --manifest <m> --model <m>` is set.
+///
+/// `Send + Sync` because the trait object lives behind an `Arc`
+/// shared across WebSocket handlers.
+pub trait ChatBackend: Send + Sync {
+    /// Run one user-prompt turn. Synchronous on purpose — the
+    /// caller wraps in `tokio::task::spawn_blocking` to keep the
+    /// async runtime free.
+    fn run_turn(&self, prompt: &str) -> Result<TurnResult, ChatBackendError>;
+}
+
+/// Default backend when `aegis ui` is started without
+/// `--manifest`/`--model`. Echoes the prompt back with an operator
+/// hint so the chat surface remains visibly functional during demos
+/// — the wow-factor framing in ADR-031 expects a usable UI even
+/// when no model is loaded.
+pub struct StubBackend;
+
+impl ChatBackend for StubBackend {
+    fn run_turn(&self, prompt: &str) -> Result<TurnResult, ChatBackendError> {
+        Ok(TurnResult {
+            assistant_text: Some(format!(
+                "echo: {prompt}\n\n(stub backend — start `aegis ui --manifest <m> --model <m> [--backend llama|litertlm]` to attach a real Session::run_turn)"
+            )),
+            tool_call_summaries: Vec::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// A test-only backend that records prompts it received + returns a
+    /// caller-supplied response. Used in handler tests to exercise the
+    /// WS frame protocol without booting an inference engine.
+    pub struct MockBackend {
+        pub response: String,
+        pub calls: AtomicUsize,
+    }
+
+    impl MockBackend {
+        pub fn new(response: impl Into<String>) -> Arc<Self> {
+            Arc::new(Self {
+                response: response.into(),
+                calls: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    impl ChatBackend for MockBackend {
+        fn run_turn(&self, _prompt: &str) -> Result<TurnResult, ChatBackendError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(TurnResult {
+                assistant_text: Some(self.response.clone()),
+                tool_call_summaries: Vec::new(),
+            })
+        }
+    }
+
+    #[test]
+    fn stub_echoes_prompt_with_hint() {
+        let r = StubBackend.run_turn("hi").unwrap();
+        let text = r.assistant_text.unwrap();
+        assert!(text.contains("echo: hi"));
+        assert!(text.contains("--manifest"));
+        assert!(text.contains("--model"));
+        assert!(r.tool_call_summaries.is_empty());
+    }
+
+    #[test]
+    fn mock_records_call_count() {
+        let m = MockBackend::new("ok");
+        m.run_turn("x").unwrap();
+        m.run_turn("y").unwrap();
+        assert_eq!(m.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn error_renders_via_display() {
+        let e = ChatBackendError::new("boom");
+        assert_eq!(format!("{e}"), "boom");
+    }
+}

--- a/crates/ui-server/src/handlers/sessions.rs
+++ b/crates/ui-server/src/handlers/sessions.rs
@@ -134,6 +134,7 @@ pub async fn stream(
     ws: WebSocketUpgrade,
     Query(params): Query<ConnectParams>,
     State(reg): State<SessionRegistry>,
+    State(backend): State<std::sync::Arc<dyn crate::ChatBackend>>,
 ) -> Response {
     if !reg.exists(&params.sid).await {
         return (
@@ -142,7 +143,7 @@ pub async fn stream(
         )
             .into_response();
     }
-    ws.on_upgrade(move |socket| handle_socket(socket, params.sid))
+    ws.on_upgrade(move |socket| handle_socket(socket, params.sid, backend))
 }
 
 /// Server → client frame body. The wire form has `schema: "v1"` at
@@ -197,7 +198,11 @@ fn encode(frame: &ServerFrame) -> Result<String, serde_json::Error> {
     serde_json::to_string(&value)
 }
 
-async fn handle_socket(mut socket: WebSocket, session_id: String) {
+async fn handle_socket(
+    mut socket: WebSocket,
+    session_id: String,
+    backend: std::sync::Arc<dyn crate::ChatBackend>,
+) {
     tracing::info!(target: "aegis_ui_server", session_id = %session_id, "ws connected");
     while let Some(msg) = socket.next().await {
         let msg = match msg {
@@ -209,7 +214,9 @@ async fn handle_socket(mut socket: WebSocket, session_id: String) {
         };
         match msg {
             Message::Text(text) => {
-                if let Err(e) = handle_text_frame(&mut socket, &session_id, text).await {
+                if let Err(e) =
+                    handle_text_frame(&mut socket, &session_id, text, &backend).await
+                {
                     tracing::warn!(target: "aegis_ui_server", session_id = %session_id, err = %e, "frame handler errored");
                 }
             }
@@ -228,6 +235,7 @@ async fn handle_text_frame(
     socket: &mut WebSocket,
     session_id: &str,
     text: String,
+    backend: &std::sync::Arc<dyn crate::ChatBackend>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let frame: ClientFrame = match serde_json::from_str(&text) {
         Ok(f) => f,
@@ -237,22 +245,28 @@ async fn handle_text_frame(
         }
     };
     match frame {
-        ClientFrame::UserPrompt { prompt } => run_stub_turn(socket, session_id, &prompt).await,
+        ClientFrame::UserPrompt { prompt } => {
+            run_turn(socket, session_id, &prompt, backend).await
+        }
     }
 }
 
-/// Stub turn: emit `turn_start`, a single `assistant_text` echoing
-/// the prompt, then `turn_end`. Sub-phase 1d.2b replaces this body
-/// with `Session::run_turn` driving the real engine.
+/// Drive one chat turn against the configured [`ChatBackend`]. Emits
+/// `turn_start`, then char-chunked `assistant_text` frames so the
+/// SPA's streaming-append rendering animates even though the
+/// backend currently returns the response whole. Tool-call summaries
+/// (1d.2b) trail as plain text; structured tool-call frames land in
+/// 1d.2c per ADR-031.
 ///
-/// The intentional 50 ms delay between frames lets the SPA prove its
-/// streaming-append rendering works (frames arrive separately) without
-/// any backend-side complexity. Drop the sleep when the real engine
-/// integration lands — token-by-token streaming gives natural pacing.
-async fn run_stub_turn(
+/// The synchronous `ChatBackend::run_turn` runs on a `spawn_blocking`
+/// thread so the inference step doesn't stall the async runtime —
+/// llama.cpp / LiteRT-LM tokens are CPU-bound and would otherwise
+/// block other WebSocket connections sharing the executor.
+async fn run_turn(
     socket: &mut WebSocket,
     _session_id: &str,
     prompt: &str,
+    backend: &std::sync::Arc<dyn crate::ChatBackend>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let turn_id = Uuid::now_v7().to_string();
 
@@ -264,27 +278,127 @@ async fn run_stub_turn(
     )
     .await?;
 
-    // Two chunks so the SPA's append-on-streaming path is exercised.
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    send_frame(
-        socket,
-        &ServerFrame::AssistantText {
-            turn_id: turn_id.clone(),
-            text: format!("echo: {prompt}"),
-        },
-    )
-    .await?;
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    send_frame(
-        socket,
-        &ServerFrame::AssistantText {
-            turn_id: turn_id.clone(),
-            text: "\n\n(stub backend — Session::run_turn integration ships in 1d.2b)".to_string(),
-        },
-    )
-    .await?;
+    // Hand the inference call to a blocking thread. `Backend::run_turn`
+    // is sync (Session::run_turn is sync); blocking the executor would
+    // freeze every other WebSocket on this process.
+    let prompt_owned = prompt.to_string();
+    let backend_for_blocking = backend.clone();
+    let result = tokio::task::spawn_blocking(move || backend_for_blocking.run_turn(&prompt_owned))
+        .await
+        .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(e.to_string()))?;
+
+    let outcome = match result {
+        Ok(o) => o,
+        Err(e) => {
+            send_error(socket, &format!("backend error: {e}")).await?;
+            send_frame(socket, &ServerFrame::TurnEnd { turn_id }).await?;
+            return Ok(());
+        }
+    };
+
+    let mut emitted_any_text = false;
+    if let Some(text) = outcome.assistant_text.as_ref() {
+        if !text.is_empty() {
+            stream_chunked(socket, &turn_id, text).await?;
+            emitted_any_text = true;
+        }
+    }
+
+    // Tool-call summaries get appended as plain text for 1d.2b.
+    // Structured `tool_call` / `tool_result` frames per ADR-031
+    // §"Inline tool-call cards" land in sub-phase 1d.2c; the
+    // protocol enum is already designed to extend without breaking
+    // older clients.
+    if !outcome.tool_call_summaries.is_empty() {
+        let header = if emitted_any_text {
+            "\n\n---\n"
+        } else {
+            "---\n"
+        };
+        send_frame(
+            socket,
+            &ServerFrame::AssistantText {
+                turn_id: turn_id.clone(),
+                text: header.to_string(),
+            },
+        )
+        .await?;
+        for summary in &outcome.tool_call_summaries {
+            send_frame(
+                socket,
+                &ServerFrame::AssistantText {
+                    turn_id: turn_id.clone(),
+                    text: format!("· {summary}\n"),
+                },
+            )
+            .await?;
+            tokio::time::sleep(Duration::from_millis(CHUNK_DELAY_MS)).await;
+        }
+        emitted_any_text = true;
+    }
+
+    if !emitted_any_text {
+        // Either no text + no tool calls, or text was empty. The SPA
+        // still needs *something* to render so the assistant bubble
+        // doesn't appear empty.
+        send_frame(
+            socket,
+            &ServerFrame::AssistantText {
+                turn_id: turn_id.clone(),
+                text: "(no output from backend)".to_string(),
+            },
+        )
+        .await?;
+    }
 
     send_frame(socket, &ServerFrame::TurnEnd { turn_id }).await?;
+    Ok(())
+}
+
+/// Per-frame char budget for chunked streaming. ~80 chars per frame
+/// gives the SPA enough granularity to show the typing animation
+/// without flooding the WebSocket.
+const CHUNK_SIZE_CHARS: usize = 80;
+/// Delay between chunks in chunked streaming. 30 ms feels like
+/// natural typing pace; lower values make the animation feel
+/// jittery on slow connections.
+const CHUNK_DELAY_MS: u64 = 30;
+
+/// Split `text` into UTF-8-safe chunks of roughly [`CHUNK_SIZE_CHARS`]
+/// characters and emit each as its own `assistant_text` frame with a
+/// small delay. Once the inference backends grow real token-by-token
+/// streaming, this body gets replaced with a token stream consumer
+/// (the wire shape stays identical).
+async fn stream_chunked(
+    socket: &mut WebSocket,
+    turn_id: &str,
+    text: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut buf = String::with_capacity(CHUNK_SIZE_CHARS + 4);
+    for ch in text.chars() {
+        buf.push(ch);
+        if buf.chars().count() >= CHUNK_SIZE_CHARS {
+            send_frame(
+                socket,
+                &ServerFrame::AssistantText {
+                    turn_id: turn_id.to_string(),
+                    text: std::mem::take(&mut buf),
+                },
+            )
+            .await?;
+            tokio::time::sleep(Duration::from_millis(CHUNK_DELAY_MS)).await;
+        }
+    }
+    if !buf.is_empty() {
+        send_frame(
+            socket,
+            &ServerFrame::AssistantText {
+                turn_id: turn_id.to_string(),
+                text: buf,
+            },
+        )
+        .await?;
+    }
     Ok(())
 }
 

--- a/crates/ui-server/src/handlers/sessions.rs
+++ b/crates/ui-server/src/handlers/sessions.rs
@@ -214,9 +214,7 @@ async fn handle_socket(
         };
         match msg {
             Message::Text(text) => {
-                if let Err(e) =
-                    handle_text_frame(&mut socket, &session_id, text, &backend).await
-                {
+                if let Err(e) = handle_text_frame(&mut socket, &session_id, text, &backend).await {
                     tracing::warn!(target: "aegis_ui_server", session_id = %session_id, err = %e, "frame handler errored");
                 }
             }
@@ -245,9 +243,7 @@ async fn handle_text_frame(
         }
     };
     match frame {
-        ClientFrame::UserPrompt { prompt } => {
-            run_turn(socket, session_id, &prompt, backend).await
-        }
+        ClientFrame::UserPrompt { prompt } => run_turn(socket, session_id, &prompt, backend).await,
     }
 }
 

--- a/crates/ui-server/src/lib.rs
+++ b/crates/ui-server/src/lib.rs
@@ -28,15 +28,18 @@
 //! accidentally expose the surface either.
 
 use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 
 use axum::extract::FromRef;
 use axum::routing::{get, post};
 use axum::Router;
 use serde::Serialize;
 
+pub mod chat;
 mod embed;
 mod handlers;
 
+pub use chat::{ChatBackend, ChatBackendError, StubBackend, TurnResult};
 pub use embed::UiDist;
 pub use handlers::sessions::SessionRegistry;
 
@@ -63,14 +66,18 @@ pub struct Config {
 
 /// Composite handler state. axum's `FromRef` impls below let
 /// individual handlers extract whichever sub-state they need
-/// (`State<Config>` or `State<SessionRegistry>`) without the router
-/// having to thread a tuple of states. Sub-phase 1d.2a introduces
-/// `SessionRegistry` for the chat surface; future surfaces add their
-/// own sub-states as new fields here.
+/// (`State<Config>` / `State<SessionRegistry>` / `State<Arc<dyn ChatBackend>>`)
+/// without the router having to thread a tuple of states.
 #[derive(Clone)]
 pub struct AppState {
     pub config: Config,
     pub sessions: SessionRegistry,
+    /// The chat surface's backend. Sub-phase 1d.2b plumbs the real
+    /// `Session::run_turn`-driven implementation through here when
+    /// `aegis ui --manifest <m> --model <m>` is provided; otherwise
+    /// [`StubBackend`] keeps the chat UI visibly functional with an
+    /// operator hint.
+    pub chat_backend: Arc<dyn ChatBackend>,
 }
 
 impl FromRef<AppState> for Config {
@@ -85,16 +92,33 @@ impl FromRef<AppState> for SessionRegistry {
     }
 }
 
-/// Build the axum router for the UI server. Pure: no I/O, no socket
-/// binding — call [`serve`] to actually run it.
+impl FromRef<AppState> for Arc<dyn ChatBackend> {
+    fn from_ref(state: &AppState) -> Arc<dyn ChatBackend> {
+        state.chat_backend.clone()
+    }
+}
+
+/// Build the axum router for the UI server with the default
+/// [`StubBackend`] attached. Convenience wrapper around
+/// [`router_with_backend`] for callers who don't have a real
+/// backend ready (tests, the CLI's no-model path).
+pub fn router(config: Config) -> Router {
+    router_with_backend(config, Arc::new(StubBackend))
+}
+
+/// Build the axum router with a caller-supplied [`ChatBackend`].
+/// `aegis-cli`'s `aegis ui` subcommand uses this overload when
+/// `--manifest`/`--model` are provided so the chat surface drives a
+/// real `Session::run_turn` instead of the stub echo.
 ///
 /// `SessionRegistry` is constructed fresh inside the router; sessions
 /// don't survive a process restart (per ADR-031 §"Single agent, single
 /// user" — persistence-across-restart is a v1.0.0 multi-turn concern).
-pub fn router(config: Config) -> Router {
+pub fn router_with_backend(config: Config, chat_backend: Arc<dyn ChatBackend>) -> Router {
     let state = AppState {
         config,
         sessions: SessionRegistry::new(),
+        chat_backend,
     };
     Router::new()
         .route("/healthz", get(handlers::health::healthz))
@@ -123,6 +147,17 @@ pub fn router(config: Config) -> Router {
 /// [ADR-031](../../docs/adrs/031-community-webui-for-local-collaboration.md)
 /// §"Localhost-only" there is no escape hatch.
 pub async fn serve(config: Config) -> anyhow::Result<()> {
+    serve_with_backend(config, Arc::new(StubBackend)).await
+}
+
+/// `serve` + a caller-supplied [`ChatBackend`]. The CLI's `aegis ui`
+/// subcommand uses this overload when it has a Session ready to
+/// drive the chat surface; the no-backend path uses [`serve`] which
+/// falls back to [`StubBackend`].
+pub async fn serve_with_backend(
+    config: Config,
+    chat_backend: Arc<dyn ChatBackend>,
+) -> anyhow::Result<()> {
     let addr = config.listen;
     if !is_loopback(addr.ip()) {
         anyhow::bail!(
@@ -134,7 +169,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let bound = listener.local_addr()?;
     tracing::info!(target: "aegis_ui_server", addr = %bound, "ui-server listening");
-    axum::serve(listener, router(config)).await?;
+    axum::serve(listener, router_with_backend(config, chat_backend)).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Closes the stub-echo loop from #150 with real model-driven turns. Operators starting `aegis ui --manifest <m> --model <m>` now get the same `Session::run_turn` flow `aegis run --prompt` runs, with the assistant text streamed back through the v1 frame protocol.

## Architecture: ChatBackend trait

New **`crates/ui-server/src/chat.rs`** defines:

- `ChatBackend` trait — `fn run_turn(&self, prompt: &str) -> Result<TurnResult, ChatBackendError>`
- `StubBackend` default — echoes the prompt with an operator hint
- `TurnResult` / `ChatBackendError` types — strip the inference-engine types so ui-server stays **leaf-level on the dep graph** (no llama.cpp / LiteRT-LM build cost on `cargo build -p aegis-ui-server`)

The trait lives in ui-server; the real implementation lives in `aegis-cli`. New `router_with_backend` / `serve_with_backend` overloads let the CLI inject the real backend while default `router` / `serve` use the stub.

## Threading

`run_turn` is sync because `Session::run_turn` is. WS handler invokes it via `tokio::task::spawn_blocking` so inference doesn't stall the executor — every other WebSocket on the process keeps draining frames during a turn.

## Chunked streaming

`Session::run_turn` returns the response whole. The WS handler splits assistant_text into **~80-char UTF-8-safe chunks with 30ms delays** so the SPA's streaming-append rendering animates naturally. When backends grow real token streaming (probably v1.0.0), the chunking utility is replaced with a token consumer — wire shape stays identical.

## CLI: `aegis ui` flags

New flags mirror `aegis run --prompt`: `--manifest`, `--model`, `--backend llama|litertlm` (default llama), plus `--config` / `--chat-template-sidecar` / `--identity-dir` / `--workload` / `--instance` / `--ledger`.

Half-set inputs (`--manifest` without `--model` or vice versa) bail fast with a clear error rather than silently falling back to stub. Both omitted → `StubBackend` with operator hint.

`crates/cli/src/run.rs` exposes new public `boot_session_for_ui` — extracted from `execute`'s prelude (BootConfig → `Session::boot` → optional approval/MCP wiring → `load_*_backend` → `set_loaded_model`) so `ui.rs` reuses the same path without copy-paste drift. `SessionBackend` wraps the booted Session in `Arc<Mutex<...>>` — serializes turns across WebSocket connections, fine for v0.9.5's single-user posture.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude aegis-llama-backend --all-targets -- -D warnings` clean
- [x] `cargo build -p aegis-cli` (no features) AND `cargo build -p aegis-cli --features llama`: both clean
- [x] `cargo test -p aegis-ui-server --lib`: 19/19 (16 existing + 3 new — StubBackend behavior, MockBackend records, error Display)
- [x] Manual smoke (stub backend over real WebSocket): handshake `101`, 4 frames delivered, assistant text reconstructs to the operator-hint message
- [x] Manual smoke (CLI validation): half-set `--manifest` exits 1 with the clear error; both paths to nonexistent files surface `Session::boot`'s actual error chain
- [ ] CI green

## What's left

- **1d.2c** — structured `tool_call` / `tool_result` / `verifiable_badge` frames hooking the F9 ledger entry to each turn (placeholder badge already exists in the SPA from #150)
- **1d.2d** — slash command palette (cmdk) + MCP Catalog (ADR-033)
- **v1.0.0** — token-by-token streaming when inference backends gain it; multi-turn loop per ADR-025; circuit breakers per ADR-027

Tracking: #147, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)