### PR TITLE
feat(design): light-theme variant + axe-core WCAG AA audit (#165)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,68 @@
+name: A11y
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ui/**'
+      - 'docs/DESIGN.md'
+      - '.github/workflows/a11y.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ui/**'
+      - 'docs/DESIGN.md'
+      - '.github/workflows/a11y.yml'
+
+# WCAG AA contrast + serious/critical axe-core findings on the four
+# Community UI surfaces (Home, Chat, Manifest Builder, Model Library)
+# in both dark and light themes. Per issue #165 (parent #161). The
+# audit is a hard gate — a PR that introduces a serious or critical
+# axe violation cannot merge without an explicit waiver in the PR
+# description.
+jobs:
+  a11y:
+    name: axe-core (dark + light) × (home / chat / manifest / models)
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # `playwright install` downloads chromium (~150MB) into a
+      # well-known cache directory. We avoid `--with-deps` because the
+      # ubuntu-24.04 runner already has the X11/glibc dependencies
+      # chromium needs; using `--with-deps` adds ~30s of apt-get for
+      # libraries already present.
+      - name: Install Playwright browser
+        run: pnpm exec playwright install chromium
+
+      - name: Build UI
+        run: pnpm build
+
+      - name: Run axe-core audit
+        run: pnpm test:a11y
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: ui/playwright-report/
+          retention-days: 14

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,3 +1,8 @@
 node_modules/
 dist/
 *.tsbuildinfo
+
+# Playwright artefacts (a11y audit, issue #165).
+playwright-report/
+test-results/
+playwright/.cache/

--- a/ui/e2e/a11y.spec.ts
+++ b/ui/e2e/a11y.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * Accessibility audit for the Community UI (issue #165). Runs axe-core
+ * against the four user-facing surfaces in both themes; fails on any
+ * `serious` or `critical` violation, plus any colour-contrast finding.
+ *
+ * "Theme" here means the manual `data-theme` attribute set by the
+ * TopNav toggle — we don't try to programmatically toggle the OS
+ * `prefers-color-scheme` because Playwright's `colorScheme` emulation
+ * doesn't trigger the manual-override CSS path (`:root[data-theme=…]`)
+ * that ships to operators.
+ */
+
+const SURFACES = [
+  { path: "/", label: "Home" },
+  { path: "/chat", label: "Chat" },
+  { path: "/manifest", label: "Manifest Builder" },
+  { path: "/models", label: "Model Library" },
+] as const;
+
+const THEMES = ["dark", "light"] as const;
+type Theme = (typeof THEMES)[number];
+
+// Tags map to the WCAG 2.1 A + AA rule sets that axe-core ships.
+// `best-practice` is intentionally omitted — those are advisory, not
+// conformance gates, and would flag things like "this <section> has
+// no <h2>" that the project doesn't commit to.
+const AXE_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+async function setTheme(page: Page, theme: Theme) {
+  // Set the same localStorage key the production toggle writes. The
+  // inline bootstrap script in `ui/index.html` reads this on first
+  // paint so we never see the wrong theme even momentarily.
+  await page.addInitScript((t: Theme) => {
+    window.localStorage.setItem("aegis-theme", t);
+  }, theme);
+}
+
+for (const theme of THEMES) {
+  for (const { path, label } of SURFACES) {
+    test(`${label} (${theme}): no serious/critical axe violations`, async ({
+      page,
+    }) => {
+      await setTheme(page, theme);
+      await page.goto(path);
+      // Settle: the SPA needs one tick to mount and (for /chat, /models)
+      // queue its first API call. We don't need the API to succeed —
+      // we're auditing chrome — but waiting `networkidle` makes the
+      // surface stable.
+      await page.waitForLoadState("networkidle");
+
+      // Sanity: confirm the theme attribute actually landed on <html>.
+      // If this fails the audit ran against the wrong palette.
+      await expect(page.locator("html")).toHaveAttribute(
+        "data-theme",
+        theme,
+      );
+
+      const results = await new AxeBuilder({ page })
+        .withTags(AXE_TAGS)
+        // Monaco editor (Manifest Builder) ships its own syntax-
+        // highlighting theme with hard-coded colours that don't quite
+        // hit WCAG AA at 13px — and the theme is part of Monaco's
+        // upstream, not ours to fix. The editor's own a11y story is
+        // covered by Monaco's accessibility-help dialog; this scan
+        // gates the chrome we author, not the IDE's surface.
+        .exclude(".monaco-editor")
+        .analyze();
+
+      const blocking = results.violations.filter(
+        (v) =>
+          v.impact === "serious" ||
+          v.impact === "critical" ||
+          v.id === "color-contrast",
+      );
+
+      // Surface the failing rule IDs in the assertion message so the
+      // CI annotation tells a reviewer what to fix without spelunking
+      // through the artifact bundle.
+      const summary = blocking
+        .map((v) => `${v.id} (impact=${v.impact}, n=${v.nodes.length})`)
+        .join("; ");
+      expect(blocking, summary || undefined).toEqual([]);
+    });
+  }
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,8 +4,32 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0b0d10" />
+    <meta name="theme-color" content="#0b0c0e" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <title>Aegis-Node — Community UI</title>
+    <!--
+      Pre-mount theme bootstrap. Reads the localStorage choice and sets
+      <html data-theme> *before* React renders, so the first paint
+      doesn't flash the wrong theme.
+
+      The body of this script must stay in sync with the contract in
+      `ui/src/lib/theme.ts` (storage key + accepted values). Kept
+      inline + minimal on purpose — no module import, no chance of a
+      blocking network fetch on first paint.
+    -->
+    <script>
+      (function () {
+        try {
+          var t = window.localStorage.getItem("aegis-theme");
+          if (t === "dark" || t === "light") {
+            document.documentElement.setAttribute("data-theme", t);
+          }
+        } catch (_e) {
+          // localStorage may throw under privacy modes; safe to ignore —
+          // CSS @media (prefers-color-scheme) is the fallback.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,8 @@
     "prebuild": "pnpm design:tokens",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "test:a11y": "playwright test"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
@@ -34,6 +35,8 @@
     "tailwind-merge": "^2.5.5"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for the a11y audit (issue #165).
+ * Single chromium project; no auth, no fixtures. Spawns `vite preview`
+ * automatically on a fixed port so the same config works in CI and
+ * locally.
+ *
+ * The UI talks to `crates/ui-server` for chat/model APIs over a
+ * WebSocket. Without that backend running these tests see the
+ * "connecting…" state — that's fine, we're auditing the SPA chrome,
+ * not full data round-trips. A separate e2e suite covers backend
+ * integration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  // a11y runs are short; no need for retries.
+  retries: 0,
+  // No parallelism so Vite preview only starts once.
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+    // Reduce flake on slow renders.
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm preview --port 4173 --strictPort",
+    url: "http://127.0.0.1:4173",
+    // 90s allows the `prebuild`-triggered token regeneration + Vite
+    // build + preview boot inside `pnpm preview` if it has to build
+    // first. Once the build is cached the start is ~1s.
+    timeout: 90_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -33,12 +33,31 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm preview --port 4173 --strictPort",
-    url: "http://127.0.0.1:4173",
-    // 90s allows the `prebuild`-triggered token regeneration + Vite
-    // build + preview boot inside `pnpm preview` if it has to build
-    // first. Once the build is cached the start is ~1s.
-    timeout: 90_000,
+    // `pnpm exec vite preview` (not `pnpm preview`) invokes the vite
+    // binary directly without going through the `preview` npm script.
+    // The script wrapper made vite's stdout invisible to Playwright's
+    // webServer probe on GitHub Actions, leading to a 90s timeout
+    // with no diagnostic output.
+    //
+    // `--host 127.0.0.1` pins the bind address. By default Vite's
+    // preview server binds to localhost on whichever address family
+    // resolves first — that can land on `::1` while Playwright probes
+    // `127.0.0.1`. Explicit pinning avoids the resolution race.
+    //
+    // `--strictPort` makes vite exit (visibly) if 4173 is busy rather
+    // than silently falling through to the next port that Playwright
+    // can't reach.
+    command:
+      "pnpm exec vite preview --port 4173 --strictPort --host 127.0.0.1",
+    // `port` makes Playwright probe both IPv4 and IPv6 loopback on the
+    // chosen port — more forgiving than a pinned `url`.
+    port: 4173,
+    // 120s headroom for cold-start CI runners. Local boots in ~1s.
+    timeout: 120_000,
     reuseExistingServer: !process.env.CI,
+    // Surface vite preview's stdout/stderr in the test run output so
+    // the next CI failure (if any) shows what the server actually did.
+    stdout: "pipe",
+    stderr: "pipe",
   },
 });

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -57,6 +57,12 @@ importers:
         specifier: ^2.5.5
         version: 2.6.1
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.60.0)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -83,6 +89,11 @@ importers:
         version: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -363,6 +374,11 @@ packages:
       monaco-editor: '>= 0.25.0 < 1'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -912,6 +928,10 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
+
   baseline-browser-mapping@2.10.27:
     resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
     engines: {node: '>=6.0.0'}
@@ -984,6 +1004,11 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1132,6 +1157,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -1315,6 +1350,11 @@ packages:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
 snapshots:
+
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.60.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1552,6 +1592,10 @@ snapshots:
       monaco-editor: 0.55.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -2012,6 +2056,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  axe-core@4.11.4: {}
+
   baseline-browser-mapping@2.10.27: {}
 
   browserslist@4.28.2:
@@ -2089,6 +2135,9 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -2190,6 +2239,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.14:
     dependencies:

--- a/ui/scripts/render-tokens.mjs
+++ b/ui/scripts/render-tokens.mjs
@@ -1,31 +1,30 @@
 #!/usr/bin/env node
 // Generate ui/src/index.css's @theme block from the YAML front matter in
-// docs/DESIGN.md. Per issue #163 (parent #161). docs/DESIGN.md is the
-// single source of truth — this script writes the derived CSS so the
-// two artefacts can't drift.
+// docs/DESIGN.md. docs/DESIGN.md is the single source of truth — this
+// script writes the derived CSS so the two artefacts can't drift.
 //
-// Scope (matches #163):
-//   - colors.*       → --color-{name}        (dark-mode values only;
-//                                              light theme lands in #165)
-//   - font.*         → --font-{name}
-//   - typography.*   → --text-{name}         (font-size only;
-//                                              richer typography lands in #164
-//                                              when component primitives consume it)
-//   - rounded.*      → --radius-{name}       (Tailwind v4 convention)
-//   - spacing.*      → --spacing-{name}
+// Issues touched: #163 (initial generator), #165 (this — dual-theme
+// emission + data-theme overrides). Parent tracker: #161.
 //
-// Out of scope per #163: components.*, elevation.*, colors.*.light. Those
-// belong to sub-issues #164 and #165 respectively.
+// Emission layout:
+//   1. Default `@theme { ... }` — dark colours + font/text/radius/spacing.
+//      Tailwind v4 registers these as CSS custom properties on :root and
+//      generates utility classes (bg-bg, text-fg, ...). Dark is the
+//      default per ADR-031's identifier-dense aesthetic.
+//   2. `@media (prefers-color-scheme: light) :root { ... }` — light colour
+//      overrides + `color-scheme: light` so native controls flip too.
+//   3. `:root[data-theme="dark"]` / `:root[data-theme="light"]` — manual
+//      override via a localStorage-driven attribute on <html>. Wins over
+//      the media query because the attribute selector is more specific.
+//
+// Non-colour tokens (font, text size, radius, spacing) don't vary by
+// mode, so they live in `@theme` only.
 //
 // Idempotency: same input → same output, byte-for-byte. CI can run this
 // and then `git diff --exit-code ui/src/index.css` to catch drift.
 //
-// Run from any CWD; paths resolve relative to the script's location.
-//
 // Lives under `ui/scripts/` (not the repo-root `scripts/`) so Node's
-// module resolver walks into `ui/node_modules/` for `js-yaml`. A previous
-// version at `scripts/design/` broke in CI because no `node_modules`
-// exists on the walk path from there.
+// module resolver walks into `ui/node_modules/` for `js-yaml`.
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -41,9 +40,9 @@ const HAND_WRITTEN_SENTINEL =
   "/* DESIGN.md tokens above — hand-written CSS below. */";
 
 const GENERATED_HEADER = `/* GENERATED FROM docs/DESIGN.md by ui/scripts/render-tokens.mjs.
- * Do not hand-edit this @theme block — run \`pnpm design:tokens\` after
- * updating the spec. Light-theme variant lands in issue #165;
- * component-level tokens land in #164. */`;
+ * Do not hand-edit anything above the sentinel comment — run
+ * \`pnpm design:tokens\` after updating the spec. Both themes
+ * (dark + light) emit from a single source. */`;
 
 function parseFrontMatter(markdown) {
   const m = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
@@ -55,17 +54,15 @@ function parseFrontMatter(markdown) {
   return yaml.load(m[1]);
 }
 
-function pickDark(value) {
-  // Color tokens are objects { dark, light }; fall back to the value
-  // itself if it's already a scalar (defensive — not currently used).
+function pickMode(value, mode) {
   if (typeof value === "string") return value;
-  if (value && typeof value === "object" && "dark" in value) return value.dark;
-  throw new Error(`Color token has no \`dark\` key: ${JSON.stringify(value)}`);
+  if (value && typeof value === "object" && mode in value) return value[mode];
+  throw new Error(
+    `Color token has no \`${mode}\` key: ${JSON.stringify(value)}`,
+  );
 }
 
 function normaliseFontStack(value) {
-  // YAML folded scalars collapse newlines to spaces; collapse runs of
-  // whitespace to single spaces so the output is one line.
   return String(value).replace(/\s+/g, " ").trim();
 }
 
@@ -73,28 +70,22 @@ function renderThemeBlock(spec) {
   const lines = [];
   lines.push("@theme {");
 
-  // ----- Colors (dark mode only at this stage) -----
-  lines.push("  /* Colors — dark mode. Light mode lands in #165. */");
+  // Dark is the default — Tailwind v4 registers these as the canonical
+  // utility-class sources (bg-bg, text-fg, ...). Light overrides come
+  // later via :root selectors so the utility-class names stay stable.
+  lines.push("  /* Colors — dark mode (default). Light overrides emit below. */");
   for (const [name, value] of Object.entries(spec.colors ?? {})) {
-    lines.push(`  --color-${name}: ${pickDark(value)};`);
+    lines.push(`  --color-${name}: ${pickMode(value, "dark")};`);
   }
   lines.push("");
 
-  // ----- Font stacks -----
   lines.push("  /* Font stacks (system-only — no webfont downloads, per ADR-031). */");
   for (const [name, value] of Object.entries(spec.font ?? {})) {
     lines.push(`  --font-${name}: ${normaliseFontStack(value)};`);
   }
   lines.push("");
 
-  // ----- Typography font sizes -----
-  //
-  // The full typography spec (weight, line-height, letter-spacing) is
-  // expressed per-component in the YAML; component primitives in #164
-  // will read it directly. At this stage we only emit font-size as
-  // --text-{name} so the existing utility-class surface keeps working.
-  lines.push("  /* Typography (font-size only at this stage; richer typography");
-  lines.push("   * is per-component and lands with primitives in #164). */");
+  lines.push("  /* Typography (font-size only; richer typography lives in component primitives). */");
   for (const [name, value] of Object.entries(spec.typography ?? {})) {
     if (value && typeof value === "object" && value.fontSize) {
       lines.push(`  --text-${name}: ${value.fontSize};`);
@@ -102,14 +93,12 @@ function renderThemeBlock(spec) {
   }
   lines.push("");
 
-  // ----- Rounded -----
   lines.push("  /* Corner radii. */");
   for (const [name, value] of Object.entries(spec.rounded ?? {})) {
     lines.push(`  --radius-${name}: ${value};`);
   }
   lines.push("");
 
-  // ----- Spacing -----
   lines.push("  /* Spacing scale. */");
   for (const [name, value] of Object.entries(spec.spacing ?? {})) {
     lines.push(`  --spacing-${name}: ${value};`);
@@ -119,13 +108,55 @@ function renderThemeBlock(spec) {
   return lines.join("\n");
 }
 
-function buildIndexCss(themeBlock, existingCss) {
+function renderModeBlock(spec, mode, selector) {
+  // Renders a CSS rule that overrides only the colour custom properties
+  // for one theme mode. `selector` is the wrapping selector text (e.g.
+  // `:root[data-theme="light"]` or the body of an @media block).
+  const lines = [];
+  lines.push(`${selector} {`);
+  lines.push(`  color-scheme: ${mode};`);
+  for (const [name, value] of Object.entries(spec.colors ?? {})) {
+    lines.push(`  --color-${name}: ${pickMode(value, mode)};`);
+  }
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function renderModeOverrides(spec) {
+  // The order matters for the cascade:
+  //   1. @theme registered dark tokens on :root.
+  //   2. :root sets color-scheme: dark as the default (not in @theme
+  //      because color-scheme is a regular CSS property, not a token).
+  //   3. @media (prefers-color-scheme: light) overrides when the OS asks.
+  //   4. data-theme attribute overrides everything when set by the
+  //      manual toggle (higher specificity than plain :root).
+  return [
+    "/* Default color-scheme for native form controls / scrollbars. */",
+    ":root {",
+    "  color-scheme: dark;",
+    "}",
+    "",
+    "/* Light mode — applies when the OS prefers light. */",
+    "@media (prefers-color-scheme: light) {",
+    renderModeBlock(spec, "light", "  :root")
+      .split("\n")
+      .map((l) => "  " + l)
+      .join("\n")
+      .replace(/^  /, ""),
+    "}",
+    "",
+    "/* Manual overrides set by the toggle in TopNav. Wins over the media query. */",
+    renderModeBlock(spec, "dark", ':root[data-theme="dark"]'),
+    "",
+    renderModeBlock(spec, "light", ':root[data-theme="light"]'),
+  ].join("\n");
+}
+
+function buildIndexCss(spec, existingCss) {
   // Pull the hand-written portion (everything after the sentinel) out
   // of the current file. If the sentinel is missing this is the first
-  // generation pass — keep whatever was already below the @theme block
-  // as the hand-written portion. The CSS that ships today has exactly
-  // the structure we want to preserve, so the no-sentinel path is the
-  // safe default for the first run.
+  // generation pass — keep whatever was already below the last generated
+  // block as the hand-written portion.
   let handWritten;
   const sentinelIdx = existingCss.indexOf(HAND_WRITTEN_SENTINEL);
   if (sentinelIdx !== -1) {
@@ -133,18 +164,23 @@ function buildIndexCss(themeBlock, existingCss) {
       .slice(sentinelIdx + HAND_WRITTEN_SENTINEL.length)
       .replace(/^\s*\n/, "");
   } else {
-    // Pull everything after the first @theme block's closing brace.
+    // Best-effort fallback: cut at the first @theme block's closing brace.
     const themeMatch = existingCss.match(/@theme\s*{[\s\S]*?\n}\s*\n/);
     handWritten = themeMatch
       ? existingCss.slice(themeMatch.index + themeMatch[0].length)
       : "";
   }
 
+  const themeBlock = renderThemeBlock(spec);
+  const modeOverrides = renderModeOverrides(spec);
+
   return [
     `@import "tailwindcss";`,
     "",
     GENERATED_HEADER,
     themeBlock,
+    "",
+    modeOverrides,
     "",
     HAND_WRITTEN_SENTINEL,
     "",
@@ -155,10 +191,9 @@ function buildIndexCss(themeBlock, existingCss) {
 function main() {
   const markdown = readFileSync(DESIGN_MD, "utf8");
   const spec = parseFrontMatter(markdown);
-  const themeBlock = renderThemeBlock(spec);
 
   const existingCss = readFileSync(INDEX_CSS, "utf8");
-  const next = buildIndexCss(themeBlock, existingCss);
+  const next = buildIndexCss(spec, existingCss);
 
   if (next === existingCss) {
     console.log("ui/src/index.css already in sync with docs/DESIGN.md.");

--- a/ui/src/components/ModelPicker.tsx
+++ b/ui/src/components/ModelPicker.tsx
@@ -205,7 +205,7 @@ export function ModelPicker({ onForkComplete, disabled }: ModelPickerProps) {
             </div>
           )}
           {error && (
-            <div className="px-3 py-2 font-mono text-xs text-red-400">
+            <div className="px-3 py-2 font-mono text-xs text-danger">
               {error instanceof Error ? error.message : String(error)}
             </div>
           )}
@@ -240,7 +240,7 @@ export function ModelPicker({ onForkComplete, disabled }: ModelPickerProps) {
                         </span>
                         <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] text-muted">
                           {m.cosign?.verified && (
-                            <span className="inline-flex items-center gap-0.5 text-emerald-300">
+                            <span className="inline-flex items-center gap-0.5 text-success">
                               <ShieldCheck
                                 className="h-3 w-3"
                                 aria-hidden="true"
@@ -264,7 +264,7 @@ export function ModelPicker({ onForkComplete, disabled }: ModelPickerProps) {
             </ul>
           )}
           {forkState.kind === "error" && (
-            <div className="border-t border-[var(--color-border)] bg-red-950/40 px-3 py-2 font-mono text-[11px] text-red-300">
+            <div className="border-t border-[var(--color-border)] bg-[var(--color-bg-elev)] px-3 py-2 font-mono text-[11px] text-danger">
               fork failed: {forkState.message}
             </div>
           )}

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -4,10 +4,13 @@ import {
   FileCode,
   Home as HomeIcon,
   MessageSquare,
+  Moon,
   ShieldCheck,
+  Sun,
 } from "lucide-react";
 import type { ComponentType, SVGProps } from "react";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/lib/theme";
 
 interface NavItem {
   to: string;
@@ -25,6 +28,7 @@ const NAV_ITEMS: NavItem[] = [
 export function TopNav() {
   const router = useRouterState();
   const currentPath = router.location.pathname;
+  const { effective, cycle } = useTheme();
 
   return (
     <nav className="border-b border-[var(--color-border)] bg-[var(--color-bg)]">
@@ -36,34 +40,58 @@ export function TopNav() {
           <ShieldCheck className="h-4 w-4 text-accent" aria-hidden="true" />
           <span>Aegis-Node</span>
         </Link>
-        <ul className="flex items-center gap-0.5">
-          {NAV_ITEMS.map((item) => {
-            const active =
-              item.to === "/"
-                ? currentPath === "/"
-                : currentPath.startsWith(item.to);
-            return (
-              <li key={item.to}>
-                <Link
-                  to={item.to}
-                  className={cn(
-                    "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition-colors",
-                    active
-                      ? "bg-[var(--color-bg-elev)] text-[var(--color-fg)]"
-                      : "text-muted hover:bg-[var(--color-bg-elev)] hover:text-[var(--color-fg)]",
-                  )}
-                  aria-current={active ? "page" : undefined}
-                >
-                  <item.icon
-                    className="h-3.5 w-3.5"
-                    aria-hidden="true"
-                  />
-                  <span>{item.label}</span>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+        <div className="flex items-center gap-1">
+          <ul className="flex items-center gap-0.5">
+            {NAV_ITEMS.map((item) => {
+              const active =
+                item.to === "/"
+                  ? currentPath === "/"
+                  : currentPath.startsWith(item.to);
+              return (
+                <li key={item.to}>
+                  <Link
+                    to={item.to}
+                    className={cn(
+                      "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition-colors",
+                      active
+                        ? "bg-[var(--color-bg-elev)] text-[var(--color-fg)]"
+                        : "text-muted hover:bg-[var(--color-bg-elev)] hover:text-[var(--color-fg)]",
+                    )}
+                    aria-current={active ? "page" : undefined}
+                  >
+                    <item.icon
+                      className="h-3.5 w-3.5"
+                      aria-hidden="true"
+                    />
+                    <span>{item.label}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          <button
+            type="button"
+            onClick={cycle}
+            className="ml-1 flex h-7 w-7 items-center justify-center rounded-md text-muted transition-colors hover:bg-[var(--color-bg-elev)] hover:text-[var(--color-fg)] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[color:var(--color-focus-ring)]/25"
+            aria-label={
+              effective === "dark"
+                ? "Switch to light theme"
+                : "Switch to dark theme"
+            }
+            aria-pressed={effective === "light"}
+            title={
+              effective === "dark"
+                ? "Switch to light theme"
+                : "Switch to dark theme"
+            }
+          >
+            {effective === "dark" ? (
+              <Moon className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <Sun className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+          </button>
+        </div>
       </div>
     </nav>
   );

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,11 +1,11 @@
 @import "tailwindcss";
 
 /* GENERATED FROM docs/DESIGN.md by ui/scripts/render-tokens.mjs.
- * Do not hand-edit this @theme block — run `pnpm design:tokens` after
- * updating the spec. Light-theme variant lands in issue #165;
- * component-level tokens land in #164. */
+ * Do not hand-edit anything above the sentinel comment — run
+ * `pnpm design:tokens` after updating the spec. Both themes
+ * (dark + light) emit from a single source. */
 @theme {
-  /* Colors — dark mode. Light mode lands in #165. */
+  /* Colors — dark mode (default). Light overrides emit below. */
   --color-bg: #0b0c0e;
   --color-bg-elev: #15171a;
   --color-fg: #edeef0;
@@ -22,8 +22,7 @@
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
 
-  /* Typography (font-size only at this stage; richer typography
-   * is per-component and lands with primitives in #164). */
+  /* Typography (font-size only; richer typography lives in component primitives). */
   --text-body: 0.875rem;
   --text-heading: 1.25rem;
   --text-caption: 0.75rem;
@@ -45,11 +44,61 @@
   --spacing-2xl: 2rem;
 }
 
-/* DESIGN.md tokens above — hand-written CSS below. */
-
+/* Default color-scheme for native form controls / scrollbars. */
 :root {
   color-scheme: dark;
 }
+
+/* Light mode — applies when the OS prefers light. */
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --color-bg: #ffffff;
+    --color-bg-elev: #f5f6f8;
+    --color-fg: #0b0c0e;
+    --color-muted: #5b6573;
+    --color-border: #d8dde5;
+    --color-border-strong: #c0c6d0;
+    --color-accent: #1e6fb8;
+    --color-success: #15803d;
+    --color-warning: #a16207;
+    --color-danger: #b91c1c;
+    --color-focus-ring: #1e6fb8;
+  }
+}
+
+/* Manual overrides set by the toggle in TopNav. Wins over the media query. */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #0b0c0e;
+  --color-bg-elev: #15171a;
+  --color-fg: #edeef0;
+  --color-muted: #9aa0a8;
+  --color-border: #272a2d;
+  --color-border-strong: #363a3f;
+  --color-accent: #7dd3fc;
+  --color-success: #4ade80;
+  --color-warning: #facc15;
+  --color-danger: #f87171;
+  --color-focus-ring: #7dd3fc;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --color-bg: #ffffff;
+  --color-bg-elev: #f5f6f8;
+  --color-fg: #0b0c0e;
+  --color-muted: #5b6573;
+  --color-border: #d8dde5;
+  --color-border-strong: #c0c6d0;
+  --color-accent: #1e6fb8;
+  --color-success: #15803d;
+  --color-warning: #a16207;
+  --color-danger: #b91c1c;
+  --color-focus-ring: #1e6fb8;
+}
+
+/* DESIGN.md tokens above — hand-written CSS below. */
 
 html,
 body,

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Theme handling. Three states:
+ *   - `"dark"` / `"light"` — manual override; written to localStorage,
+ *     mirrored to `<html data-theme>`. Wins over the OS preference.
+ *   - `"system"` — clear the override; CSS falls back to
+ *     `@media (prefers-color-scheme: light)`.
+ *
+ * The CSS cascade is set up by `ui/scripts/render-tokens.mjs` —
+ * see `ui/src/index.css` after generation. This module only flips the
+ * attribute; all colour resolution happens in CSS.
+ *
+ * To avoid FOUC, the initial value is also written by an inline script
+ * in `ui/index.html` *before* React mounts.
+ */
+
+export type ThemeChoice = "dark" | "light" | "system";
+
+export const THEME_STORAGE_KEY = "aegis-theme";
+
+/** Read the persisted choice. Defaults to `"system"` if absent or invalid. */
+export function readStoredTheme(): ThemeChoice {
+  if (typeof window === "undefined") return "system";
+  try {
+    const v = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (v === "dark" || v === "light") return v;
+  } catch {
+    // localStorage may throw under privacy modes / sandboxed iframes —
+    // not a fatal condition; fall through to default.
+  }
+  return "system";
+}
+
+/** Apply a choice to <html> and localStorage. */
+export function applyTheme(choice: ThemeChoice): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (choice === "system") {
+    root.removeAttribute("data-theme");
+    try {
+      window.localStorage.removeItem(THEME_STORAGE_KEY);
+    } catch {
+      // ignore — see readStoredTheme
+    }
+  } else {
+    root.setAttribute("data-theme", choice);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, choice);
+    } catch {
+      // ignore — see readStoredTheme
+    }
+  }
+}
+
+/**
+ * Reactive hook returning the current choice + the effective mode.
+ *   - `choice` is what the user picked (or "system" by default).
+ *   - `effective` is the actual mode in use right now ("dark" or
+ *     "light") — useful for icons / aria-pressed.
+ *
+ * Listens to `prefers-color-scheme` so a system-level switch
+ * propagates without manual override.
+ */
+export function useTheme(): {
+  choice: ThemeChoice;
+  effective: "dark" | "light";
+  setChoice: (c: ThemeChoice) => void;
+  cycle: () => void;
+} {
+  const [choice, setChoiceState] = useState<ThemeChoice>(() =>
+    readStoredTheme(),
+  );
+  const [systemPrefersLight, setSystemPrefersLight] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-color-scheme: light)").matches;
+  });
+
+  useEffect(() => {
+    if (!window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-color-scheme: light)");
+    const onChange = (e: MediaQueryListEvent) =>
+      setSystemPrefersLight(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  const setChoice = (c: ThemeChoice) => {
+    applyTheme(c);
+    setChoiceState(c);
+  };
+
+  // 2-state cycle: dark ↔ light. Explicit "system" reset is not part
+  // of the chrome — users can clear localStorage to get it back. Keep
+  // the toggle simple; an explicit menu lands when we have more themes.
+  const cycle = () => {
+    const next: ThemeChoice =
+      choice === "light" ? "dark" : choice === "dark" ? "light" : systemPrefersLight ? "dark" : "light";
+    setChoice(next);
+  };
+
+  const effective: "dark" | "light" =
+    choice === "system" ? (systemPrefersLight ? "light" : "dark") : choice;
+
+  return { choice, effective, setChoice, cycle };
+}

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -66,7 +66,7 @@ export function Home() {
           )}
 
           {state.kind === "error" && (
-            <p className="font-mono text-sm text-red-400">
+            <p className="font-mono text-sm text-danger">
               error: {state.message}
             </p>
           )}

--- a/ui/src/pages/Manifest.tsx
+++ b/ui/src/pages/Manifest.tsx
@@ -297,7 +297,7 @@ function ValidateStatus({ state }: { state: ValidateState }) {
   if (state.kind === "error") {
     return (
       <span
-        className="inline-flex items-center gap-1 font-mono text-xs text-red-400"
+        className="inline-flex items-center gap-1 font-mono text-xs text-danger"
         title={state.message}
       >
         <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />
@@ -308,7 +308,7 @@ function ValidateStatus({ state }: { state: ValidateState }) {
   const { errors, warnings, infos } = state.summary;
   if (errors === 0 && warnings === 0 && infos === 0) {
     return (
-      <span className="inline-flex items-center font-mono text-xs text-emerald-400">
+      <span className="inline-flex items-center font-mono text-xs text-success">
         ✓ clean
       </span>
     );
@@ -316,19 +316,19 @@ function ValidateStatus({ state }: { state: ValidateState }) {
   return (
     <span className="inline-flex items-center gap-2 font-mono text-xs">
       {errors > 0 && (
-        <span className="inline-flex items-center gap-1 text-red-400">
+        <span className="inline-flex items-center gap-1 text-danger">
           <CircleAlert className="h-3.5 w-3.5" aria-hidden="true" />
           {errors} error{errors === 1 ? "" : "s"}
         </span>
       )}
       {warnings > 0 && (
-        <span className="inline-flex items-center gap-1 text-amber-300">
+        <span className="inline-flex items-center gap-1 text-warning">
           <TriangleAlert className="h-3.5 w-3.5" aria-hidden="true" />
           {warnings} warn{warnings === 1 ? "" : "s"}
         </span>
       )}
       {infos > 0 && (
-        <span className="inline-flex items-center gap-1 text-sky-300">
+        <span className="inline-flex items-center gap-1 text-accent">
           <Info className="h-3.5 w-3.5" aria-hidden="true" />
           {infos} info
         </span>
@@ -340,12 +340,12 @@ function ValidateStatus({ state }: { state: ValidateState }) {
 function ValidateFindings({ state }: { state: ValidateState }) {
   if (state.kind === "error") {
     return (
-      <div className="mt-4 rounded-md border border-amber-700 bg-amber-950/40 p-3 text-xs">
-        <p className="mb-1 font-semibold text-amber-200">
+      <div className="mt-4 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] p-3 text-xs">
+        <p className="mb-1 font-semibold text-warning">
           Live validate unavailable
         </p>
-        <p className="font-mono text-amber-200/70">{state.message}</p>
-        <p className="mt-2 text-amber-200/70">
+        <p className="font-mono text-[var(--color-fg)]">{state.message}</p>
+        <p className="mt-2 text-muted">
           Install via{" "}
           <code className="font-mono">make build-go-validate</code>, put{" "}
           <code className="font-mono">aegis-validate</code> on PATH, or set the{" "}
@@ -368,10 +368,10 @@ function ValidateFindings({ state }: { state: ValidateState }) {
             <span
               className={
                 f.severity === "error"
-                  ? "font-mono text-red-400"
+                  ? "font-mono text-danger"
                   : f.severity === "warn"
-                    ? "font-mono text-amber-300"
-                    : "font-mono text-sky-300"
+                    ? "font-mono text-warning"
+                    : "font-mono text-accent"
               }
             >
               {f.severity}

--- a/ui/src/pages/Models.tsx
+++ b/ui/src/pages/Models.tsx
@@ -76,7 +76,7 @@ export function Models() {
       )}
 
       {error && (
-        <p className="font-mono text-sm text-red-400">
+        <p className="font-mono text-sm text-danger">
           error: {error instanceof Error ? error.message : String(error)}
         </p>
       )}
@@ -181,7 +181,7 @@ function CosignBadge({ cosign }: { cosign: ModelCosign }) {
       : `verified · key ${cosign.key_path ?? "*"}`;
   return (
     <span
-      className="inline-flex items-center gap-1 rounded bg-emerald-950/40 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300"
+      className="inline-flex items-center gap-1 rounded border border-[var(--color-border)] bg-[var(--color-bg-elev)] px-1.5 py-0.5 font-mono text-[10px] text-success"
       title={tooltip}
     >
       <ShieldCheck className="h-3 w-3" aria-hidden="true" />
@@ -194,7 +194,7 @@ function CosignDetails({ cosign }: { cosign: ModelCosign }) {
   if (cosign.mode === "key") {
     return (
       <span>
-        <span className="text-emerald-300">✓ keyed</span> ·{" "}
+        <span className="text-success">✓ keyed</span> ·{" "}
         <span className="text-muted">key:</span>{" "}
         {cosign.key_path ?? "(unknown)"}
       </span>
@@ -202,7 +202,7 @@ function CosignDetails({ cosign }: { cosign: ModelCosign }) {
   }
   return (
     <span>
-      <span className="text-emerald-300">✓ keyless</span>
+      <span className="text-success">✓ keyless</span>
       {cosign.keyless_identity_pattern && (
         <>
           {" "}


### PR DESCRIPTION
Closes #165 and the parent #161 design-system adoption tracker.

**Stacked on #178** (the modernization PR). Base branch is `design/164b-modernize-tokens` so the diff shows only the light-theme + a11y work. When #178 merges, this PR auto-rebases to `main`.

## Headline changes

| Area | Change |
|---|---|
| Light theme | Generator emits dark + light from a single source; OS-level + manual override both supported. |
| Theme toggle | Sun/moon button in TopNav, localStorage-persisted, FOUC-free via pre-mount inline script in `index.html`. |
| Semantic-colour migration | All legacy `text-red-400` / `text-amber-300` / `text-emerald-300` etc. swapped to `text-danger` / `text-warning` / `text-success` — both modes hit AA. |
| WCAG AA audit | Playwright + `@axe-core/playwright`, 4 surfaces × 2 themes = 8 audits, runs in CI, fails on serious/critical violations or contrast findings. |
| Monaco exclusion | `.monaco-editor` excluded from axe scans — Monaco ships its own theme tokens, fixing them is upstream's job. |

## Light theme — how it works

The generator (`ui/scripts/render-tokens.mjs`) now emits three layers, in cascade order:

1. **`@theme { ... }`** — dark tokens (the default; matches Aegis's identifier-dense positioning per ADR-031).
2. **`@media (prefers-color-scheme: light) :root { ... }`** — light overrides + `color-scheme: light` so native controls flip too. Wins when the OS prefers light.
3. **`:root[data-theme=\"dark\"|\"light\"]`** — manual overrides written by the toggle. Wins over the media query (higher specificity).

The toggle (`ui/src/lib/theme.ts` + `ui/src/components/TopNav.tsx`) writes `aegis-theme` to localStorage and sets `<html data-theme>`. A small inline script in `ui/index.html` reads the same key *before* React mounts — first paint is always the correct theme.

## Semantic-colour migration (load-bearing for the audit)

The Chat surface was already restyled in #178 to use semantic tokens. Three other surfaces still used legacy Tailwind colours that don't translate to light mode — they pass on dark accidentally but fail on light:

| Before | After | Surfaces |
|---|---|---|
| `text-red-400` / `bg-red-950/40` | `text-danger` | Home, Manifest, Models, ModelPicker |
| `text-amber-300` / `text-amber-200(/70)` | `text-warning` | Manifest |
| `text-emerald-300` / `text-emerald-400` | `text-success` | Manifest, Models, ModelPicker |
| `text-sky-300` | `text-accent` | Manifest |

Visually no regression in dark mode (the tokens resolve to similar shades) and clean AA in light mode (`text-danger` is `#b91c1c`, etc).

## axe-core audit

Tags: `wcag2a wcag2aa wcag21a wcag21aa`. Fails on `serious` / `critical` impact or any `color-contrast` finding. Monaco editor scope explicitly excluded — its `#608b4e` syntax-highlight green hits 4.2:1 on its `#1e1e1e` background, which is Monaco's choice, not ours.

```
8 passed (10.7s)
```

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean (14s)
- [x] `pnpm design:tokens` idempotent
- [x] `pnpm test:a11y` — **8/8 passing** locally
- [ ] CI: `.github/workflows/a11y.yml` green on this PR
- [ ] Manual smoke (reviewer): click the sun/moon toggle in TopNav; observe colours flip immediately; reload the page; theme persists; clear localStorage; theme returns to OS preference

## Out of scope (per the issue)

- Further design iteration (visual weight, additional surfaces) — separate follow-up.
- Backend-dependent surfaces (Models list, Chat with messages) — the audit covers their loading / error states. Once the backend is running the loaded-data states should still pass since they use the same semantic tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)