### PR TITLE
feat(inference-engine, cli): multi-turn loop + Triple-Bound Circuit Breaker (#181)

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -125,6 +125,27 @@ pub struct RunArgs {
     /// be `0.0` (`omitted` is also fine — defaults to `0.0`).
     #[arg(long, value_enum, default_value_t = BackendKind::default())]
     pub backend: BackendKind,
+
+    /// Triple-Bound Circuit Breaker (ADR-025) — hard cap on the
+    /// number of model invocations in `--prompt` mode. Whichever of
+    /// `--max-turns`, `--max-tokens`, `--max-seconds` trips first
+    /// halts the loop with a structured `TurnCapExceeded` error.
+    #[arg(long, default_value_t = 10)]
+    pub max_turns: u32,
+
+    /// Cumulative token budget across all turns. Backends that don't
+    /// yet report usage (today: llama + litertlm both) contribute
+    /// zero to this counter, so the cap won't trip on them; a follow-
+    /// up wires per-backend usage reporting. ADR-025 default is
+    /// per-backend; the CLI default `u64::MAX` defers to that path.
+    #[arg(long, default_value_t = u64::MAX)]
+    pub max_tokens: u64,
+
+    /// Wallclock budget in seconds, from the moment the loop starts.
+    /// Five minutes covers tool-heavy turns on commodity CPU
+    /// (per ADR-025 §"Defaults rationale").
+    #[arg(long, default_value_t = 300)]
+    pub max_seconds: u64,
 }
 
 /// Result of an `aegis run` invocation. Used by tests to assert
@@ -292,7 +313,7 @@ fn run_prompt(
     args: &RunArgs,
     prompt: &str,
 ) -> Result<(bool, Option<String>)> {
-    use aegis_inference_engine::ToolCallResult;
+    use aegis_inference_engine::{ToolCallResult, TurnLimits};
 
     let loaded = match args.backend {
         BackendKind::Llama => load_llama_backend(session, &args.model)?,
@@ -304,30 +325,70 @@ fn run_prompt(
     // `Session::with_loaded_model`.
     session.set_loaded_model(loaded);
 
-    let outcome = session.run_turn(prompt).context("run_turn")?;
+    let limits = TurnLimits {
+        max_turns: args.max_turns,
+        max_tokens: args.max_tokens,
+        max_seconds: args.max_seconds,
+    };
 
-    // Print the outcome for the user (and for the demo .tape recorder
-    // — these lines are what the GIF shows).
-    if let Some(text) = &outcome.assistant_text {
-        println!("# assistant");
-        println!("{text}");
-    }
-    for (i, call) in outcome.tool_calls.iter().enumerate() {
-        match &call.result {
-            ToolCallResult::Success(value) => {
-                println!("# tool[{i}] {} → success", call.name);
-                let pretty =
-                    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
-                println!("{pretty}");
-            }
-            ToolCallResult::Denied(reason) => {
-                println!("# tool[{i}] {} → DENIED: {reason}", call.name);
-            }
-            ToolCallResult::RequiresApproval(reason) => {
-                println!("# tool[{i}] {} → REQUIRES_APPROVAL: {reason}", call.name);
-            }
-            ToolCallResult::Unroutable(reason) => {
-                println!("# tool[{i}] {} → UNROUTABLE: {reason}", call.name);
+    // Drive the multi-turn loop (ADR-025). Cap-trips surface as a
+    // typed `TurnCapExceeded` error which we catch here and translate
+    // into the structured stderr block ADR-025 §3 specifies, then
+    // signal the outer caller via `halted=true` so the exit code is
+    // non-zero. The partial F9 ledger is already on disk — the
+    // `write_turn_cap_violation` hook fired before this point.
+    let result = match session.run(prompt, limits) {
+        Ok(r) => r,
+        Err(aegis_inference_engine::Error::TurnCapExceeded {
+            bound,
+            at_turn,
+            max_turns,
+            tokens_consumed,
+            max_tokens,
+            wallclock_seconds,
+            max_seconds,
+        }) => {
+            eprintln!("Error: TurnCapExceeded");
+            eprintln!("- bound: {bound} ({at_turn}/{max_turns})");
+            eprintln!("- turns_executed: {at_turn}");
+            eprintln!("- tokens_consumed: {tokens_consumed}/{max_tokens}");
+            eprintln!("- wallclock_seconds: {wallclock_seconds:.1}/{max_seconds}");
+            return Ok((true, Some(format!("turn cap exceeded ({bound})"))));
+        }
+        Err(other) => {
+            return Err(anyhow::Error::from(other)).context("session.run");
+        }
+    };
+
+    // Print every turn's outcome for the user (and for the demo .tape
+    // recorder — these lines are what the GIF shows). Per-turn headers
+    // make it legible when the loop went more than once.
+    let multi = result.turns.len() > 1;
+    for (turn_idx, outcome) in result.turns.iter().enumerate() {
+        if multi {
+            println!("# turn {}", turn_idx + 1);
+        }
+        if let Some(text) = &outcome.assistant_text {
+            println!("# assistant");
+            println!("{text}");
+        }
+        for (i, call) in outcome.tool_calls.iter().enumerate() {
+            match &call.result {
+                ToolCallResult::Success(value) => {
+                    println!("# tool[{i}] {} → success", call.name);
+                    let pretty =
+                        serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+                    println!("{pretty}");
+                }
+                ToolCallResult::Denied(reason) => {
+                    println!("# tool[{i}] {} → DENIED: {reason}", call.name);
+                }
+                ToolCallResult::RequiresApproval(reason) => {
+                    println!("# tool[{i}] {} → REQUIRES_APPROVAL: {reason}", call.name);
+                }
+                ToolCallResult::Unroutable(reason) => {
+                    println!("# tool[{i}] {} → UNROUTABLE: {reason}", call.name);
+                }
             }
         }
     }

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -44,6 +44,9 @@ fn args_for(
         script: Some(script),
         prompt: None,
         backend: aegis_cli::run::BackendKind::Llama,
+        max_turns: 10,
+        max_tokens: u64::MAX,
+        max_seconds: 300,
     }
 }
 
@@ -292,6 +295,9 @@ tools: {}
         script: Some(work.path().join("does-not-exist.json")),
         prompt: None,
         backend: aegis_cli::run::BackendKind::Llama,
+        max_turns: 10,
+        max_tokens: u64::MAX,
+        max_seconds: 300,
     };
     let err = execute(args).unwrap_err();
     let msg = format!("{err}");
@@ -333,6 +339,9 @@ tools: {}
         script: None,
         prompt: None,
         backend: aegis_cli::run::BackendKind::Llama,
+        max_turns: 10,
+        max_tokens: u64::MAX,
+        max_seconds: 300,
     };
     let err = execute(args).unwrap_err();
     let msg = format!("{err}");
@@ -377,6 +386,9 @@ tools: {}
         script: None,
         prompt: Some("hello".to_string()),
         backend: aegis_cli::run::BackendKind::Llama,
+        max_turns: 10,
+        max_tokens: u64::MAX,
+        max_seconds: 300,
     };
     let err = execute(args).unwrap_err();
     let msg = format!("{err:#}");
@@ -419,6 +431,9 @@ tools: {}
         script: None,
         prompt: Some("hello".to_string()),
         backend: aegis_cli::run::BackendKind::Litertlm,
+        max_turns: 10,
+        max_tokens: u64::MAX,
+        max_seconds: 300,
     };
     let err = execute(args).unwrap_err();
     let msg = format!("{err:#}");

--- a/crates/cli/tests/runtime.rs
+++ b/crates/cli/tests/runtime.rs
@@ -116,6 +116,9 @@ fn runtime_conformance_golden() {
         script: Some(script_path),
         prompt: None,
         backend: aegis_cli::run::BackendKind::Llama,
+        max_turns: 10,
+        max_tokens: u64::MAX,
+        max_seconds: 300,
     };
 
     let outcome = execute(args).expect("aegis run");

--- a/crates/inference-engine/src/backend.rs
+++ b/crates/inference-engine/src/backend.rs
@@ -119,7 +119,7 @@ pub struct InferRequest {
 }
 
 /// Outputs of one inference turn.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct InferResponse {
     /// The model's free-text reasoning (everything outside any
     /// `<tool_call>` blocks, with leading/trailing whitespace
@@ -132,6 +132,15 @@ pub struct InferResponse {
     /// Optional terminal assistant message — set when the model
     /// produced text intended for the user (vs. only tool calls).
     pub assistant_text: Option<String>,
+    /// Tokens consumed by this single inference call (prompt + output).
+    /// Used by the multi-turn driver's Triple-Bound Circuit Breaker
+    /// (per ADR-025) to accumulate against `TurnLimits::max_tokens`.
+    /// `None` means "backend didn't report usage" — the driver treats
+    /// this as zero for accumulation, which means the token bound
+    /// won't trip on backends that don't yet wire up usage reporting.
+    /// New backends should populate this; existing backends keep
+    /// working unchanged.
+    pub tokens_used: Option<u64>,
 }
 
 /// Trait for anything that can load a model from disk and return a

--- a/crates/inference-engine/src/error.rs
+++ b/crates/inference-engine/src/error.rs
@@ -86,4 +86,31 @@ pub enum Error {
 
     #[error("requires approval: {reason}")]
     RequireApproval { reason: String },
+
+    /// The multi-turn driver hit one of its three bounds: turn count,
+    /// cumulative token budget, or wallclock. Per ADR-025 §"Triple-Bound
+    /// Circuit Breaker". Capped termination is *not* an exception in the
+    /// runtime's value system — it's a structured halt with a partial
+    /// F9 ledger left on disk for forensics. The CLI maps this to a
+    /// non-zero exit with a parseable stderr block (per ADR-025 §3).
+    #[error(
+        "turn cap exceeded ({bound:?}): turn {at_turn} of max {max_turns}, \
+         tokens {tokens_consumed}/{max_tokens}, wallclock {wallclock_seconds:.1}s/{max_seconds}s"
+    )]
+    TurnCapExceeded {
+        /// Which of the three bounds tripped.
+        bound: crate::turn::TurnCapKind,
+        /// 1-based turn index at which the cap tripped.
+        at_turn: u32,
+        /// Configured `max_turns` for this session.
+        max_turns: u32,
+        /// Cumulative tokens consumed across completed turns.
+        tokens_consumed: u64,
+        /// Configured `max_tokens` for this session.
+        max_tokens: u64,
+        /// Wallclock elapsed from the start of the run.
+        wallclock_seconds: f64,
+        /// Configured `max_seconds` for this session.
+        max_seconds: u64,
+    },
 }

--- a/crates/inference-engine/src/lib.rs
+++ b/crates/inference-engine/src/lib.rs
@@ -23,4 +23,7 @@ pub use backend::{
 };
 pub use error::{Error, Result};
 pub use session::{BootConfig, NetworkConnectionDecision, NetworkConnectionMeta, Session};
-pub use turn::{ToolCallOutcome, ToolCallResult, TurnOutcome};
+pub use turn::{
+    SessionRunResult, SessionTermination, ToolCallOutcome, ToolCallResult, TurnCapKind, TurnLimits,
+    TurnOutcome,
+};

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -314,6 +314,64 @@ impl Session {
         &self.policy
     }
 
+    /// Append a `TurnCapExceeded` Violation to the F9 ledger.
+    /// Called by the multi-turn driver ([`Self::run`]) when the
+    /// Triple-Bound Circuit Breaker trips (per ADR-025). The
+    /// payload shape is namespaced under
+    /// `violationKind: "TurnCapExceeded"` so existing v1 ledger
+    /// readers can ignore it while ADR-026's schema v2 work can
+    /// upgrade it to a first-class entry kind.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn write_turn_cap_violation(
+        &mut self,
+        bound: crate::turn::TurnCapKind,
+        at_turn: u32,
+        max_turns: u32,
+        tokens_consumed: u64,
+        max_tokens: u64,
+        wallclock_seconds: f64,
+        max_seconds: u64,
+    ) -> Result<()> {
+        let mut payload = Map::new();
+        payload.insert(
+            "violationKind".to_string(),
+            Value::String("TurnCapExceeded".to_string()),
+        );
+        payload.insert(
+            "violationReason".to_string(),
+            Value::String(format!(
+                "turn cap exceeded: bound={bound:?}, turn {at_turn}/{max_turns}, \
+                 tokens {tokens_consumed}/{max_tokens}, \
+                 wallclock {wallclock_seconds:.1}s/{max_seconds}s"
+            )),
+        );
+        payload.insert(
+            "capBound".to_string(),
+            Value::String(format!("{bound:?}").to_lowercase()),
+        );
+        payload.insert("atTurn".to_string(), Value::Number(at_turn.into()));
+        payload.insert("maxTurns".to_string(), Value::Number(max_turns.into()));
+        payload.insert(
+            "tokensConsumed".to_string(),
+            Value::Number(tokens_consumed.into()),
+        );
+        payload.insert("maxTokens".to_string(), Value::Number(max_tokens.into()));
+        // f64 — Number::from_f64 can fail on NaN/inf which we never produce.
+        if let Some(n) = serde_json::Number::from_f64(wallclock_seconds) {
+            payload.insert("wallclockSeconds".to_string(), Value::Number(n));
+        }
+        payload.insert("maxSeconds".to_string(), Value::Number(max_seconds.into()));
+
+        self.ledger.append(Entry {
+            session_id: self.session_id.clone(),
+            entry_type: EntryType::Violation,
+            agent_identity_hash: self.agent_identity_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
+    }
+
     pub fn spiffe_id(&self) -> &SpiffeId {
         &self.spiffe_id
     }

--- a/crates/inference-engine/src/turn.rs
+++ b/crates/inference-engine/src/turn.rs
@@ -33,9 +33,11 @@
 //! native namespaces is rejected at [`Session::boot`] with
 //! [`Error::ReservedMcpServerName`] — the conflict is loud, not silent.
 
+use std::fmt;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
-use crate::backend::{InferRequest, ToolCall, ToolDecl};
+use crate::backend::{ChatMessage, ChatRole, InferRequest, ToolCall, ToolDecl};
 use crate::error::{Error, Result};
 use crate::session::Session;
 
@@ -43,6 +45,89 @@ use crate::session::Session;
 /// `server_name` matches any of these collides with native dispatch
 /// and is refused at boot.
 pub const RESERVED_NATIVE_NAMESPACES: &[&str] = &["filesystem", "network", "exec"];
+
+/// Triple-Bound Circuit Breaker config for [`Session::run`] (ADR-025).
+///
+/// Each bound is independent — whichever trips first halts the loop
+/// and writes a `TurnCapExceeded` Violation to the F9 ledger before
+/// the driver returns [`Error::TurnCapExceeded`].
+#[derive(Debug, Clone, Copy)]
+pub struct TurnLimits {
+    /// Hard cap on model invocations per session. ADR-025 default: 10.
+    pub max_turns: u32,
+    /// Cumulative token budget across all turns. Backends that don't
+    /// report usage ([`crate::InferResponse::tokens_used`] == None)
+    /// contribute 0 to the accumulator, so this bound only trips on
+    /// backends with wired usage reporting. ADR-025 default: per-backend.
+    /// The library default of `u64::MAX` is "effectively unbounded" —
+    /// callers (the CLI) set it explicitly.
+    pub max_tokens: u64,
+    /// Wallclock budget from [`Session::run`] entry. ADR-025 default: 300s.
+    pub max_seconds: u64,
+}
+
+impl Default for TurnLimits {
+    fn default() -> Self {
+        Self {
+            max_turns: 10,
+            max_tokens: u64::MAX,
+            max_seconds: 300,
+        }
+    }
+}
+
+/// Which bound of the Triple-Bound Circuit Breaker tripped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCapKind {
+    /// `max_turns` exceeded.
+    Turns,
+    /// `max_tokens` exceeded.
+    Tokens,
+    /// `max_seconds` (wallclock) exceeded.
+    Wallclock,
+}
+
+impl fmt::Display for TurnCapKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            TurnCapKind::Turns => "turns",
+            TurnCapKind::Tokens => "tokens",
+            TurnCapKind::Wallclock => "wallclock",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Why [`Session::run`] stopped. Capped termination surfaces as
+/// [`Error::TurnCapExceeded`] on the [`Result`]; [`Session::run`]
+/// only returns this variant on clean termination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionTermination {
+    /// The most recent turn emitted no tool calls. The assistant text
+    /// from that turn is the final response. ADR-025 §"Loop shape"
+    /// case "tool_call list is empty".
+    Done,
+}
+
+/// Aggregate outcome of [`Session::run`]: per-turn captures + the
+/// reason the loop halted + cumulative usage counters.
+#[derive(Debug, Clone)]
+pub struct SessionRunResult {
+    /// Per-turn outcomes in chronological order. Includes the
+    /// final turn (the one whose empty tool-call list triggered
+    /// the clean termination).
+    pub turns: Vec<TurnOutcome>,
+    /// Why the loop ended. On clean termination this is
+    /// [`SessionTermination::Done`]. Capped termination doesn't
+    /// reach this struct — see [`Error::TurnCapExceeded`].
+    pub termination: SessionTermination,
+    /// Sum of [`crate::InferResponse::tokens_used`] across all
+    /// completed turns (treating `None` as zero).
+    pub tokens_consumed: u64,
+    /// Wallclock from the start of [`Session::run`] to the
+    /// turn that produced the final assistant text.
+    pub wallclock: Duration,
+}
 
 /// Outcome of one [`Session::run_turn`] call. Captures every
 /// observable side-effect the caller might want to act on (logs,
@@ -120,11 +205,152 @@ impl Session {
     ///   short-circuiting the turn — the agent saw the refusal, the
     ///   ledger has the Violation, the next turn can adapt.
     pub fn run_turn(&mut self, user_message: &str) -> Result<TurnOutcome> {
-        let tools = self.tool_catalog();
-        let messages = vec![crate::backend::ChatMessage {
-            role: crate::backend::ChatRole::User,
+        let messages = vec![ChatMessage {
+            role: ChatRole::User,
             content: user_message.to_string(),
         }];
+        let (outcome, _tokens) = self.run_one_turn(&messages, user_message)?;
+        Ok(outcome)
+    }
+
+    /// Drive a session through up to `limits.max_turns` LLM-B
+    /// invocations, accumulating tool results into the context window
+    /// for the next turn, until the model emits a turn with no tool
+    /// calls (clean termination) or one of the Triple-Bound Circuit
+    /// Breaker bounds trips (capped termination).
+    ///
+    /// Implements [ADR-025](../../docs/adrs/025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md).
+    ///
+    /// **Clean termination** returns `Ok(SessionRunResult)` with every
+    /// turn's outcome in order.
+    ///
+    /// **Capped termination** writes a `TurnCapExceeded` Violation entry
+    /// to the F9 ledger and returns [`Error::TurnCapExceeded`]. The
+    /// ledger left on disk contains every fully-completed turn before
+    /// the cap fired — the "partial F9 ledger" promise from ADR-025 §3.
+    /// Callers parse the ledger (via `aegis verify` or directly) to
+    /// reconstruct what happened before the halt.
+    ///
+    /// ## Message-history caveat
+    ///
+    /// Between turns the driver accumulates:
+    /// - the original user message,
+    /// - one [`ChatRole::Assistant`] message per turn carrying the
+    ///   model's reasoning + assistant text,
+    /// - one [`ChatRole::Tool`] message per dispatched call carrying a
+    ///   JSON-shaped `{"tool": name, "args": ..., "result": ...}` body.
+    ///
+    /// The exact serialization is chat-template-dependent — Gemma 4 and
+    /// other production backends benefit from richer tool-call /
+    /// tool-result markers than `ChatMessage` exposes today. Lifting
+    /// the message shape (per-message `tool_call_id`, `tool_name`) is
+    /// tracked under ADR-026 + #182.
+    pub fn run(&mut self, prompt: &str, limits: TurnLimits) -> Result<SessionRunResult> {
+        let started = Instant::now();
+        let mut messages = vec![ChatMessage {
+            role: ChatRole::User,
+            content: prompt.to_string(),
+        }];
+        let mut turns: Vec<TurnOutcome> = Vec::with_capacity(limits.max_turns as usize);
+        let mut tokens_consumed: u64 = 0;
+
+        // The driver runs as a for-loop with explicit cap checks at
+        // the top so the bounds are visible without grep'ing for
+        // mid-loop branches. ADR-025 §"Loop shape" is the spec.
+        for turn_index in 1..=limits.max_turns {
+            // Wallclock cap is checked before invoking the backend so
+            // a hung tool from the previous turn can't push the model
+            // over the bound; ditto a slow backend prompt-eval.
+            let elapsed = started.elapsed();
+            if elapsed.as_secs() >= limits.max_seconds {
+                return Err(self.emit_cap_and_build_err(
+                    TurnCapKind::Wallclock,
+                    turn_index,
+                    &limits,
+                    tokens_consumed,
+                    elapsed.as_secs_f64(),
+                )?);
+            }
+            // Token cap on cumulative — `tokens_used` per turn is
+            // optional ([`InferResponse::tokens_used`]). Backends that
+            // don't report contribute 0; bound never trips on them.
+            if tokens_consumed >= limits.max_tokens {
+                return Err(self.emit_cap_and_build_err(
+                    TurnCapKind::Tokens,
+                    turn_index,
+                    &limits,
+                    tokens_consumed,
+                    elapsed.as_secs_f64(),
+                )?);
+            }
+
+            let (outcome, used) = self.run_one_turn(&messages, prompt)?;
+            tokens_consumed = tokens_consumed.saturating_add(used.unwrap_or(0));
+            let no_tool_calls = outcome.tool_calls.is_empty();
+
+            // Accumulate assistant + tool messages for the next turn.
+            // The Assistant message carries the model's reasoning AND
+            // the final assistant text (when present); we deliberately
+            // omit a separate per-turn tool-call structured block — the
+            // backend already parsed `tool_calls` and the tool-result
+            // messages below carry the names back.
+            let assistant_content = match &outcome.assistant_text {
+                Some(text) => text.clone(),
+                None => String::new(),
+            };
+            if !assistant_content.is_empty() {
+                messages.push(ChatMessage {
+                    role: ChatRole::Assistant,
+                    content: assistant_content,
+                });
+            }
+            for tc in &outcome.tool_calls {
+                let body = serde_json::json!({
+                    "tool": tc.name,
+                    "args": tc.arguments,
+                    "result": tool_call_result_to_value(&tc.result),
+                });
+                messages.push(ChatMessage {
+                    role: ChatRole::Tool,
+                    content: body.to_string(),
+                });
+            }
+            turns.push(outcome);
+
+            if no_tool_calls {
+                // Clean termination: the model produced text and no
+                // tool calls — the task is its own answer.
+                return Ok(SessionRunResult {
+                    turns,
+                    termination: SessionTermination::Done,
+                    tokens_consumed,
+                    wallclock: started.elapsed(),
+                });
+            }
+        }
+
+        // Fell out of the loop without returning — `max_turns` exhausted.
+        let elapsed = started.elapsed();
+        Err(self.emit_cap_and_build_err(
+            TurnCapKind::Turns,
+            limits.max_turns,
+            &limits,
+            tokens_consumed,
+            elapsed.as_secs_f64(),
+        )?)
+    }
+
+    /// Shared per-turn dispatch used by both [`Self::run_turn`] (legacy
+    /// single-turn) and [`Self::run`] (multi-turn). Takes the full
+    /// `messages` history so the multi-turn driver can accumulate
+    /// across turns. Returns the outcome plus the backend-reported
+    /// `tokens_used` (when available).
+    fn run_one_turn(
+        &mut self,
+        messages: &[ChatMessage],
+        original_prompt: &str,
+    ) -> Result<(TurnOutcome, Option<u64>)> {
+        let tools = self.tool_catalog();
 
         let response = {
             let model = self
@@ -132,36 +358,69 @@ impl Session {
                 .as_mut()
                 .ok_or(Error::NoBackendConfigured)?;
             model.infer(InferRequest {
-                messages,
+                messages: messages.to_vec(),
                 tools: tools.clone(),
             })?
         };
 
-        // Emit one F5 reasoning step capturing the model's stated
-        // chain — input + reasoning + tools considered + selected.
         let tools_considered: Vec<String> = tools.iter().map(|t| t.name.clone()).collect();
         let tool_selected = response.tool_calls.first().map(|c| c.name.clone());
         let step_uuid = self.record_reasoning_step(
-            user_message,
+            original_prompt,
             &response.reasoning,
             tools_considered,
             tool_selected,
         )?;
         let step_id = step_uuid.to_string();
 
-        // Dispatch each tool call. We capture per-call outcomes rather
-        // than short-circuit the loop on Denied/RequireApproval —
-        // those are normal runtime conditions, not turn-fatal errors.
         let mut outcomes = Vec::with_capacity(response.tool_calls.len());
         for call in response.tool_calls {
             let outcome = self.dispatch_tool_call(call, Some(&step_id))?;
             outcomes.push(outcome);
         }
 
-        Ok(TurnOutcome {
-            assistant_text: response.assistant_text,
-            tool_calls: outcomes,
-            reasoning_step_id: step_id,
+        let assistant_text = response.assistant_text;
+        let tokens_used = response.tokens_used;
+        Ok((
+            TurnOutcome {
+                assistant_text,
+                tool_calls: outcomes,
+                reasoning_step_id: step_id,
+            },
+            tokens_used,
+        ))
+    }
+
+    /// Write the `TurnCapExceeded` Violation entry to the ledger and
+    /// build the structured [`Error::TurnCapExceeded`] the driver
+    /// returns. Either the entry-write or the error build can fail —
+    /// both surface to the caller, which is correct: a failed ledger
+    /// write is itself a load-bearing failure on the security-review path.
+    fn emit_cap_and_build_err(
+        &mut self,
+        bound: TurnCapKind,
+        at_turn: u32,
+        limits: &TurnLimits,
+        tokens_consumed: u64,
+        wallclock_seconds: f64,
+    ) -> Result<Error> {
+        self.write_turn_cap_violation(
+            bound,
+            at_turn,
+            limits.max_turns,
+            tokens_consumed,
+            limits.max_tokens,
+            wallclock_seconds,
+            limits.max_seconds,
+        )?;
+        Ok(Error::TurnCapExceeded {
+            bound,
+            at_turn,
+            max_turns: limits.max_turns,
+            tokens_consumed,
+            max_tokens: limits.max_tokens,
+            wallclock_seconds,
+            max_seconds: limits.max_seconds,
         })
     }
 
@@ -432,6 +691,23 @@ impl Session {
             other => Err(Error::UnroutableToolCall {
                 name: format!("exec__{other}"),
             }),
+        }
+    }
+}
+
+/// Serialise a [`ToolCallResult`] into JSON suitable for inclusion in
+/// a [`ChatRole::Tool`] history message. Each variant becomes a
+/// discriminated object — the model sees the structure and the verdict
+/// without needing to parse free text.
+fn tool_call_result_to_value(result: &ToolCallResult) -> serde_json::Value {
+    match result {
+        ToolCallResult::Success(v) => serde_json::json!({"status": "success", "value": v}),
+        ToolCallResult::Denied(r) => serde_json::json!({"status": "denied", "reason": r}),
+        ToolCallResult::RequiresApproval(r) => {
+            serde_json::json!({"status": "requires_approval", "reason": r})
+        }
+        ToolCallResult::Unroutable(r) => {
+            serde_json::json!({"status": "unroutable", "reason": r})
         }
     }
 }

--- a/crates/inference-engine/tests/run_multi_turn.rs
+++ b/crates/inference-engine/tests/run_multi_turn.rs
@@ -1,0 +1,336 @@
+//! Integration tests for the multi-turn driver `Session::run`
+//! (ADR-025, issue #181). Validates the Triple-Bound Circuit Breaker —
+//! one test per bound plus clean-termination + context-accumulation
+//! checks.
+//!
+//! Reuses the existing [`MockLoadedModel`] pattern from `run_turn.rs`
+//! (canned responses, captured requests). Kept in its own file so the
+//! single-turn surface in `run_turn.rs` stays focused on F5 emission
+//! + dispatch invariants.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use aegis_identity::LocalCa;
+use aegis_inference_engine::{
+    BackendError, BootConfig, Error, InferRequest, InferResponse, LoadedModel, Session,
+    SessionTermination, ToolCall, TurnCapKind, TurnLimits,
+};
+
+const TRUST_DOMAIN: &str = "multi-turn-test.local";
+
+struct MockLoadedModel {
+    queue: Arc<Mutex<Vec<Result<InferResponse, BackendError>>>>,
+    captured: Arc<Mutex<Vec<InferRequest>>>,
+}
+
+impl MockLoadedModel {
+    fn new(responses: Vec<InferResponse>) -> (Self, MockHandle) {
+        let queue = Arc::new(Mutex::new(
+            responses.into_iter().map(Ok).collect::<Vec<_>>(),
+        ));
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let handle = MockHandle {
+            captured: captured.clone(),
+        };
+        (Self { queue, captured }, handle)
+    }
+}
+
+impl LoadedModel for MockLoadedModel {
+    fn infer(&mut self, request: InferRequest) -> Result<InferResponse, BackendError> {
+        self.captured.lock().unwrap().push(request);
+        let mut q = self.queue.lock().unwrap();
+        q.remove(0)
+    }
+}
+
+struct MockHandle {
+    captured: Arc<Mutex<Vec<InferRequest>>>,
+}
+
+impl MockHandle {
+    fn captured(&self) -> Vec<InferRequest> {
+        self.captured.lock().unwrap().clone()
+    }
+}
+
+fn write_manifest_with_read_grant(path: &Path) {
+    // Read-only manifest. The multi-turn tests only need a path that
+    // the dispatcher will accept for `filesystem__read`; no writes,
+    // no grants. The temp-dir base path is allowed under
+    // `tools.filesystem.read` (prefix-matched by the policy engine).
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "multi-turn-test", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://multi-turn-test.local/agent/loop/inst-001" }}
+tools:
+  filesystem:
+    read: ["{}"]
+"#,
+        path.parent().unwrap().display()
+    );
+    std::fs::write(path, yaml).unwrap();
+}
+
+fn boot_session(dir: &Path, ca_dir: &Path) -> Session {
+    LocalCa::init(ca_dir, TRUST_DOMAIN).unwrap();
+
+    let manifest_path = dir.join("manifest.yaml");
+    let model_path = dir.join("model.gguf");
+    let ledger_path = dir.join("ledger.jsonl");
+    write_manifest_with_read_grant(&manifest_path);
+    std::fs::write(&model_path, b"fake-model-bytes").unwrap();
+
+    let cfg = BootConfig {
+        session_id: "session-multi-turn".to_string(),
+        manifest_path,
+        model_path,
+        config_path: None,
+        chat_template_sidecar: None,
+        identity_dir: ca_dir.to_path_buf(),
+        workload_name: "loop".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path,
+    };
+    Session::boot(cfg).unwrap()
+}
+
+fn final_text_response(text: &str) -> InferResponse {
+    InferResponse {
+        reasoning: text.to_string(),
+        tool_calls: vec![],
+        assistant_text: Some(text.to_string()),
+        tokens_used: None,
+    }
+}
+
+fn read_call_response(path: &str) -> InferResponse {
+    InferResponse {
+        reasoning: format!("reading {path}"),
+        tool_calls: vec![ToolCall {
+            name: "filesystem__read".to_string(),
+            arguments: serde_json::json!({"path": path}),
+        }],
+        assistant_text: None,
+        tokens_used: None,
+    }
+}
+
+#[test]
+fn run_clean_termination_returns_after_first_turn_with_no_tool_calls() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    let (mock, _handle) = MockLoadedModel::new(vec![final_text_response("hi back")]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+
+    let result = session
+        .run("hello", TurnLimits::default())
+        .expect("clean termination");
+
+    assert_eq!(result.turns.len(), 1, "one turn, no tools → done");
+    assert_eq!(result.termination, SessionTermination::Done);
+    assert_eq!(result.turns[0].assistant_text.as_deref(), Some("hi back"));
+    assert!(result.turns[0].tool_calls.is_empty());
+}
+
+#[test]
+fn run_max_turns_exceeded_writes_violation_and_returns_err() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    // Pre-create the target file so the dispatcher's read succeeds.
+    let target = dir.path().join("file.txt");
+    std::fs::write(&target, b"contents").unwrap();
+    let target_str = target.to_str().unwrap().to_string();
+
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    // Queue *three* responses, all emitting a read call — the model
+    // never says "done." With max_turns=2 the driver runs turns 1 and
+    // 2, then on the loop check at the top of "turn 3" the cap trips.
+    // We need a third response on the queue only to defend against
+    // the test being wrong in a way that runs an extra turn; the cap
+    // check at the top of the loop should fire first.
+    let responses = (0..3)
+        .map(|_| read_call_response(&target_str))
+        .collect::<Vec<_>>();
+    let (mock, _handle) = MockLoadedModel::new(responses);
+    let mut session = session.with_loaded_model(Box::new(mock));
+
+    let err = session
+        .run(
+            "read it",
+            TurnLimits {
+                max_turns: 2,
+                max_tokens: u64::MAX,
+                max_seconds: 300,
+            },
+        )
+        .expect_err("should cap on turns");
+
+    match err {
+        Error::TurnCapExceeded {
+            bound,
+            at_turn,
+            max_turns,
+            ..
+        } => {
+            assert_eq!(bound, TurnCapKind::Turns);
+            assert_eq!(at_turn, 2);
+            assert_eq!(max_turns, 2);
+        }
+        other => panic!("expected TurnCapExceeded(Turns), got {other:?}"),
+    }
+
+    // Ledger has a TurnCapExceeded Violation entry on disk.
+    let ledger = std::fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+    assert!(
+        ledger.contains("\"violationKind\":\"TurnCapExceeded\""),
+        "ledger should carry the cap violation. got:\n{ledger}"
+    );
+    assert!(
+        ledger.contains("\"capBound\":\"turns\""),
+        "ledger should record which bound tripped (capBound=turns)"
+    );
+}
+
+#[test]
+fn run_max_tokens_exceeded_caps_after_token_overflow() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("file.txt");
+    std::fs::write(&target, b"contents").unwrap();
+    let target_str = target.to_str().unwrap().to_string();
+
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    // First response burns 100 tokens (above max_tokens=50). The
+    // token check fires at the top of turn 2.
+    let mut t1 = read_call_response(&target_str);
+    t1.tokens_used = Some(100);
+    let t2 = final_text_response("done");
+    let (mock, _handle) = MockLoadedModel::new(vec![t1, t2]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+
+    let err = session
+        .run(
+            "go",
+            TurnLimits {
+                max_turns: 10,
+                max_tokens: 50,
+                max_seconds: 300,
+            },
+        )
+        .expect_err("should cap on tokens");
+
+    match err {
+        Error::TurnCapExceeded {
+            bound,
+            tokens_consumed,
+            max_tokens,
+            ..
+        } => {
+            assert_eq!(bound, TurnCapKind::Tokens);
+            assert_eq!(tokens_consumed, 100);
+            assert_eq!(max_tokens, 50);
+        }
+        other => panic!("expected TurnCapExceeded(Tokens), got {other:?}"),
+    }
+
+    let ledger = std::fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+    assert!(ledger.contains("\"capBound\":\"tokens\""));
+}
+
+#[test]
+fn run_max_seconds_exceeded_caps_immediately_when_budget_is_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    // `max_seconds: 0` causes the wallclock check at the top of
+    // turn 1 to trip before the model is invoked — useful as a
+    // deterministic test of the wallclock branch without timing
+    // dependencies. The behaviour matches ADR-025 §"Loop shape":
+    // wallclock is checked at every loop entry.
+    let (mock, _handle) = MockLoadedModel::new(vec![final_text_response("unused")]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+
+    let err = session
+        .run(
+            "go",
+            TurnLimits {
+                max_turns: 10,
+                max_tokens: u64::MAX,
+                max_seconds: 0,
+            },
+        )
+        .expect_err("should cap on wallclock");
+
+    match err {
+        Error::TurnCapExceeded {
+            bound, max_seconds, ..
+        } => {
+            assert_eq!(bound, TurnCapKind::Wallclock);
+            assert_eq!(max_seconds, 0);
+        }
+        other => panic!("expected TurnCapExceeded(Wallclock), got {other:?}"),
+    }
+
+    let ledger = std::fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+    assert!(ledger.contains("\"capBound\":\"wallclock\""));
+}
+
+#[test]
+fn run_accumulates_tool_results_into_next_turn_context() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("file.txt");
+    std::fs::write(&target, b"contents").unwrap();
+    let target_str = target.to_str().unwrap().to_string();
+
+    let session = boot_session(dir.path(), ca_dir.path());
+
+    // Two-turn loop: turn 1 reads the file; turn 2 emits the final
+    // answer with no tool calls (clean termination).
+    let responses = vec![
+        read_call_response(&target_str),
+        final_text_response("here is the summary"),
+    ];
+    let (mock, handle) = MockLoadedModel::new(responses);
+    let mut session = session.with_loaded_model(Box::new(mock));
+
+    let result = session
+        .run("summarise the file", TurnLimits::default())
+        .expect("clean termination on turn 2");
+
+    assert_eq!(result.turns.len(), 2);
+    assert_eq!(result.termination, SessionTermination::Done);
+
+    // Turn 1's InferRequest carries just the user prompt.
+    // Turn 2's InferRequest carries the user prompt + a Tool message
+    // for the read result (assistant_text was None on turn 1, so no
+    // assistant message is appended — see Session::run).
+    let captured = handle.captured();
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].messages.len(), 1);
+    assert_eq!(
+        captured[1].messages.len(),
+        2,
+        "turn 2 should see the user prompt + the turn-1 tool result message"
+    );
+    let tool_msg = &captured[1].messages[1];
+    assert!(
+        tool_msg.content.contains("filesystem__read"),
+        "turn-2 history message should carry the tool name: {}",
+        tool_msg.content
+    );
+    assert!(
+        tool_msg.content.contains("success"),
+        "turn-2 history message should carry the dispatch verdict: {}",
+        tool_msg.content
+    );
+}

--- a/crates/inference-engine/tests/run_turn.rs
+++ b/crates/inference-engine/tests/run_turn.rs
@@ -144,6 +144,7 @@ fn run_turn_emits_reasoning_then_dispatches_one_mcp_tool_call() {
             arguments: serde_json::json!({"city": "Paris"}),
         }],
         assistant_text: Some("Looking up the weather.".to_string()),
+        tokens_used: None,
     };
     let (mock, mock_handle) = MockLoadedModel::new(vec![Ok(response)]);
 
@@ -243,6 +244,7 @@ fn run_turn_marks_unroutable_tool_call_without_propagating_error() {
             arguments: serde_json::Value::Null,
         }],
         assistant_text: None,
+        tokens_used: None,
     };
     let (mock, _h) = MockLoadedModel::new(vec![Ok(response)]);
     let mut session = session.with_loaded_model(Box::new(mock));
@@ -273,6 +275,7 @@ fn run_turn_records_denied_tool_call_without_short_circuiting() {
             arguments: serde_json::Value::Null,
         }],
         assistant_text: None,
+        tokens_used: None,
     };
     let (mock, _h) = MockLoadedModel::new(vec![Ok(response)]);
     let mut session = session.with_loaded_model(Box::new(mock));
@@ -368,6 +371,7 @@ fn run_turn_dispatches_filesystem_read_natively_and_returns_contents() {
             arguments: serde_json::json!({"path": target.to_str().unwrap()}),
         }],
         assistant_text: Some("Reading.".to_string()),
+        tokens_used: None,
     };
     let (mock, mock_handle) = MockLoadedModel::new(vec![Ok(response)]);
     let mut session = session.with_loaded_model(Box::new(mock));
@@ -423,6 +427,7 @@ fn run_turn_records_denied_filesystem_read_outside_allowed_paths() {
             arguments: serde_json::json!({"path": "/etc/passwd"}),
         }],
         assistant_text: None,
+        tokens_used: None,
     };
     let (mock, _h) = MockLoadedModel::new(vec![Ok(response)]);
     let mut session = session.with_loaded_model(Box::new(mock));
@@ -463,6 +468,7 @@ fn run_turn_dispatches_filesystem_write_natively_against_a_write_grant() {
             }),
         }],
         assistant_text: None,
+        tokens_used: None,
     };
     let (mock, _h) = MockLoadedModel::new(vec![Ok(response)]);
     let mut session = session.with_loaded_model(Box::new(mock));
@@ -501,6 +507,7 @@ fn run_turn_marks_native_tool_with_missing_args_as_unroutable() {
             arguments: serde_json::json!({}),
         }],
         assistant_text: None,
+        tokens_used: None,
     };
     let (mock, _h) = MockLoadedModel::new(vec![Ok(response)]);
     let mut session = session.with_loaded_model(Box::new(mock));

--- a/crates/litertlm-backend/src/chat.rs
+++ b/crates/litertlm-backend/src/chat.rs
@@ -356,6 +356,11 @@ pub(crate) fn parse_conversation_response(raw_json: &str) -> Result<InferRespons
         reasoning: content,
         tool_calls,
         assistant_text,
+        // LiteRT-LM's runtime doesn't surface usage stats yet; the
+        // multi-turn driver's token bound treats None as "no
+        // contribution" so this won't trip the cap. Follow-up under
+        // #181's open questions section.
+        tokens_used: None,
     })
 }
 

--- a/crates/llama-backend/src/chat.rs
+++ b/crates/llama-backend/src/chat.rs
@@ -252,6 +252,11 @@ pub(crate) fn parse_response(raw: &str) -> InferResponse {
         reasoning: reasoning_trimmed,
         tool_calls,
         assistant_text,
+        // llama.cpp's logits-based usage reporting isn't wired here yet;
+        // the multi-turn driver's token bound treats None as "no
+        // contribution" so this won't trip the cap. Follow-up tracked
+        // under #181's open questions section.
+        tokens_used: None,
     }
 }
 


### PR DESCRIPTION
Closes **#181**. Implements [ADR-025](../blob/feat/181-adr-025-multi-turn-loop/docs/adrs/025-multi-turn-agent-loop-with-triple-bound-circuit-breaker.md) — bounded multi-turn agent loop with hard caps on turn count, cumulative token budget, and wallclock.

Foundation for the v1.0.0 GA work tracked in #134. #182 (ledger v2), #183 (aggregate quota), #185/186 (approvals + SVID rebinding) all build on this loop.

## What's new

| Surface | Change |
|---|---|
| `Session::run(prompt, TurnLimits)` | New multi-turn driver. Loops `run_one_turn` (a new private helper used by both the new driver and the existing single-turn `Session::run_turn`), accumulating assistant + tool messages into the context window between turns. |
| `TurnLimits` | `{ max_turns, max_tokens, max_seconds }` with ADR-025 defaults (10 / per-backend / 300s). |
| `TurnCapKind` | `Turns` / `Tokens` / `Wallclock` discriminator. |
| `Error::TurnCapExceeded { bound, at_turn, max_turns, tokens_consumed, max_tokens, wallclock_seconds, max_seconds }` | Carries full cap diagnostics for the CLI's stderr block. |
| `SessionRunResult` | `{ turns, termination, tokens_consumed, wallclock }` returned on clean termination. |
| F9 ledger | New `Violation` entry with `violationKind: \"TurnCapExceeded\"` + `capBound`/`atTurn`/`tokensConsumed`/etc. fields. Written *before* the driver returns the error — the \"partial ledger preserved\" promise from ADR-025 §3. v1-schema-compatible; ADR-026 (#182) will move this to a first-class `session_end.cap_record` field. |
| CLI | New `--max-turns` / `--max-tokens` / `--max-seconds` flags on `aegis run`. The `--prompt` path now drives the multi-turn loop. Cap-trips render the ADR-025 §3 stderr block and signal `halted=true` (non-zero exit). |
| `InferResponse::tokens_used: Option<u64>` | New backend-reported field. Existing backends return `None` (the cap won't trip on them); future backends with wired usage stats will. |

## Tests

`crates/inference-engine/tests/run_multi_turn.rs` — 5 integration tests:

1. Clean termination (1 turn, no tools → `Done`).
2. `max_turns` cap trips + writes Violation entry to ledger.
3. `max_tokens` cap trips when cumulative tokens exceed the limit.
4. `max_seconds` cap trips at loop entry when budget is zero.
5. Tool results from turn N flow into turn N+1's context window.

Existing single-turn surface (`tests/run_turn.rs`) is **unchanged in behaviour** — `Session::run_turn` keeps its existing signature.

## Verified locally

- `cargo fmt --all --check` clean
- `cargo clippy --workspace … --all-targets -- -D warnings` clean
- `cargo test --workspace …` — **221/221 passing** (5 new + 216 pre-existing)

## Acceptance check (per #181)

- [x] `Session::run` returns `SessionRunResult { turns, … }` capturing every turn's tool calls + assistant text.
- [x] All three caps fire integration tests (`max_turns_exceeded`, `max_tokens_exceeded`, `max_seconds_exceeded`); each reads the resulting ledger and asserts the cap record.
- [x] CLI `aegis run --max-turns N --prompt …` against a model that emits a tool call ends with `TurnCapExceeded`, exits non-zero, prints the structured error block.
- [x] Existing single-turn behaviour preserved: `Session::run_turn` is unchanged and tested.
- [x] No F9 ledger schema changes (per scope) — ADR-026 (#182) handles the schema v2 work.

## Scope notes for reviewer

- **Ledger entry uses `EntryType::Violation`**, namespaced under `violationKind: \"TurnCapExceeded\"`. v1 readers can ignore it; #182 will lift it into a first-class entry kind.
- **Token usage is opt-in per backend.** Llama + LiteRT-LM both carry `tokens_used: None` (TODO comments in both backends point at the open question in #181). The cap can't trip on backends that don't report — a deliberate choice so the loop is forward-compatible with usage reporting landing later.
- **Multi-turn chat message shape**: tool results between turns serialise as `ChatRole::Tool { content: {tool, args, result} JSON }`. Real-world Gemma-4 chat-template integration (proper tool-call / tool-result markers) is examples follow-up (#190) + ADR-026 (#182) which extends `ChatMessage` with `tool_call_id` + `tool_name` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)