### PR TITLE
docs(adr-017, devcontainer): platform floor at ubuntu-24.04 / glibc 2.38 (PR 2 of #157)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,8 +4,15 @@
 # ghcr.io/<owner>/aegis-node-devbox.
 #
 # Tool versions are kept aligned with mise.toml at the repo root.
+#
+# Base: ubuntu-24.04 — matches the project's platform floor per
+# ADR-017 §"Supported platforms" (glibc ≥ 2.38, GLIBCXX ≥ 3.4.31).
+# 22.04 (jammy) is best-effort llama-only; LiteRT-LM (Gemma 4 family)
+# fails at link time on jammy because the upstream prebuilt
+# libaegis_litertlm_engine_cpu.so requires a newer glibc / libstdc++.
+# See #157 / docs/CHAT.md for the operator-facing guidance.
 
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 ARG TARGETARCH
 

--- a/docs/CHAT.md
+++ b/docs/CHAT.md
@@ -88,7 +88,10 @@ cargo install --locked --path crates/cli --features "llama litertlm" --force
 > Ubuntu 24.04 / Debian Trixie / RHEL 10 territory. Older distros
 > (Ubuntu 22.04, RHEL 9, Debian Bookworm) will fail at link time
 > with `undefined reference to __isoc23_strtoull@GLIBC_2.38`. CI's
-> `litertlm.yml` job runs on `ubuntu-24.04` for this reason.
+> `litertlm.yml` job runs on `ubuntu-24.04` for this reason. See
+> [ADR-017 §"Supported platforms"](adrs/017-local-development-environment-devcontainer-mise.md#supported-platforms)
+> for the full compatibility table and the project's platform-floor
+> rationale.
 
 ## Running the chat surface
 

--- a/docs/adrs/017-local-development-environment-devcontainer-mise.md
+++ b/docs/adrs/017-local-development-environment-devcontainer-mise.md
@@ -1,7 +1,7 @@
 # 17. Local Development Environment: Devcontainer (Canonical) + mise (Native Fallback)
 
 **Status:** Accepted
-**Date:** 2026-04-27
+**Date:** 2026-04-27 (amended 2026-05-07 — added §"Supported platforms" platform-floor clause)
 **Domain:** Developer Experience / Supply Chain
 
 ## Context
@@ -38,6 +38,50 @@ Adopt a two-track local development environment with a single source of truth fo
 - Two paths to test (devcontainer + native via `mise`); CI should validate both.
 - `mise` is less ubiquitous than `asdf`; teams already invested in `asdf` can consume a generated `.tool-versions` file as a courtesy export.
 - Devcontainer requires Docker/Podman, which some restricted enterprise laptops still cannot run; the `mise` path exists exactly for that reason but does require host-level installs.
+
+## Supported platforms
+
+*Amendment 2026-05-07 (per [#157](https://github.com/tosin2013/aegis-node/issues/157)).*
+
+The project's **minimum supported Linux platform** is anything providing
+**glibc ≥ 2.38** and **GLIBCXX ≥ 3.4.31** (libstdc++ from GCC ≥ 13.2).
+Concretely:
+
+| Platform | glibc | GLIBCXX max | Status |
+|---|---|---|---|
+| Ubuntu 24.04 LTS (Noble) | 2.39 | 3.4.32 | ✅ Fully supported (devcontainer base; CI runners) |
+| Debian 13 (Trixie) | 2.41 | 3.4.33 | ✅ Fully supported |
+| RHEL 10 / Rocky 10 / AlmaLinux 10 | 2.39 | 3.4.32 | ✅ Fully supported |
+| Fedora 40+ | 2.39+ | 3.4.32+ | ✅ Fully supported |
+| Ubuntu 22.04 LTS (Jammy) | 2.35 | 3.4.30 | ⚠️ `--features llama` only |
+| Debian 12 (Bookworm) | 2.36 | 3.4.30 | ⚠️ `--features llama` only |
+| RHEL 9 / Rocky 9 | 2.34 | 3.4.30 | ⚠️ `--features llama` only |
+
+**Why the floor:** the LiteRT-LM backend (per [ADR-023](023-litertlm-as-second-inference-backend.md))
+ships as a **prebuilt** `libaegis_litertlm_engine_cpu.so` published as
+an OCI artifact. The upstream publish runs on a 24.04-class sysroot,
+so the `.so` carries `GLIBC_2.38` + `GLIBCXX_3.4.31` symbol references.
+Linking it on an older host fails with `undefined reference to
+__isoc23_strtoull@GLIBC_2.38` (and similar) — not a code bug, an ABI
+mismatch we can't avoid without forcing every operator to rebuild
+LiteRT-LM from Bazel sources.
+
+**Best-effort vs. unsupported:** "best-effort llama-only" platforms
+(jammy, bookworm, RHEL 9) build cleanly with `--features llama` —
+Qwen / Llama / Mistral via llama.cpp work end-to-end. Operators just
+can't run `--features litertlm` (Gemma 4 family) without upgrading.
+Aegis-Node accepts patches that improve the older-platform
+experience but does not test against them in CI.
+
+**CI alignment:** every workflow's `runs-on:` is pinned to
+`ubuntu-24.04` (PR 1 of #157 / [#158](https://github.com/tosin2013/aegis-node/pull/158)).
+The devcontainer base image is `mcr.microsoft.com/devcontainers/base:ubuntu-24.04`.
+Bumping the floor requires updating both in lockstep + this clause.
+
+**Operator guidance:** [docs/CHAT.md](../CHAT.md) §"Build feature
+flags" describes the operator-facing consequences (when to use
+`--features llama` only vs. `--features "llama litertlm"`) and how
+to detect the platform-floor mismatch from a link error.
 
 ## Domain Considerations
 


### PR DESCRIPTION
## Summary

PR 2 of three for the **#157 platform-floor migration**. Bumps the devcontainer base from `ubuntu-22.04` → `ubuntu-24.04` and amends **ADR-017** with a new "Supported platforms" clause that spells out the project's platform floor: **glibc ≥ 2.38** + **GLIBCXX ≥ 3.4.31** (libstdc++ from GCC ≥ 13.2).

(PR 1 — workflow `runs-on:` pins — merged in #158.)

## Why this floor exists

Documented honestly: the LiteRT-LM backend (per ADR-023) ships as a **prebuilt** `libaegis_litertlm_engine_cpu.so` published from a 24.04-class sysroot. The `.so` carries `GLIBC_2.38` + `GLIBCXX_3.4.31` symbol references; older platforms fail at link time with `undefined reference to __isoc23_strtoull@GLIBC_2.38`. Not a code bug — an ABI mismatch we can't avoid without forcing every operator to rebuild LiteRT-LM from Bazel sources.

## Compatibility table (added to ADR-017)

| Platform | glibc | GLIBCXX max | Status |
|---|---|---|---|
| Ubuntu 24.04 LTS (Noble) | 2.39 | 3.4.32 | ✅ Fully supported (devcontainer base; CI runners) |
| Debian 13 (Trixie) | 2.41 | 3.4.33 | ✅ Fully supported |
| RHEL 10 / Rocky 10 / AlmaLinux 10 | 2.39 | 3.4.32 | ✅ Fully supported |
| Fedora 40+ | 2.39+ | 3.4.32+ | ✅ Fully supported |
| Ubuntu 22.04 LTS (Jammy) | 2.35 | 3.4.30 | ⚠️ `--features llama` only |
| Debian 12 (Bookworm) | 2.36 | 3.4.30 | ⚠️ `--features llama` only |
| RHEL 9 / Rocky 9 | 2.34 | 3.4.30 | ⚠️ `--features llama` only |

"Best-effort" platforms build cleanly with `--features llama` (Qwen / Llama / Mistral via llama.cpp end-to-end). They just can't run `--features litertlm` (Gemma 4 family) without upgrading. Aegis-Node accepts patches improving their experience but does not test against them in CI.

## Files changed

- **`.devcontainer/Dockerfile`** — base image `ubuntu-22.04` → `ubuntu-24.04` with a comment block explaining the floor + cross-reference to #157 / docs/CHAT.md.
- **`docs/adrs/017-local-development-environment-devcontainer-mise.md`** — new "Supported platforms" §, status line bumped to "amended 2026-05-07."
- **`docs/CHAT.md`** — existing GLIBC callout now cross-references ADR-017 §"Supported platforms" instead of inlining the full detail. The operator hint stays where operators look (chat surface docs); the policy lives in the ADR.

## Test plan

- [x] Devcontainer base swap is a single-line change; rebuild on a fresh checkout produces a 24.04 container that can `cargo build -p aegis-cli --features "llama litertlm"` cleanly *if* the OCI registry has the prebuilt `.so` available (verified separately on a 24.04 host)
- [x] ADR-017 amendment renders cleanly on GitHub; cross-references resolve
- [x] `docs/CHAT.md` cross-reference link points at the new section anchor (`#supported-platforms`)
- [ ] CI green
- [ ] PR 3 of #157 (optional): smoke-test job that locks against accidental glibc-2.35 dependency reintroduction. Not strictly needed unless we actually have one near-miss; tracking issue stays open in case it comes up.

## Related

- #157 — platform-floor migration tracker (audit + 3-PR plan)
- #158 — PR 1 (workflow `runs-on:` pins) — merged
- ADR-014 / ADR-023 — backends; ADR-023 is the reason for the floor
- docs/CHAT.md — operator-facing chat surface guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)