### PR TITLE
feat(engine, ui-server, ui): preserve tool-call args + verifiable F9 anchor (sub-phase 1d.2c.2)

### DIFF
--- a/crates/cli/src/ui.rs
+++ b/crates/cli/src/ui.rs
@@ -219,12 +219,9 @@ impl ChatBackend for SessionBackend {
 
         // Convert each engine-side `ToolCallOutcome` into the
         // structured `TurnToolCall` shape the WS handler emits as
-        // `tool_call` + `tool_result` frames. Args are not yet
-        // preserved on `ToolCallOutcome` (the engine drops them
-        // after dispatch — adding them is an additive engine API
-        // change scoped to a follow-up); for 1d.2c.1 we surface
-        // an empty-object placeholder so the SPA's card has a
-        // stable shape to render.
+        // `tool_call` + `tool_result` frames. Args come straight
+        // from the engine now (1d.2c.2 added preservation); the
+        // SPA renders them in the card's expandable detail panel.
         let tool_calls = outcome
             .tool_calls
             .into_iter()
@@ -237,7 +234,7 @@ impl ChatBackend for SessionBackend {
                 // overkill here.
                 call_id: format!("call-{i}"),
                 name: call.name,
-                args: serde_json::json!({}),
+                args: call.arguments,
                 status: convert_status(call.result),
             })
             .collect();
@@ -245,6 +242,12 @@ impl ChatBackend for SessionBackend {
         Ok(TurnResult {
             assistant_text: outcome.assistant_text,
             tool_calls,
+            // F5 reasoning-step UUID the engine just wrote — the
+            // SPA's verifiable badge anchors to this for the future
+            // `/replay/<anchor>` route. Always populated for the
+            // real backend (every `Session::run_turn` writes a
+            // reasoning_step entry); only `None` on stub backends.
+            verifiable_anchor: Some(outcome.reasoning_step_id),
         })
     }
 }

--- a/crates/inference-engine/src/turn.rs
+++ b/crates/inference-engine/src/turn.rs
@@ -56,13 +56,32 @@ pub struct TurnOutcome {
     pub assistant_text: Option<String>,
     /// Per-tool-call outcome, in emission order.
     pub tool_calls: Vec<ToolCallOutcome>,
+    /// UUIDv7 of the F5 reasoning-step ledger entry this turn
+    /// produced. The same id appears in
+    /// [F9](../../docs/adrs/011-hash-chained-tamper-evident-ledger.md)
+    /// as the step's `id` and on every per-call ledger entry the
+    /// dispatcher emits during the turn (each carries
+    /// `reasoning_step_id`). Surfaced here so callers — the WebUI
+    /// chat surface (ADR-031), evidence-pack generators, replay
+    /// viewers — can anchor their per-turn UI to the cryptographic
+    /// trail in the F9 ledger without re-reading the file.
+    pub reasoning_step_id: String,
 }
 
-/// Outcome of one dispatched [`ToolCall`].
+/// Outcome of one dispatched [`ToolCall`]. Captures the model's
+/// emitted args alongside the mediator's terminal result so callers
+/// have the full call signature in-process, not just the verdict.
 #[derive(Debug, Clone)]
 pub struct ToolCallOutcome {
     /// Tool name as the model emitted it (`<namespace>__<tool>`).
     pub name: String,
+    /// Args the model passed, preserved verbatim from the
+    /// [`ToolCall::arguments`] the mediator received. The runtime
+    /// validates these against the manifest's allowlist + ADR-024
+    /// `pre_validate` clauses before dispatch; surfacing them on
+    /// the outcome lets the WebUI render them inside its inline
+    /// tool-call cards (ADR-031 §"Inline tool-call cards").
+    pub arguments: serde_json::Value,
     /// Result of the dispatch.
     pub result: ToolCallResult,
 }
@@ -142,6 +161,7 @@ impl Session {
         Ok(TurnOutcome {
             assistant_text: response.assistant_text,
             tool_calls: outcomes,
+            reasoning_step_id: step_id,
         })
     }
 
@@ -268,6 +288,7 @@ impl Session {
         let Some((namespace, tool)) = split_mcp_name(&call.name) else {
             return Ok(ToolCallOutcome {
                 name: call.name.clone(),
+                arguments: call.arguments,
                 result: ToolCallResult::Unroutable(format!(
                     "tool name {:?} not in <namespace>__<tool> shape",
                     call.name
@@ -300,6 +321,7 @@ impl Session {
         };
         Ok(ToolCallOutcome {
             name: call.name,
+            arguments: call.arguments,
             result,
         })
     }

--- a/crates/ui-server/src/chat.rs
+++ b/crates/ui-server/src/chat.rs
@@ -53,6 +53,12 @@ pub struct TurnResult {
     /// flattened this into plain-text summaries; 1d.2c switches to
     /// structured frames so the SPA renders gate decisions inline.
     pub tool_calls: Vec<TurnToolCall>,
+    /// Cryptographic anchor for the turn — UUIDv7 of the F5
+    /// reasoning-step ledger entry the engine just wrote. Surfaced
+    /// to the SPA via the `turn_end` frame so the verifiable badge
+    /// can link to a future `/replay/<anchor>` route. `None` for
+    /// stub / mock backends that don't write to a ledger.
+    pub verifiable_anchor: Option<String>,
 }
 
 /// One model-emitted tool call + its mediator outcome, structured
@@ -164,6 +170,10 @@ impl ChatBackend for StubBackend {
                 "echo: {prompt}\n\n(stub backend — start `aegis ui --manifest <m> --model <m> [--backend llama|litertlm]` to attach a real Session::run_turn)"
             )),
             tool_calls: Vec::new(),
+            // Stub doesn't write to a ledger, so there's no F9
+            // anchor to surface. The SPA suppresses the verifiable
+            // badge when this is `None`.
+            verifiable_anchor: None,
         })
     }
 }
@@ -198,6 +208,7 @@ mod tests {
             Ok(TurnResult {
                 assistant_text: Some(self.response.clone()),
                 tool_calls: Vec::new(),
+                verifiable_anchor: None,
             })
         }
     }

--- a/crates/ui-server/src/handlers/sessions.rs
+++ b/crates/ui-server/src/handlers/sessions.rs
@@ -185,7 +185,16 @@ pub enum ServerFrame {
     },
     /// Turn complete. No more frames will arrive for this `turn_id`
     /// until a fresh `user_prompt` triggers another turn.
-    TurnEnd { turn_id: String },
+    /// `verifiable_anchor` carries the UUIDv7 of the F5 reasoning-
+    /// step ledger entry the engine wrote during this turn — the
+    /// SPA's verifiable badge links to a future `/replay/<anchor>`
+    /// route. Omitted (and absent on the wire) for stub / mock
+    /// backends that don't write to a ledger.
+    TurnEnd {
+        turn_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        verifiable_anchor: Option<String>,
+    },
     /// Protocol or runtime error. Non-fatal — the connection stays
     /// open so the operator can retry.
     Error { message: String },
@@ -312,10 +321,18 @@ async fn run_turn(
         Ok(o) => o,
         Err(e) => {
             send_error(socket, &format!("backend error: {e}")).await?;
-            send_frame(socket, &ServerFrame::TurnEnd { turn_id }).await?;
+            send_frame(
+                socket,
+                &ServerFrame::TurnEnd {
+                    turn_id,
+                    verifiable_anchor: None,
+                },
+            )
+            .await?;
             return Ok(());
         }
     };
+    let verifiable_anchor = outcome.verifiable_anchor.clone();
 
     let mut emitted_anything = false;
     if let Some(text) = outcome.assistant_text.as_ref() {
@@ -393,7 +410,14 @@ async fn run_turn(
         .await?;
     }
 
-    send_frame(socket, &ServerFrame::TurnEnd { turn_id }).await?;
+    send_frame(
+        socket,
+        &ServerFrame::TurnEnd {
+            turn_id,
+            verifiable_anchor,
+        },
+    )
+    .await?;
     Ok(())
 }
 
@@ -587,6 +611,37 @@ mod tests {
         assert_eq!(v["status"], "denied");
         assert_eq!(v["reason"], "path /etc not in allowlist");
         assert!(v.get("value").is_none(), "value must be omitted when None");
+    }
+
+    #[test]
+    fn turn_end_with_anchor_emits_verifiable_field() {
+        let f = ServerFrame::TurnEnd {
+            turn_id: "t-1".to_string(),
+            verifiable_anchor: Some("019e0284-c183-7f21-94a2-620bdabca8a8".to_string()),
+        };
+        let s = encode(&f).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["type"], "turn_end");
+        assert_eq!(v["turn_id"], "t-1");
+        assert_eq!(
+            v["verifiable_anchor"],
+            "019e0284-c183-7f21-94a2-620bdabca8a8"
+        );
+    }
+
+    #[test]
+    fn turn_end_without_anchor_omits_field() {
+        let f = ServerFrame::TurnEnd {
+            turn_id: "t-1".to_string(),
+            verifiable_anchor: None,
+        };
+        let s = encode(&f).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["type"], "turn_end");
+        assert!(
+            v.get("verifiable_anchor").is_none(),
+            "verifiable_anchor must be omitted when None (stub-backend case)",
+        );
     }
 
     #[test]

--- a/ui/src/lib/chat-ws.ts
+++ b/ui/src/lib/chat-ws.ts
@@ -53,7 +53,15 @@ export type ServerFrame =
       value?: unknown;
       reason?: string;
     }
-  | { schema: "v1"; type: "turn_end"; turn_id: string }
+  | {
+      schema: "v1";
+      type: "turn_end";
+      turn_id: string;
+      /** UUIDv7 of the F5 reasoning-step ledger entry the engine
+       *  wrote during this turn. Absent for stub backends that
+       *  don't write to a ledger. */
+      verifiable_anchor?: string;
+    }
   | { schema: "v1"; type: "error"; message: string };
 
 export type ClientFrame = {
@@ -139,8 +147,13 @@ function isServerFrame(v: unknown): v is ServerFrame {
   if (o.schema !== "v1" || typeof o.type !== "string") return false;
   switch (o.type) {
     case "turn_start":
-    case "turn_end":
       return typeof o.turn_id === "string";
+    case "turn_end":
+      return (
+        typeof o.turn_id === "string" &&
+        (o.verifiable_anchor === undefined ||
+          typeof o.verifiable_anchor === "string")
+      );
     case "assistant_text":
       return typeof o.turn_id === "string" && typeof o.text === "string";
     case "tool_call":

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -37,9 +37,12 @@ interface TextMessage {
   text: string;
   /** Set on the assistant message that's currently streaming. */
   pending?: boolean;
-  /** Set on assistant messages once `turn_end` arrives. The 1d.2c
-   *  verifiable-badge surface uses this hook. */
-  verifiable?: boolean;
+  /** UUIDv7 of the F5 reasoning-step ledger entry, set by `turn_end`
+   *  for backends that write to a ledger (real `Session::run_turn`,
+   *  not the StubBackend). The verifiable badge tooltip shows the
+   *  full anchor; click-through to a future `/replay/<anchor>` route
+   *  is queued for ADR-010 viewer integration. */
+  verifiableAnchor?: string;
 }
 
 interface ToolCallMessage {
@@ -139,10 +142,15 @@ export function Chat() {
       }
       case "turn_end": {
         const turnId = frame.turn_id;
+        const anchor = frame.verifiable_anchor;
         setMessages((prev) =>
           prev.map((m) =>
             m.kind === "text" && m.id === turnId
-              ? { ...m, pending: false, verifiable: true }
+              ? {
+                  ...m,
+                  pending: false,
+                  verifiableAnchor: anchor,
+                }
               : m,
           ),
         );
@@ -359,13 +367,13 @@ function MessageBubble({ message }: { message: TextMessage }) {
             <span className="ml-1 inline-block h-3 w-3 animate-pulse rounded-full bg-accent align-middle" />
           )}
         </div>
-        {message.verifiable && (
+        {message.verifiableAnchor && (
           <span
-            className="inline-flex items-center gap-1 self-start font-mono text-[10px] text-muted"
-            title="Sub-phase 1d.2c.2 will hook this badge to the F9 ledger entry for this turn"
+            className="inline-flex cursor-help items-center gap-1 self-start rounded bg-emerald-950/40 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300"
+            title={`F9 reasoning-step uuid: ${message.verifiableAnchor} — click-through to /replay/<anchor> lands when the ADR-010 viewer wires up`}
           >
             <ShieldCheck className="h-3 w-3" aria-hidden="true" />
-            verifiable (1d.2c.2)
+            verifiable · {message.verifiableAnchor.slice(0, 8)}…
           </span>
         )}
       </div>
@@ -486,7 +494,7 @@ function ToolCallCard({ call }: { call: ToolCallMessage }) {
           <div className="border-t border-[var(--color-border)] px-3 py-2 text-xs">
             <div className="mb-2">
               <div className="mb-1 font-mono text-[10px] uppercase tracking-wider text-muted">
-                args (1d.2c.2: full args land when the engine preserves them)
+                args
               </div>
               <pre className="overflow-x-auto rounded bg-[var(--color-bg-elev)] p-2 font-mono text-[11px] text-[var(--color-fg)]">
                 {argsJson}


### PR DESCRIPTION
## Summary

Closes the two follow-ups #152 left for 1d.2c.2: **tool-call cards now show the real model-emitted args** (no more empty `{}` placeholder), and **the per-turn verifiable badge anchors to the F5 reasoning-step ledger entry** the engine wrote.

## Engine API (crates/inference-engine)

Two additive changes to `turn.rs`:

- `ToolCallOutcome.arguments: serde_json::Value` — populated at both `ToolCallOutcome` construction sites (the unroutable-name early return and the post-dispatch normal path). The runtime already validates these against the manifest's allowlist + ADR-024 `pre_validate` clauses *before* dispatch; surfacing them on the outcome lets downstream consumers render the full call signature in-process.
- `TurnOutcome.reasoning_step_id: String` — UUIDv7 the F5 reasoning-step entry was written under. Lets callers (WebUI chat surface, future evidence-pack generators, replay viewers) anchor per-turn UI to the cryptographic trail in the F9 ledger without re-reading the file.

Both fields are **additive**; `aegis-inference-engine`'s 9/9 tests stay green without modification.

## ui-server

- `TurnResult.verifiable_anchor: Option<String>` — populated by `SessionBackend`, `None` for stub / mock backends.
- `ServerFrame::TurnEnd` extended with `verifiable_anchor: Option<String>` (`skip_serializing_if = Option::is_none` so stub frames omit the field on the wire).
- 2 new wire-shape tests covering anchor present / absent.

## CLI

`SessionBackend` swaps the `serde_json::json!({})` placeholder for `call.arguments`, and surfaces `outcome.reasoning_step_id` via `TurnResult.verifiable_anchor`.

## SPA

- `chat-ws.ts`: `ServerFrame.turn_end` gains optional `verifiable_anchor`; `isServerFrame` validates the union.
- `Chat.tsx`: `TextMessage.verifiable: boolean` → `verifiableAnchor: string | undefined`. Badge shows truncated UUID (`verifiable · 019e02a6…`) with a tooltip carrying the full uuid + a forward-reference to the future `/replay/<anchor>` route.
- `ToolCallCard` drops the "1d.2c.2: full args land when…" footnote — args render real now.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude aegis-llama-backend --all-targets -- -D warnings` clean
- [x] `cargo test` (default members): all green; ui-server lib **25/25** (was 23; +2 anchor wire-shape); inference-engine **9/9** unchanged
- [x] `pnpm typecheck` + `pnpm build` clean
- [x] Manual smoke (stub backend, real WebSocket): `turn_end` frame omits `verifiable_anchor` as expected for stub
- [ ] CI green
- [ ] Manual smoke against `--features llama` + a real manifest with tool grants: cards render real args + assistant message gets a real anchor

## What's left in 1d.2

- **1d.2d** — slash command palette (cmdk) + MCP Catalog (ADR-033)
- **1d.2e** — model picker dropdown + Session Forking (#153)

Tracking: #147, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)