### PR TITLE
ci: pin all workflows to ubuntu-24.04 (PR 1 of #157)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cross-language:
     name: Go validator ↔ Rust enforcer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/demos-renderer-publish.yml
+++ b/.github/workflows/demos-renderer-publish.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   publish:
     name: Build + push demos/Dockerfile to GHCR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -55,7 +55,7 @@ permissions:
 jobs:
   build-renderer:
     name: Build demo renderer image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       image_tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -101,7 +101,7 @@ jobs:
   snapshot:
     name: ${{ matrix.demo }}
     needs: build-renderer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/devbox.yml
+++ b/.github/workflows/devbox.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     name: Build + sign devbox image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: go vet + test + golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/litertlm-runtime-publish.yml
+++ b/.github/workflows/litertlm-runtime-publish.yml
@@ -73,7 +73,7 @@ permissions:
 jobs:
   publish:
     name: Bazel → .so → OCI → cosign
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/llama.yml
+++ b/.github/workflows/llama.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   build:
     name: cargo test (llama-backend)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/models-publish.yml
+++ b/.github/workflows/models-publish.yml
@@ -76,7 +76,7 @@ permissions:
 jobs:
   publish:
     name: HF → OCI → cosign
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   release:
     name: Compose release body + create draft
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/replay-viewer-snapshot.yml
+++ b/.github/workflows/replay-viewer-snapshot.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   snapshot:
     name: F8-C DOM snapshot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: tools/replay-viewer/snapshot

--- a/.github/workflows/replay-viewer.yml
+++ b/.github/workflows/replay-viewer.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   airgap:
     name: ADR-010 air-gap rules
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Run check-airgap.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: cargo fmt + clippy + test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate:
     name: proto + JSON Schema + JSON-LD
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   validate:
     name: aegis validate (every committed manifest)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Pin all 14 workflow `runs-on` declarations to `ubuntu-24.04` instead of `ubuntu-latest`. **Behaviour-neutral today** — GitHub's `ubuntu-latest` already resolves to 24.04 since the 2025 default flip — but locks the floor so a future GHA default bump (24.04 → 26.04 next) doesn't silently shift our CI environment under us.

This is **PR 1 of three** for the #157 platform-floor migration.

## Why pin

Per #157 the project's platform floor is **glibc ≥ 2.38 + GLIBCXX ≥ 3.4.31**, driven by LiteRT-LM's prebuilt `.so` requirement (per ADR-023). Pinning the runner version here makes that floor explicit and reproducible. The matching devcontainer bump + ADR-017 amendment ship in PR 2.

## Files changed

| Workflow | Before | After |
|---|---|---|
| `conformance.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `demos-renderer-publish.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `demos.yml` (×2 jobs) | `ubuntu-latest` | `ubuntu-24.04` |
| `devbox.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `go.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `litertlm-runtime-publish.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `llama.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `models-publish.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `release.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `replay-viewer-snapshot.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `replay-viewer.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `rust.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `schemas.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `validate.yml` | `ubuntu-latest` | `ubuntu-24.04` |
| `litertlm.yml` | `ubuntu-24.04` | (unchanged — was already explicit) |

15 line changes total, 14 files.

## Test plan

- [x] Every `runs-on:` value is now `ubuntu-24.04` (verified via grep)
- [ ] CI runs the same way it did before — this is the canary; if anything goes red on a workflow that wasn't red before, that's a real bug we wanted to catch
- [ ] Subsequent PRs (PR 2 — devcontainer + ADR-017; PR 3 — optional smoke matrix) reference this one

## Related

- #157 — platform-floor migration tracker (full audit + 3-PR plan)
- ADR-017 — dev environment (amended in PR 2)
- ADR-023 — LiteRT-LM backend (the load-bearing reason for the floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)