### PR TITLE
feat(design): modernize tokens — Linear/Vercel refined dev-tool aesthetic

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -8,22 +8,25 @@ description: >
 
 colors:
   bg:
-    dark: "#0b0d10"
+    dark: "#0b0c0e"
     light: "#ffffff"
   bg-elev:
-    dark: "#11151a"
+    dark: "#15171a"
     light: "#f5f6f8"
   fg:
-    dark: "#e5e9ef"
-    light: "#0b0d10"
+    dark: "#edeef0"
+    light: "#0b0c0e"
   muted:
-    dark: "#8a93a3"
+    dark: "#9aa0a8"
     light: "#5b6573"
   border:
-    dark: "#1f2630"
+    dark: "#272a2d"
     light: "#d8dde5"
+  border-strong:
+    dark: "#363a3f"
+    light: "#c0c6d0"
   accent:
-    dark: "#7cc4ff"
+    dark: "#7dd3fc"
     light: "#1e6fb8"
   success:
     dark: "#4ade80"
@@ -35,37 +38,37 @@ colors:
     dark: "#f87171"
     light: "#b91c1c"
   focus-ring:
-    dark: "#7cc4ff"
+    dark: "#7dd3fc"
     light: "#1e6fb8"
 
 typography:
   body:
     fontFamily: "{font.sans}"
-    fontSize: "0.9375rem"
+    fontSize: "0.875rem"
     fontWeight: "400"
-    lineHeight: "1.55"
-    letterSpacing: "0"
+    lineHeight: "1.5"
+    letterSpacing: "-0.005em"
   heading:
     fontFamily: "{font.sans}"
     fontSize: "1.25rem"
     fontWeight: "600"
-    lineHeight: "1.3"
-    letterSpacing: "-0.01em"
+    lineHeight: "1.25"
+    letterSpacing: "-0.02em"
   caption:
     fontFamily: "{font.sans}"
-    fontSize: "0.8125rem"
+    fontSize: "0.75rem"
     fontWeight: "500"
     lineHeight: "1.4"
     letterSpacing: "0"
   mono-id:
     fontFamily: "{font.mono}"
-    fontSize: "0.92em"
+    fontSize: "0.8125rem"
     fontWeight: "500"
     lineHeight: "1.4"
     letterSpacing: "0"
   code:
     fontFamily: "{font.mono}"
-    fontSize: "0.875rem"
+    fontSize: "0.8125rem"
     fontWeight: "400"
     lineHeight: "1.5"
     letterSpacing: "0"
@@ -97,26 +100,24 @@ elevation:
     boxShadow: "none"
   raised:
     dark: "none"
-    light: "0 1px 2px rgba(11, 13, 16, 0.06), 0 1px 1px rgba(11, 13, 16, 0.04)"
+    light: "0 1px 2px rgba(11, 12, 14, 0.06), 0 1px 1px rgba(11, 12, 14, 0.04)"
   floating:
-    dark: "0 4px 12px rgba(0, 0, 0, 0.4)"
-    light: "0 4px 12px rgba(11, 13, 16, 0.1), 0 2px 4px rgba(11, 13, 16, 0.06)"
+    dark: "0 8px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px {colors.border}"
+    light: "0 8px 24px rgba(11, 12, 14, 0.12), 0 2px 6px rgba(11, 12, 14, 0.06)"
 
 components:
   Button:
     typography: "{typography.body}"
     rounded: "{rounded.md}"
-    padding: "{spacing.sm} {spacing.lg}"
+    padding: "{spacing.xs} {spacing.md}"
     variants:
       primary:
-        backgroundColor: "{colors.accent}"
+        backgroundColor: "{colors.fg}"
         textColor: "{colors.bg}"
         hover:
-          backgroundColor: "{colors.accent}"
-          opacity: "0.92"
+          opacity: "0.9"
         active:
-          backgroundColor: "{colors.accent}"
-          opacity: "0.84"
+          opacity: "0.82"
         disabled:
           backgroundColor: "{colors.muted}"
           textColor: "{colors.bg}"
@@ -126,7 +127,8 @@ components:
         textColor: "{colors.fg}"
         border: "1px solid {colors.border}"
         hover:
-          borderColor: "{colors.accent}"
+          borderColor: "{colors.border-strong}"
+          backgroundColor: "{colors.bg}"
         active:
           backgroundColor: "{colors.bg}"
         disabled:
@@ -137,39 +139,40 @@ components:
         textColor: "{colors.muted}"
         hover:
           textColor: "{colors.fg}"
+          backgroundColor: "{colors.bg-elev}"
         active:
-          textColor: "{colors.accent}"
+          textColor: "{colors.fg}"
   Input:
     typography: "{typography.body}"
     rounded: "{rounded.md}"
-    padding: "{spacing.sm} {spacing.md}"
+    padding: "{spacing.xs} {spacing.md}"
     backgroundColor: "{colors.bg-elev}"
     textColor: "{colors.fg}"
     border: "1px solid {colors.border}"
     placeholderColor: "{colors.muted}"
     focus:
-      borderColor: "{colors.accent}"
-      boxShadow: "0 0 0 2px {colors.focus-ring}33"
+      borderColor: "{colors.border-strong}"
+      boxShadow: "0 0 0 3px {colors.focus-ring}26"
     disabled:
       textColor: "{colors.muted}"
       opacity: "0.6"
   Select:
     typography: "{typography.body}"
     rounded: "{rounded.md}"
-    padding: "{spacing.sm} {spacing.md}"
+    padding: "{spacing.xs} {spacing.md}"
     backgroundColor: "{colors.bg-elev}"
     textColor: "{colors.fg}"
     border: "1px solid {colors.border}"
     focus:
-      borderColor: "{colors.accent}"
-      boxShadow: "0 0 0 2px {colors.focus-ring}33"
+      borderColor: "{colors.border-strong}"
+      boxShadow: "0 0 0 3px {colors.focus-ring}26"
   Card:
     backgroundColor: "{colors.bg-elev}"
     textColor: "{colors.fg}"
     border: "1px solid {colors.border}"
     rounded: "{rounded.md}"
-    padding: "{spacing.lg}"
-    elevation: "{elevation.raised}"
+    padding: "{spacing.md}"
+    elevation: "{elevation.none}"
   NavLink:
     typography: "{typography.body}"
     rounded: "{rounded.md}"
@@ -178,31 +181,39 @@ components:
     textColor: "{colors.muted}"
     hover:
       textColor: "{colors.fg}"
+      backgroundColor: "{colors.bg-elev}"
     active:
       backgroundColor: "{colors.bg-elev}"
-      textColor: "{colors.accent}"
+      textColor: "{colors.fg}"
+  IdentifierChip:
+    typography: "{typography.mono-id}"
+    rounded: "{rounded.sm}"
+    padding: "1px {spacing.sm}"
+    backgroundColor: "{colors.bg-elev}"
+    textColor: "{colors.accent}"
+    border: "1px solid {colors.border}"
   ToolCallChip:
     typography: "{typography.mono-id}"
     rounded: "{rounded.sm}"
-    padding: "{spacing.xs} {spacing.sm}"
+    padding: "1px {spacing.sm}"
     backgroundColor: "{colors.bg-elev}"
     textColor: "{colors.accent}"
     border: "1px solid {colors.border}"
   ApprovalBanner:
     typography: "{typography.body}"
     rounded: "{rounded.md}"
-    padding: "{spacing.lg}"
+    padding: "{spacing.md}"
     backgroundColor: "{colors.bg-elev}"
     textColor: "{colors.fg}"
     variants:
       advisory:
-        borderLeft: "4px solid {colors.muted}"
+        borderLeft: "3px solid {colors.muted}"
       validating:
-        borderLeft: "4px solid {colors.accent}"
+        borderLeft: "3px solid {colors.accent}"
       blocking:
-        borderLeft: "4px solid {colors.warning}"
+        borderLeft: "3px solid {colors.warning}"
       escalating:
-        borderLeft: "4px solid {colors.danger}"
+        borderLeft: "3px solid {colors.danger}"
 ---
 
 # Aegis-Node Community UI — Design System
@@ -250,59 +261,80 @@ step — see the *Don'ts*.
 
 ## Colors
 
-Six core role colours plus three semantic colours, each defined in both
-themes:
+Seven core role colours plus three semantic colours, each defined in both
+themes. The dark-mode palette is positioned on Radix `slateDark` steps so
+every interactive state (hover, active, focus, border, solid) comes from
+the same hue family — no opacity hacks, no ad-hoc tints.
 
 - **`bg` / `bg-elev`** — page background and one level of elevated surface
-  (cards, the nav bar's active pill, raised approval banners). The dark theme
-  uses pure value differential between the two; the light theme adds a subtle
-  shadow on `bg-elev` via the `elevation.raised` token so the boundary stays
-  readable on white.
-- **`fg`** — primary text colour. Aimed at WCAG AA against `bg` in both
-  themes; sub-issue #165 audits the result.
-- **`muted`** — secondary text and inactive navigation. The light-mode value
-  is intentionally darker than the dark-mode value so contrast against `bg`
-  stays balanced — dark text on white needs more weight than light text on
-  near-black.
-- **`border`** — `1px` rule used on inputs, selects, cards, and the top nav.
-  Low contrast on purpose; the UI uses surface differential, not lines, as
-  the primary structural signal.
+  (cards, the nav bar's active pill, raised approval banners). The dark
+  theme uses pure value differential between the two; the light theme adds
+  a subtle shadow on `bg-elev` via the `elevation.raised` token so the
+  boundary stays readable on white. Dark `bg` is `#0b0c0e` — cooler than
+  pure black, biased very slightly toward Radix slate1.
+- **`fg`** — primary text colour. Dark-mode is Radix `slate12`
+  (`#edeef0`) — ~16:1 contrast on `bg` (AAA).
+- **`muted`** — secondary text and inactive navigation. Dark-mode is Radix
+  `slate10`-ish (`#9aa0a8`) — ~7:1 contrast on `bg` (AA normal, AAA large).
+  The light-mode value is intentionally darker than the dark-mode value so
+  contrast against `bg` stays balanced — dark text on white needs more
+  weight than light text on near-black.
+- **`border`** — `1px` rule used on inputs, selects, cards, and the top
+  nav. Dark-mode is Radix `slate4` (`#272a2d`). Low contrast on purpose;
+  the UI uses surface differential and 1px hairlines, not blurred shadows,
+  as the structural signal.
+- **`border-strong`** — used for focused-input borders and `Button.secondary`
+  on hover. Dark-mode is Radix `slate6` (`#363a3f`). One step up from
+  `border` so focus reads as a clear state change without a high-chroma
+  accent ring at rest.
 - **`accent`** — identifier colour. Used for workload IDs, OCI digests,
-  manifest hashes, the shield logo, active nav, primary button background,
-  approval-banner *validating* border. Dark-mode is a bright sky blue
-  (`#7cc4ff`); light-mode steps down to a darker blue (`#1e6fb8`) that keeps
-  AA contrast on white. **Identifier coverage is the most important property
-  of this token** — see the *Do's*.
-- **`success` / `warning` / `danger`** — semantic colours for approval state,
-  quota warnings, and policy-block events. **Never the only signal** — they
-  must pair with an icon or text label (see the *Don'ts*). The light-mode
-  values step down to the `-700` band of each hue family so they remain AA
-  against white text on a coloured chip; the dark-mode values are the
-  Tailwind `-400` band tuned for legibility against `bg-elev`.
+  manifest hashes, the shield logo, focus rings, links, approval-banner
+  *validating* border. Dark-mode is `#7dd3fc` (Tailwind sky-300); light-mode
+  steps down to a darker blue (`#1e6fb8`) that keeps AA contrast on white.
+  **Identifier coverage is the most important property of this token** —
+  see the *Do's*. Accent is **not** the default button-primary fill; per
+  the modern dev-tool pattern (Linear, Vercel Geist), primary actions are
+  inverted neutrals (`fg` on `bg`), and accent is reserved for inline
+  identifier emphasis + focus state.
+- **`success` / `warning` / `danger`** — semantic colours for approval
+  state, quota warnings, and policy-block events. **Never the only
+  signal** — they must pair with an icon or text label (see the *Don'ts*).
+  The light-mode values step down to the `-700` band of each hue family so
+  they remain AA against white text on a coloured chip; the dark-mode
+  values are the Tailwind `-400` band tuned for legibility against
+  `bg-elev`.
 - **`focus-ring`** — `accent`, surfaced as a separate token so the
   WCAG-audit pass can override it without affecting visual identity.
 
 ## Typography
 
-Five named scales: `body`, `heading`, `caption`, `mono-id`, `code`. Two font
-stacks, defined under `font.*` and referenced symbolically. The Community UI
-ships **without webfont downloads** — both stacks resolve to system fonts
-exclusively so the localhost surface has no third-party network dependency
-at runtime (consistent with ADR-031's loopback-only stance and
-ADR-008's network-deny-by-default).
+Five named scales: `body`, `heading`, `caption`, `mono-id`, `code`. Two
+font stacks, defined under `font.*` and referenced symbolically. The
+Community UI ships **without webfont downloads** — both stacks resolve to
+system fonts exclusively so the localhost surface has no third-party
+network dependency at runtime (consistent with ADR-031's loopback-only
+stance and ADR-008's network-deny-by-default).
 
-- **`body`** — the default. 0.9375rem (15px) / 1.55 line-height — matches
-  the existing UI's body settings so the regenerated CSS produces the same
-  visible output.
-- **`heading`** — page titles and section headings. Sans, semibold, slight
-  negative letter-spacing for tightness at large sizes.
+Tightness over bigness is the rule. System sans serifs (SF Pro Display on
+macOS, Segoe UI Variable on Windows 11, Cantarell on GNOME) render heavier
+than Inter/Geist at the same weight, so we cap body weight at 400 and
+headings at 600, and apply small negative letter-spacing to mimic the
+optical correction that webfonts apply at small sizes.
+
+- **`body`** — the default. 0.875rem (14px) / 1.5 line-height / -0.005em
+  letter-spacing. Tighter than the v0 placeholder (which was 15px/1.55/0);
+  matches Linear/Geist chrome density.
+- **`heading`** — page titles and section headings. Sans, semibold,
+  -0.02em letter-spacing. Tight at large sizes — heading text should read
+  as "compact precision," not "marketing hero."
 - **`caption`** — small auxiliary text in chips and metadata strips. Sans,
-  medium weight, smaller than body. **Never used for primary content.**
-- **`mono-id`** — *the* identifier scale. Monospace, medium weight, sized
-  relative to surrounding text (`0.92em`) so it sits naturally inside body
-  copy. Used wherever the *Do's* call for identifier rendering.
-- **`code`** — code blocks. Monospace, normal weight, absolute size so it
-  doesn't shrink inside captions or chips.
+  medium weight, 0.75rem (12px). **Never used for primary content.**
+- **`mono-id`** — *the* identifier scale. Monospace, medium weight,
+  0.8125rem (13px) — slightly smaller than body, so identifiers sit
+  tightly inside `<IdentifierChip>`s without inflating their height. Used
+  wherever the *Do's* call for identifier rendering.
+- **`code`** — code blocks. Monospace, normal weight, 0.8125rem to pair
+  with `mono-id`.
 
 ## Layout
 
@@ -320,19 +352,30 @@ token-shaped, and is the domain of individual surface layouts.
 
 ## Elevation & Depth
 
-Two ramps: `raised` (cards, the active nav pill) and `floating` (popovers,
-dropdowns, the model-picker overlay). Each token is mode-aware:
+The design system is **flat by default**. Vercel Geist's pattern — replace
+soft drop-shadows with 1px hairline borders at the `border` colour —
+applies everywhere except true floating surfaces (popovers, dropdowns,
+the future approval modal).
 
-- **Dark mode**: elevation is encoded as a *surface differential*
-  (`bg-elev` vs `bg`); shadows are intentionally minimal because they read
-  poorly on near-black backgrounds.
-- **Light mode**: elevation uses subtle black-tinted shadows because the
-  surface differential alone (`#ffffff` vs `#f5f6f8`) is too low-contrast
-  on most monitors.
+Two ramps: `raised` (cards, the active nav pill, message bubbles, banners)
+and `floating` (Radix `<DialogContent>`, `<TooltipContent>`,
+`<SelectContent>`).
 
-This split is one place where the design system genuinely behaves differently
-across modes; component definitions should reference `elevation.raised` and
-let the generator pick the right shadow per mode.
+- **Dark mode `raised`**: `boxShadow: "none"`. Elevation is encoded as a
+  *surface differential* (`bg-elev` vs `bg`) plus the 1px `border` ring.
+  Soft shadows read poorly on near-black backgrounds and undermine the
+  precise, identifier-dense aesthetic.
+- **Light mode `raised`**: subtle black-tinted shadow because the surface
+  differential alone (`#ffffff` vs `#f5f6f8`) is too low-contrast on most
+  monitors.
+- **`floating` (both modes)**: a heavier shadow because tooltips and
+  dropdowns must detach visually from the chrome they're anchored to.
+  Dark mode pairs the shadow with a 1px `border` ring so the surface
+  remains readable on near-black backgrounds.
+
+Component definitions should reference `elevation.*` and let the generator
+pick the right value per mode. Never hand-author `box-shadow` in component
+files.
 
 ## Shapes
 
@@ -351,21 +394,22 @@ not "rounded SaaS dashboard."
 
 ## Components
 
-Seven primitive components defined in the front matter. Each maps to one of
-the existing or planned UI surfaces:
+Eight primitive components defined in the front matter. Each maps to one
+of the existing or planned UI surfaces:
 
 | Component | Used in | Notes |
 |---|---|---|
-| **`Button`** | Manifest Builder, chat send, model-library actions | Three variants: `primary` (accent fill), `secondary` (bordered), `ghost` (text-only). Disabled state collapses to muted at 50% opacity. |
-| **`Input`** | Chat composer, Manifest Builder forms, model OCI ref entry | Always bordered. Focus state adds a `2px` translucent ring in `accent`. |
+| **`Button`** | Manifest Builder, chat send, model-library actions | Three variants: `primary` (inverted-neutral: `fg`-on-`bg`), `secondary` (bordered, surface), `ghost` (text-only with surface-fill on hover). Per the Linear/Geist pattern, primary buttons are *not* accent-filled — accent is reserved for identifier emphasis, focus rings, and links. |
+| **`Input`** | Chat composer, Manifest Builder forms, model OCI ref entry | Always bordered. Focus state pulls border up to `border-strong` and adds a 3px translucent ring in `accent` — chroma is in the ring, not the border, so the input doesn't fight the surrounding chrome at rest. |
 | **`Select`** | Backend picker, manifest tier selection, model dropdown | Same skin as `Input`; the chevron icon is `muted`, flipping to `fg` on hover. |
-| **`Card`** | Home tiles, manifest preview, model library entries | `bg-elev` surface + 1px border + `lg` padding. Picks up the `raised` elevation token. |
-| **`NavLink`** | Top nav (`ui/src/components/TopNav.tsx`) | Three states: default (`muted`), hover (`fg`), active (`bg-elev` + `accent`). |
-| **`ToolCallChip`** | Chat thread tool-call inline cards (per sub-phase 1d.2c) | Monospace identifier styling — tool names render in `accent`, args in `fg`. The chip is itself an identifier. |
-| **`ApprovalBanner`** | F3 approval cards in chat (per ADR-029) | Four tier variants — `advisory`, `validating`, `blocking`, `escalating` — differing **only** in left-border colour. The tier label is also rendered in text inside the banner, never as colour alone. |
+| **`Card`** | Home tiles, manifest preview, model library entries | `bg-elev` surface + 1px `border` + `md` padding (0.75rem). **No box-shadow.** The 1px border is the elevation signal in dark mode. |
+| **`NavLink`** | Top nav (`ui/src/components/TopNav.tsx`) | Three states: default (`muted`), hover (`fg` + `bg-elev`), active (`bg-elev` + `fg`). Active state no longer uses `accent` for text — frees the accent treatment for genuine identifiers. |
+| **`IdentifierChip`** | Workload IDs, OCI digests, manifest hashes, SPIFFE URIs, F9 ledger entry IDs | Monospace, accent text, `bg-elev` fill, 1px `border`, 4px radius, 1px-by-`sm` padding. Sits inline in body copy. Pairs with `<Tooltip>` to recover bytes when the chip is truncated. |
+| **`ToolCallChip`** | Chat thread tool-call inline cards (per sub-phase 1d.2c) | Same visual treatment as `IdentifierChip` — a tool name *is* an identifier. The two components share token values; keeping them as separate entries documents intent. |
+| **`ApprovalBanner`** | F3 approval cards in chat (per ADR-029) | Four tier variants — `advisory`, `validating`, `blocking`, `escalating` — differing **only** in left-border colour (3px). The tier label is also rendered in text inside the banner, never as colour alone. |
 
-Variants under each component define hover, active, disabled, focus states.
-The component spec is theme-agnostic — token references like
+Variants under each component define hover, active, disabled, focus
+states. The component spec is theme-agnostic — token references like
 `{colors.accent}` resolve per mode at CSS generation.
 
 ## Do's and Don'ts

--- a/docs/plans/design-modernization.md
+++ b/docs/plans/design-modernization.md
@@ -1,0 +1,154 @@
+# Design modernization — refined dev-tool pass
+
+**Status:** proposal · authored 2026-05-15
+**Anchor issue:** follow-up on #164 (primitives) — the design system landed
+backwards-compatible by design so the regenerated CSS produced byte-identical
+visible output. That kept #162/#163/#164 reviewable. This document is the
+follow-up that actually modernizes the visual treatment.
+
+## Goal
+
+Move the Community UI from "placeholder dark theme" to a refined dev-tool
+aesthetic in the Linear / Vercel Geist / Radix Themes family — without
+breaking the project's "zero-trust, identifier-dense" positioning per
+ADR-031.
+
+## What "modern dev tool" means here
+
+Synthesised from four references (full notes in commit history):
+
+- **Vercel Geist** — shadows are *replaced* by 1px hairline borders
+  (`0 0 0 1px <border>`). Flat elevation. 14px body. Bright accent
+  (`#3291ff` link blue) used sparingly.
+- **Radix `slateDark`** — 12-step neutral scale where every interactive
+  state (hover, active, focus, border, solid, solid-hover) comes from the
+  *same hue family*. No opacity hacks. Steps used: 1 (bg), 2/3 (elev), 4
+  (border), 10 (muted text), 12 (fg).
+- **Linear** — identifiers ("ENG-1234", PR refs) render as monospace chips
+  with a subtle filled bg + 1px ring, not as colored text. Primary actions
+  are colored; links stay neutral underlined. Border-less surfaces use
+  background steps and whitespace for structure.
+- **Resend docs** — inline code never raw; always a monospace chip with
+  filled background. Mirrors Linear's identifier treatment.
+
+## Constraints to respect
+
+| Constraint | Source | Implication |
+|---|---|---|
+| System fonts only — no webfont downloads | ADR-031 (loopback-only stance) | Can't ship Geist Sans / Inter literally. Use system stack at sizes/weights that pair well with SF Pro / Segoe UI Variable |
+| Identifiers are first-class visual citizens | ADR-031 + `docs/DESIGN.md` *Don'ts* | Identifier-chip pattern is non-negotiable; the modernization should *strengthen* it, not weaken it |
+| WCAG AA contrast for fg + accent on bg | Sub-issue #165 | All proposed tokens must hit AA at minimum; AAA where free |
+| Dark-first; light theme deferred | Sub-issue #165 | Dark palette only in this pass |
+
+## Token deltas (dark mode)
+
+Current values are from the placeholder palette preserved through #162/#163.
+Proposed values come from the research, rounded onto Radix slate where the
+research recommended slate steps.
+
+| Token       | Current     | Proposed     | Delta + rationale |
+|-------------|-------------|--------------|-------------------|
+| `bg`        | `#0b0d10`   | `#0b0c0e`    | Slightly cooler — drop a faint green hint that read "early-2000s terminal" |
+| `bg-elev`   | `#11151a`   | `#15171a`    | One step lighter — pairs with border-only elevation pattern |
+| `fg`        | `#e5e9ef`   | `#edeef0`    | Radix `slate12`. Bumps contrast against `bg` from ~14.6:1 to ~16.2:1 (AAA) |
+| `muted`     | `#8a93a3`   | `#9aa0a8`    | Brighter — current was muddy at AA boundary; new is solid AA on `bg-elev` chips |
+| `border`    | `#1f2630`   | `#272a2d`    | More visible — current borders disappeared on Linux LCDs at normal viewing distance |
+| `accent`    | `#7cc4ff`   | `#7dd3fc`    | Indistinguishable hex-wise (~1 chroma step) — but lock onto the Tailwind `sky-300` value so engineers reading code map it instantly |
+| `border-strong` | _new_   | `#363a3f`    | Radix `slate6`. For focused-input rings + button-secondary borders that need to read present |
+
+### Body typography
+
+| Property | Current | Proposed | Rationale |
+|---|---|---|---|
+| body fontSize | `0.9375rem` (15px) | `0.875rem` (14px) | Linear / Geist chrome density |
+| body lineHeight | `1.55` | `1.5` | Tighter; reads as "tool," not "marketing" |
+| body letterSpacing | `0` | `-0.005em` | Mimics the optical correction Geist / Inter apply at small sizes |
+| heading fontWeight | `600` | `600` *(unchanged)* | System sans at 700 reads too heavy vs Inter/Geist; 600 is correct |
+| heading letterSpacing | `-0.01em` | `-0.02em` | Tighter headings; closer to Geist heading optics |
+
+### Elevation
+
+**No box-shadows.** Replace with 1px borders at `border` (`slate4`). Geist's
+pattern: `box-shadow: 0 0 0 1px var(--color-border)` for raised surfaces,
+which is equivalent to a 1px ring but stacks cleanly with hover states. For
+*floating* surfaces (popovers, dropdowns) keep a single low-spread shadow
+because tooltips/dropdowns need to detach visually from the underlying
+chrome — but use it sparingly.
+
+### Identifier-chip pattern (the headline change)
+
+Today every workload-ID, OCI digest, manifest hash is rendered as colored
+monospace inline text. Move to a *chip* treatment per Linear / Resend:
+
+```
+<span class="font-mono text-xs text-accent bg-[var(--color-bg-elev)]
+             border border-[var(--color-border)] rounded
+             px-1.5 py-0.5">
+  sha256:7c4a3b…
+</span>
+```
+
+This is small enough to sit in body copy, distinct enough to read as
+"identifier — important," and consistent across the Chat verifiable badge,
+tool-call card name, model-library OCI digest, and (later) the manifest
+builder's workload-ID field.
+
+Codify as a new component in `docs/DESIGN.md`: `IdentifierChip`.
+
+### Button primary
+
+Current: `bg-accent text-bg` (accent fill). Modern dev-tool pattern (Linear,
+Geist, Vercel): primary buttons are **inverted neutrals** — `bg-fg
+text-bg` — and accent is reserved for *links*, *focused state*, *important
+inline info*. This frees `accent` to do its identifier-emphasis job without
+visually competing with every CTA.
+
+For Aegis specifically: chat's *Send* button is more of a "secondary"
+action than a hero CTA, so it stays in the `secondary` variant either way.
+But `default` (the primary variant) should be re-spec'd as inverted neutral
+so it lands correctly the first time someone uses it.
+
+## Component-level changes (motivated by tokens, but spec'd here)
+
+- **Button** — `default` variant flips from accent-fill to fg-on-bg. Heights
+  drop one rung: `sm` 7 → 7, `md` 9 → 8, `lg` 11 → 9. Tighter chrome.
+- **Input / Textarea / Select** — focus ring drops from `accent/30` to
+  `accent/40` and the border-on-focus moves from `accent` to `border-strong`
+  for less chroma at rest.
+- **Card** — `padding` drops from `spacing.lg` (1rem) to `spacing.md` (0.75rem).
+  Border is `1px solid border` and the surface is `bg-elev`. **No shadow.**
+- **IdentifierChip** — *new* primitive. Renders monospace, accent-colored
+  text on `bg-elev` with `border` 1px and `radius.sm`. Has a `truncate` prop
+  that pairs with a tooltip on hover.
+
+## Out of scope (deferred to other issues)
+
+- Light-theme variant — sub-issue #165.
+- WCAG audit — sub-issue #165.
+- Component primitives for non-Chat surfaces (Manifest, Models, Home) — same
+  follow-up as #164's deferred migration list.
+- Motion / micro-interactions beyond the existing 150ms transition-colors —
+  separate pass once we have a Storybook to iterate in.
+
+## Plan of attack for this PR
+
+1. Update `docs/DESIGN.md` front matter with the new token values + the
+   `IdentifierChip` component spec. Update prose sections that reference
+   specific values.
+2. Run `pnpm design:tokens`. Verify the regenerated `@theme` block.
+3. Update primitives in `ui/src/components/ui/`:
+   - `button.tsx` — flip `default` variant, drop sizes one rung.
+   - `input.tsx`, `textarea.tsx`, `select.tsx` — refine focus rings.
+   - `card.tsx` — tighten padding, drop shadow.
+   - *new* `identifier-chip.tsx`.
+4. Restyle Chat (`ui/src/pages/Chat.tsx`):
+   - Header: tighter typography, smaller icon.
+   - Message bubbles: refine padding, use new colors, identifier chip for
+     verifiable-anchor.
+   - Tool-call cards: replace inline `font-mono text-xs text-accent` with
+     `<IdentifierChip>` for the tool name. Tighten card padding.
+   - Composer: use updated Button + Textarea (smaller heights, refined
+     focus rings).
+5. Verify `pnpm build`, screenshot via Vite dev server (loopback only).
+6. PR description includes before/after screenshots so the reviewer can
+   approve the visual direction.

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -28,15 +28,15 @@ export function TopNav() {
 
   return (
     <nav className="border-b border-[var(--color-border)] bg-[var(--color-bg)]">
-      <div className="mx-auto flex max-w-3xl items-center justify-between px-6 py-3">
+      <div className="mx-auto flex max-w-3xl items-center justify-between px-6 py-2.5">
         <Link
           to="/"
-          className="flex items-center gap-2 text-sm font-semibold tracking-tight transition-colors hover:text-accent"
+          className="flex items-center gap-2 text-sm font-semibold tracking-tight transition-colors"
         >
-          <ShieldCheck className="h-5 w-5 text-accent" aria-hidden="true" />
+          <ShieldCheck className="h-4 w-4 text-accent" aria-hidden="true" />
           <span>Aegis-Node</span>
         </Link>
-        <ul className="flex items-center gap-1">
+        <ul className="flex items-center gap-0.5">
           {NAV_ITEMS.map((item) => {
             const active =
               item.to === "/"
@@ -47,15 +47,15 @@ export function TopNav() {
                 <Link
                   to={item.to}
                   className={cn(
-                    "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors",
+                    "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition-colors",
                     active
-                      ? "bg-[var(--color-bg-elev)] text-accent"
-                      : "text-muted hover:text-fg",
+                      ? "bg-[var(--color-bg-elev)] text-[var(--color-fg)]"
+                      : "text-muted hover:bg-[var(--color-bg-elev)] hover:text-[var(--color-fg)]",
                   )}
                   aria-current={active ? "page" : undefined}
                 >
                   <item.icon
-                    className="h-4 w-4"
+                    className="h-3.5 w-3.5"
                     aria-hidden="true"
                   />
                   <span>{item.label}</span>

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -15,26 +15,29 @@ const buttonVariants = cva(
   cn(
     "inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap",
     "rounded-md font-medium transition-colors",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+    "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[color:var(--color-focus-ring)]/25",
     "disabled:pointer-events-none disabled:opacity-50",
     "[&_svg]:pointer-events-none [&_svg]:shrink-0",
   ),
   {
     variants: {
+      // `default` is the inverted-neutral primary (Linear/Geist pattern).
+      // Accent is reserved for identifier emphasis + focus rings —
+      // intentionally NOT used as a button fill.
       variant: {
         default:
-          "bg-accent text-[var(--color-bg)] hover:opacity-90 active:opacity-80",
+          "bg-[var(--color-fg)] text-[var(--color-bg)] hover:opacity-90 active:opacity-82",
         secondary:
-          "bg-[var(--color-bg-elev)] text-[var(--color-fg)] border border-[var(--color-border)] hover:border-accent hover:text-accent",
+          "bg-[var(--color-bg-elev)] text-[var(--color-fg)] border border-[var(--color-border)] hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg)]",
         ghost:
           "bg-transparent text-muted hover:bg-[var(--color-bg-elev)] hover:text-[var(--color-fg)]",
         danger:
-          "bg-[var(--color-danger)] text-[var(--color-bg)] hover:opacity-90 active:opacity-80",
+          "bg-[var(--color-danger)] text-[var(--color-bg)] hover:opacity-90 active:opacity-82",
       },
       size: {
-        sm: "h-8 px-2 text-xs [&_svg]:h-3.5 [&_svg]:w-3.5",
-        md: "h-9 px-3 text-sm [&_svg]:h-4 [&_svg]:w-4",
-        lg: "h-11 px-4 text-base [&_svg]:h-5 [&_svg]:w-5",
+        sm: "h-7 px-2 text-xs [&_svg]:h-3.5 [&_svg]:w-3.5",
+        md: "h-8 px-3 text-sm [&_svg]:h-3.5 [&_svg]:w-3.5",
+        lg: "h-9 px-3.5 text-sm [&_svg]:h-4 [&_svg]:w-4",
       },
     },
     defaultVariants: {

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -15,7 +15,9 @@ export const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elev)] text-[var(--color-fg)] shadow-sm",
+      // Flat by default — 1px hairline border replaces drop shadow
+      // (Geist pattern). Surface differential against `bg` does the rest.
+      "rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] text-[var(--color-fg)]",
       className,
     )}
     {...props}
@@ -29,7 +31,7 @@ export const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col gap-1 px-6 pt-5 pb-3", className)}
+    className={cn("flex flex-col gap-1 px-5 pt-4 pb-3", className)}
     {...props}
   />
 ));
@@ -42,7 +44,7 @@ export const CardTitle = React.forwardRef<
   <h2
     ref={ref}
     className={cn(
-      "text-base font-semibold tracking-tight text-[var(--color-fg)]",
+      "text-sm font-semibold tracking-tight text-[var(--color-fg)]",
       className,
     )}
     {...props}
@@ -54,6 +56,6 @@ export const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("px-6 pb-6", className)} {...props} />
+  <div ref={ref} className={cn("px-5 pb-5", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";

--- a/ui/src/components/ui/identifier-chip.tsx
+++ b/ui/src/components/ui/identifier-chip.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * IdentifierChip primitive per `docs/DESIGN.md` (`components.IdentifierChip`).
+ *
+ * Used for workload IDs, OCI digests, manifest hashes, SPIFFE URIs, F9
+ * ledger entry IDs, and tool names. The chip treatment is the project's
+ * answer to DESIGN.md's *Do*: "Render identifiers in mono with accent."
+ * Per the Linear / Resend pattern, identifiers are rendered as filled
+ * chips with a 1px ring — not as raw colored text inline with prose.
+ *
+ * When the identifier is truncated to fit, pair the chip with `<Tooltip>`
+ * so the full bytes are recoverable on hover/focus. Truncation without
+ * a tooltip is explicitly forbidden by DESIGN.md's *Don'ts*.
+ */
+export interface IdentifierChipProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Visual emphasis. `default` is accent-on-bg-elev; `muted` drops
+   *  the accent color for places where the identifier is metadata,
+   *  not the primary content (e.g. in a hover tooltip). */
+  tone?: "default" | "muted";
+}
+
+export const IdentifierChip = React.forwardRef<
+  HTMLSpanElement,
+  IdentifierChipProps
+>(({ className, tone = "default", children, ...props }, ref) => (
+  <span
+    ref={ref}
+    className={cn(
+      "inline-flex items-center gap-1 rounded-sm border border-[var(--color-border)]",
+      "bg-[var(--color-bg-elev)] px-1.5 py-px",
+      "font-mono text-[13px] font-medium leading-tight",
+      "max-w-full truncate align-baseline",
+      tone === "default" ? "text-accent" : "text-muted",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </span>
+));
+IdentifierChip.displayName = "IdentifierChip";

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -17,13 +17,13 @@ export const Input = React.forwardRef<
     type={type}
     ref={ref}
     className={cn(
-      "flex h-9 w-full min-w-0 rounded-md border border-[var(--color-border)]",
+      "flex h-8 w-full min-w-0 rounded-md border border-[var(--color-border)]",
       "bg-[var(--color-bg-elev)] px-3 py-1 text-sm text-[var(--color-fg)]",
       "placeholder:text-muted",
       "transition-colors",
-      "focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30",
+      "focus:border-[var(--color-border-strong)] focus:outline-none focus:ring-3 focus:ring-[color:var(--color-focus-ring)]/25",
       "disabled:cursor-not-allowed disabled:opacity-60",
-      "aria-invalid:border-[var(--color-danger)] aria-invalid:focus:ring-[var(--color-danger)]/30",
+      "aria-invalid:border-[var(--color-danger)] aria-invalid:focus:ring-[var(--color-danger)]/25",
       className,
     )}
     {...props}

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -21,13 +21,13 @@ export const Select = React.forwardRef<
     <select
       ref={ref}
       className={cn(
-        "flex h-9 w-full min-w-0 appearance-none rounded-md",
+        "flex h-8 w-full min-w-0 appearance-none rounded-md",
         "border border-[var(--color-border)]",
         "bg-[var(--color-bg-elev)] pr-8 pl-3 text-sm text-[var(--color-fg)]",
         "transition-colors",
-        "focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30",
+        "focus:border-[var(--color-border-strong)] focus:outline-none focus:ring-3 focus:ring-[color:var(--color-focus-ring)]/25",
         "disabled:cursor-not-allowed disabled:opacity-60",
-        "aria-invalid:border-[var(--color-danger)] aria-invalid:focus:ring-[var(--color-danger)]/30",
+        "aria-invalid:border-[var(--color-danger)] aria-invalid:focus:ring-[var(--color-danger)]/25",
         className,
       )}
       {...props}

--- a/ui/src/components/ui/textarea.tsx
+++ b/ui/src/components/ui/textarea.tsx
@@ -22,9 +22,9 @@ export const Textarea = React.forwardRef<
       "bg-[var(--color-bg-elev)] px-3 py-2 text-sm text-[var(--color-fg)]",
       "placeholder:text-muted",
       "resize-none transition-colors",
-      "focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30",
+      "focus:border-[var(--color-border-strong)] focus:outline-none focus:ring-3 focus:ring-[color:var(--color-focus-ring)]/25",
       "disabled:cursor-not-allowed disabled:opacity-60",
-      "aria-invalid:border-[var(--color-danger)] aria-invalid:focus:ring-[var(--color-danger)]/30",
+      "aria-invalid:border-[var(--color-danger)] aria-invalid:focus:ring-[var(--color-danger)]/25",
       className,
     )}
     {...props}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -6,16 +6,17 @@
  * component-level tokens land in #164. */
 @theme {
   /* Colors — dark mode. Light mode lands in #165. */
-  --color-bg: #0b0d10;
-  --color-bg-elev: #11151a;
-  --color-fg: #e5e9ef;
-  --color-muted: #8a93a3;
-  --color-border: #1f2630;
-  --color-accent: #7cc4ff;
+  --color-bg: #0b0c0e;
+  --color-bg-elev: #15171a;
+  --color-fg: #edeef0;
+  --color-muted: #9aa0a8;
+  --color-border: #272a2d;
+  --color-border-strong: #363a3f;
+  --color-accent: #7dd3fc;
   --color-success: #4ade80;
   --color-warning: #facc15;
   --color-danger: #f87171;
-  --color-focus-ring: #7cc4ff;
+  --color-focus-ring: #7dd3fc;
 
   /* Font stacks (system-only — no webfont downloads, per ADR-031). */
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -23,11 +24,11 @@
 
   /* Typography (font-size only at this stage; richer typography
    * is per-component and lands with primitives in #164). */
-  --text-body: 0.9375rem;
+  --text-body: 0.875rem;
   --text-heading: 1.25rem;
-  --text-caption: 0.8125rem;
-  --text-mono-id: 0.92em;
-  --text-code: 0.875rem;
+  --text-caption: 0.75rem;
+  --text-mono-id: 0.8125rem;
+  --text-code: 0.8125rem;
 
   /* Corner radii. */
   --radius-sm: 0.25rem;
@@ -62,6 +63,7 @@ body,
 }
 
 body {
-  font-size: 15px;
-  line-height: 1.55;
+  font-size: var(--text-body, 0.875rem);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
 }

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { IdentifierChip } from "@/components/ui/identifier-chip";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { ModelPicker } from "@/components/ModelPicker";
@@ -289,14 +290,13 @@ export function Chat() {
 
   return (
     <>
-      <header className="mb-6 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <MessageSquare className="h-7 w-7 text-accent" aria-hidden="true" />
+      <header className="mb-5 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <MessageSquare className="h-5 w-5 text-accent" aria-hidden="true" />
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Chat</h1>
-            <p className="text-sm text-muted">
-              Inline tool-call cards render gate decisions per ADR-031 ·
-              verifiable-badge wiring lands in 1d.2c.2
+            <h1 className="text-lg font-semibold tracking-tight">Chat</h1>
+            <p className="text-xs text-muted">
+              Inline tool-call cards render gate decisions per ADR-031
             </p>
           </div>
         </div>
@@ -307,10 +307,10 @@ export function Chat() {
       </header>
 
       <Card>
-        <CardContent className="flex h-[560px] flex-col gap-4 p-0">
+        <CardContent className="flex h-[560px] flex-col gap-3 p-0">
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto px-6 pt-5 pb-2"
+            className="flex-1 overflow-y-auto px-5 pt-4 pb-2"
           >
             <div className="flex flex-col gap-4">
               {messages.map((m) =>
@@ -323,7 +323,7 @@ export function Chat() {
             </div>
           </div>
 
-          <div className="border-t border-[var(--color-border)] px-6 py-4">
+          <div className="border-t border-[var(--color-border)] px-5 py-3">
             <div className="flex items-end gap-2">
               <Textarea
                 value={input}
@@ -335,13 +335,13 @@ export function Chat() {
                     : "connecting…"
                 }
                 disabled={conn.kind !== "open"}
-                rows={2}
-                className="min-h-[44px] flex-1 bg-[var(--color-bg)]"
+                rows={1}
+                className="min-h-[36px] flex-1 bg-[var(--color-bg)] py-2"
               />
               <Button
                 type="button"
-                variant="secondary"
-                size="lg"
+                variant="default"
+                size="md"
                 onClick={handleSend}
                 disabled={!canSend}
                 aria-label="Send"
@@ -360,42 +360,47 @@ export function Chat() {
 function MessageBubble({ message }: { message: TextMessage }) {
   if (message.role === "system") {
     return (
-      <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-xs text-muted">
+      <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-xs text-muted">
         {message.text}
       </div>
     );
   }
   const isUser = message.role === "user";
   return (
-    <div className={cn("flex gap-3", isUser ? "flex-row-reverse" : "flex-row")}>
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-elev)]">
+    <div className={cn("flex gap-2.5", isUser ? "flex-row-reverse" : "flex-row")}>
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-elev)]">
         {isUser ? (
-          <User className="h-4 w-4 text-muted" aria-hidden="true" />
+          <User className="h-3.5 w-3.5 text-muted" aria-hidden="true" />
         ) : (
-          <Bot className="h-4 w-4 text-accent" aria-hidden="true" />
+          <Bot className="h-3.5 w-3.5 text-accent" aria-hidden="true" />
         )}
       </div>
-      <div className="flex max-w-[80%] flex-col gap-1">
+      <div className="flex max-w-[80%] flex-col gap-1.5">
         <div
           className={cn(
-            "whitespace-pre-wrap rounded-md px-3 py-2 text-sm",
+            "whitespace-pre-wrap rounded-md px-3 py-2 text-sm leading-relaxed",
             isUser
               ? "bg-[var(--color-bg-elev)] text-[var(--color-fg)]"
-              : "bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-fg)]",
+              : "border border-[var(--color-border)] bg-[var(--color-bg)] text-[var(--color-fg)]",
           )}
         >
           {message.text}
           {message.pending && (
-            <span className="ml-1 inline-block h-3 w-3 animate-pulse rounded-full bg-accent align-middle" />
+            <span className="ml-1 inline-block h-2 w-2 animate-pulse rounded-full bg-accent align-middle" />
           )}
         </div>
         {message.verifiableAnchor && (
           <span
-            className="inline-flex cursor-help items-center gap-1 self-start rounded bg-emerald-950/40 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300"
+            className={cn(
+              "inline-flex cursor-help items-center gap-1.5 self-start text-[11px] text-muted",
+            )}
             title={`F9 reasoning-step uuid: ${message.verifiableAnchor} — click-through to /replay/<anchor> lands when the ADR-010 viewer wires up`}
           >
-            <ShieldCheck className="h-3 w-3" aria-hidden="true" />
-            verifiable · {message.verifiableAnchor.slice(0, 8)}…
+            <ShieldCheck className="h-3 w-3 text-success" aria-hidden="true" />
+            <span>verifiable</span>
+            <IdentifierChip className="text-[11px]">
+              {message.verifiableAnchor.slice(0, 8)}
+            </IdentifierChip>
           </span>
         )}
       </div>
@@ -408,32 +413,27 @@ const TOOL_STATUS_META: Record<
   {
     label: string;
     color: string;
-    bg: string;
     Icon: typeof CircleAlert;
   }
 > = {
   success: {
     label: "success",
-    color: "text-emerald-300",
-    bg: "bg-emerald-950/40",
+    color: "text-success",
     Icon: ShieldCheck,
   },
   denied: {
     label: "denied",
-    color: "text-red-400",
-    bg: "bg-red-950/40",
+    color: "text-danger",
     Icon: ShieldOff,
   },
   requires_approval: {
     label: "approval required",
-    color: "text-amber-300",
-    bg: "bg-amber-950/40",
+    color: "text-warning",
     Icon: Lock,
   },
   unroutable: {
     label: "unroutable",
-    color: "text-sky-300",
-    bg: "bg-sky-950/40",
+    color: "text-muted",
     Icon: HelpCircle,
   },
 };
@@ -467,9 +467,9 @@ function ToolCallCard({ call }: { call: ToolCallMessage }) {
   }, [call.value]);
 
   return (
-    <div className="flex gap-3">
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-elev)]">
-        <Hammer className="h-4 w-4 text-accent" aria-hidden="true" />
+    <div className="flex gap-2.5">
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-elev)]">
+        <Hammer className="h-3.5 w-3.5 text-accent" aria-hidden="true" />
       </div>
       <div className="flex max-w-[80%] flex-1 flex-col rounded-md border border-[var(--color-border)] bg-[var(--color-bg)]">
         <Button
@@ -479,7 +479,7 @@ function ToolCallCard({ call }: { call: ToolCallMessage }) {
           className="h-auto justify-between gap-3 rounded-none px-3 py-2 text-left text-sm font-normal text-[var(--color-fg)] hover:text-[var(--color-fg)]"
           aria-expanded={expanded}
         >
-          <div className="flex items-center gap-2 truncate">
+          <div className="flex min-w-0 items-center gap-2">
             {expanded ? (
               <ChevronDown
                 className="h-3.5 w-3.5 shrink-0 text-muted"
@@ -491,13 +491,12 @@ function ToolCallCard({ call }: { call: ToolCallMessage }) {
                 aria-hidden="true"
               />
             )}
-            <span className="font-mono text-xs text-accent">{call.name}</span>
+            <IdentifierChip>{call.name}</IdentifierChip>
           </div>
           {meta ? (
             <span
               className={cn(
-                "inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[10px]",
-                meta.bg,
+                "inline-flex shrink-0 items-center gap-1 text-[11px] font-medium",
                 meta.color,
               )}
             >
@@ -507,8 +506,8 @@ function ToolCallCard({ call }: { call: ToolCallMessage }) {
               {meta.label}
             </span>
           ) : (
-            <span className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] text-muted">
-              <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-accent" />
+            <span className="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-muted">
+              <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
               dispatching…
             </span>
           )}
@@ -553,7 +552,7 @@ function ToolCallCard({ call }: { call: ToolCallMessage }) {
 function ConnectionPill({ state }: { state: ConnState }) {
   if (state.kind === "connecting") {
     return (
-      <span className="inline-flex items-center gap-1 font-mono text-xs text-muted">
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted">
         <ArrowDown className="h-3.5 w-3.5 animate-pulse" aria-hidden="true" />
         connecting…
       </span>
@@ -562,7 +561,7 @@ function ConnectionPill({ state }: { state: ConnState }) {
   if (state.kind === "open") {
     return (
       <span
-        className="inline-flex items-center gap-1 rounded bg-emerald-950/40 px-2 py-0.5 font-mono text-xs text-emerald-300"
+        className="inline-flex items-center gap-1.5 text-xs text-success"
         title={`session ${state.sessionId}`}
       >
         <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
@@ -572,7 +571,7 @@ function ConnectionPill({ state }: { state: ConnState }) {
   }
   if (state.kind === "closed") {
     return (
-      <span className="inline-flex items-center gap-1 font-mono text-xs text-amber-300">
+      <span className="inline-flex items-center gap-1.5 text-xs text-warning">
         <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />
         closed{state.reason ? ` · ${state.reason}` : ""}
       </span>
@@ -580,7 +579,7 @@ function ConnectionPill({ state }: { state: ConnState }) {
   }
   return (
     <span
-      className="inline-flex items-center gap-1 font-mono text-xs text-red-400"
+      className="inline-flex items-center gap-1.5 text-xs text-danger"
       title={state.message}
     >
       <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />


### PR DESCRIPTION
Follow-up to the design-system rollout (#162, #163, #164 — all in main as of #175). Those PRs landed backwards-compatible by design — the regenerated CSS produced byte-identical visible output so the work stayed reviewable. This PR is the actual visual modernization that the design-system rollout was meant to enable.

## Research

Synthesised from four references — full notes in [`docs/plans/design-modernization.md`](../blob/design/164b-modernize-tokens/docs/plans/design-modernization.md):

| Reference | Lesson borrowed |
|---|---|
| Vercel Geist | Flat 1px-border elevation; no soft shadows on dark |
| Radix `slateDark` | 12-step neutral scale; every state from the same hue |
| Linear | Identifier-as-chip pattern; accent reserved for emphasis (not CTAs) |
| Resend docs | Inline code rendered as filled chip, never raw text |

## Token deltas (dark mode only — light variant + WCAG audit in #165)

| Token | Old | New | Why |
|---|---|---|---|
| `bg` | `#0b0d10` | `#0b0c0e` | Cooler near-black, no green hint |
| `bg-elev` | `#11151a` | `#15171a` | One step lighter; pairs with flat elevation |
| `fg` | `#e5e9ef` | `#edeef0` | Radix slate12; AAA contrast on `bg` |
| `muted` | `#8a93a3` | `#9aa0a8` | Clean AA on `bg-elev` chips |
| `border` | `#1f2630` | `#272a2d` | More visible — borders disappeared on LCDs |
| `border-strong` | _new_ | `#363a3f` | Radix slate6 for focused-input borders |
| `accent` | `#7cc4ff` | `#7dd3fc` | Pinned to Tailwind sky-300 |
| body fontSize | 15px | **14px** | Linear/Geist chrome density |
| body lineHeight | 1.55 | **1.5** | Tighter; "tool," not "marketing" |
| body letterSpacing | 0 | **-0.005em** | Mimics Geist's optical correction |

## Headline visual change

Identifiers — workload IDs, OCI digests, manifest hashes, ledger entry IDs, tool names — now render as **`<IdentifierChip>`** (monospace, accent text, `bg-elev` fill, 1px `border`, 4px radius). Previously they were raw colored text inline with prose. This is the pattern Linear and Resend use and the single most visible upgrade.

## Component deltas

- **Button** — `default` variant flips from accent-fill to **inverted-neutral** (`fg`-on-`bg`) per Linear/Geist convention. Accent reserved for identifier emphasis + focus rings. Heights drop one rung (sm 8→7, md 9→8, lg 11→9).
- **Input / Textarea / Select** — focus border moves to `border-strong`; chroma lives in the 3px translucent ring.
- **Card** — tighter padding, zero box-shadow (Geist's border-only-elevation pattern).
- **NavLink** — active state uses `fg` not `accent`. Frees `accent` for genuine identifiers.
- **IdentifierChip** *(new)* — chip primitive replacing inline colored text.

## Chat surface restyle

- Header: `text-2xl` → `text-lg`, smaller icon.
- Message bubbles: tighter avatars, tighter gaps.
- Verifiable badge: uses `<IdentifierChip>` for the anchor hash; ShieldCheck flips to `text-success`.
- Tool-call cards: tool name as `<IdentifierChip>`. Status pills are text-only with semantic colour tokens (no more `bg-emerald-950/40` hacks).
- ConnectionPill: text-only with semantic colours.
- Composer: Send button → `variant=\"default\"` (inverted-neutral); Textarea drops min-h 44→36.

## TopNav

Active state uses `bg-elev` + `fg` (not `accent`). Tighter padding, smaller icons.

## Out of scope (deferred)

- Home, Manifest, Models pages — tokens propagate via `@theme` but these weren't explicitly restyled.
- Light-theme variant + WCAG audit — sub-issue **#165**.
- Further iteration on visual weight — the refined direction reads as \"subtly different\" rather than \"obviously modern\" without side-by-side. **Acknowledged with the maintainer during review; we agreed to ship as-is and iterate later.**

## Visual review note

Reviewed live via Vite preview on localhost; verified the new bundle was actually loading in the browser (via temporary magenta debug stripe — pipeline confirmed clean). The deltas are intentionally subtle per the picked aesthetic. The most obviously different element is the **Chat Send button** flipping from bordered-secondary to inverted-neutral primary (light button, dark text).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean (14s)
- [x] `pnpm design:tokens` idempotent
- [ ] Reviewer manual smoke: Chat send button is inverted-neutral, TopNav active is `fg` not `accent`, tool-call card tool name is a chip.
- [ ] Eye-test: do the dark-mode values still feel \"Aegis-Node\" or have we drifted?

🤖 Generated with [Claude Code](https://claude.com/claude-code)