### PR TITLE
feat(ledger-writer, inference-engine): ADR-026 foundation — hierarchical per-turn ledger (#182)

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -234,6 +234,7 @@ pub fn execute(args: RunArgs) -> Result<RunOutcome> {
         workload_name: args.workload.clone(),
         instance: args.instance.clone(),
         ledger_path: ledger_path.clone(),
+        ledger_schema: None,
     };
     let mut session = Session::boot(cfg).context("boot")?;
 
@@ -632,6 +633,7 @@ pub fn boot_session_for_ui(
         workload_name: workload,
         instance,
         ledger_path,
+        ledger_schema: None,
     };
     let mut session = Session::boot(cfg).context("boot")?;
 

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -19,7 +19,7 @@ use aegis_identity::{
     verify_chat_template_binding, verify_digest_binding, Digest, DigestField, DigestTriple,
     LocalCa, SpiffeId,
 };
-use aegis_ledger_writer::{Entry, EntryType, LedgerWriter};
+use aegis_ledger_writer::{Entry, EntryType, LedgerSchemaVersion, LedgerWriter};
 use aegis_mcp_client::McpClient;
 use aegis_policy::Policy;
 use chrono::{DateTime, Utc};
@@ -49,6 +49,11 @@ pub struct BootConfig {
     pub workload_name: String,
     pub instance: String,
     pub ledger_path: PathBuf,
+    /// Ledger schema version (ADR-026). `None` means the default
+    /// ([`LedgerSchemaVersion::V1`]) — existing callers stay on v1
+    /// without churn. New callers opt in to v2 by setting
+    /// `Some(LedgerSchemaVersion::V2)`.
+    pub ledger_schema: Option<LedgerSchemaVersion>,
 }
 
 /// Live agent session: compiled policy, open ledger, issued SVID, the
@@ -207,7 +212,12 @@ impl Session {
 
         let agent_identity_hash = sha256_bytes(svid.spiffe_id.uri().as_bytes());
 
-        let mut ledger = LedgerWriter::create(&cfg.ledger_path, cfg.session_id.clone())?;
+        let schema_version = cfg.ledger_schema.unwrap_or_default();
+        let mut ledger = LedgerWriter::create_with_version(
+            &cfg.ledger_path,
+            cfg.session_id.clone(),
+            schema_version,
+        )?;
 
         let mut payload = Map::new();
         payload.insert("spiffeId".to_string(), Value::String(svid.spiffe_id.uri()));
@@ -333,6 +343,172 @@ impl Session {
 
     pub fn policy(&self) -> &Policy {
         &self.policy
+    }
+
+    /// Ledger schema version this session is writing under (ADR-026).
+    /// Determines whether the multi-turn driver emits v2 `turn_start` /
+    /// `turn_end` / `tool_call` / `tool_result` entries.
+    pub fn schema_version(&self) -> LedgerSchemaVersion {
+        self.ledger.schema_version()
+    }
+
+    /// Write a `turn_start` entry (v2, ADR-026 §"Per-turn entry sequence").
+    /// Records the turn number, the bound model digest, and a SHA-256
+    /// of the canonical-serialized input context so F8 replay can
+    /// detect mid-session context tampering. Caller is responsible for
+    /// only invoking this on v2 ledgers — emitting it on a v1 file
+    /// would taint the chain with an entry type v1 consumers don't
+    /// expect.
+    pub(crate) fn write_turn_start(
+        &mut self,
+        turn_number: u32,
+        context_digest_hex: &str,
+    ) -> Result<()> {
+        let mut payload = Map::new();
+        payload.insert("turnNumber".to_string(), Value::Number(turn_number.into()));
+        payload.insert(
+            "modelDigestHex".to_string(),
+            Value::String(hex::encode(self.bound_digests.model.0)),
+        );
+        payload.insert(
+            "contextDigestHex".to_string(),
+            Value::String(context_digest_hex.to_string()),
+        );
+        self.ledger.append(Entry {
+            session_id: self.session_id.clone(),
+            entry_type: EntryType::TurnStart,
+            agent_identity_hash: self.agent_identity_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
+    }
+
+    /// Write a `turn_end` entry (v2). Closes a turn with cumulative
+    /// usage counters. `quotaSnapshots` lives in ADR-027 territory and
+    /// is emitted as an empty array for now — the field is reserved
+    /// and won't reshape when [#183](https://github.com/tosin2013/aegis-node/issues/183) lands.
+    pub(crate) fn write_turn_end(
+        &mut self,
+        turn_number: u32,
+        tokens_in: Option<u64>,
+        tokens_out: Option<u64>,
+        tokens_cumulative: u64,
+        wallclock_ms_cumulative: u64,
+    ) -> Result<()> {
+        let mut payload = Map::new();
+        payload.insert("turnNumber".to_string(), Value::Number(turn_number.into()));
+        if let Some(t) = tokens_in {
+            payload.insert("tokensIn".to_string(), Value::Number(t.into()));
+        }
+        if let Some(t) = tokens_out {
+            payload.insert("tokensOut".to_string(), Value::Number(t.into()));
+        }
+        payload.insert(
+            "tokensCumulative".to_string(),
+            Value::Number(tokens_cumulative.into()),
+        );
+        payload.insert(
+            "wallclockMsCumulative".to_string(),
+            Value::Number(wallclock_ms_cumulative.into()),
+        );
+        payload.insert("quotaSnapshots".to_string(), Value::Array(Vec::new()));
+        self.ledger.append(Entry {
+            session_id: self.session_id.clone(),
+            entry_type: EntryType::TurnEnd,
+            agent_identity_hash: self.agent_identity_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
+    }
+
+    /// Write a `tool_call` entry (v2). Records that the model elected
+    /// to invoke `tool_name` with `arguments` during the given turn.
+    /// `request_args_hex` is the SHA-256 of the canonical-serialized
+    /// arguments — F8 replay matches calls to results without storing
+    /// the args twice in the chain.
+    pub(crate) fn write_tool_call_entry(
+        &mut self,
+        turn_number: u32,
+        tool_call_id: &str,
+        tool_name: &str,
+        tool_origin: &crate::adversarial::ToolOrigin,
+        request_args_hex: &str,
+    ) -> Result<()> {
+        let mut payload = Map::new();
+        payload.insert("turnNumber".to_string(), Value::Number(turn_number.into()));
+        payload.insert(
+            "toolCallId".to_string(),
+            Value::String(tool_call_id.to_string()),
+        );
+        payload.insert("toolName".to_string(), Value::String(tool_name.to_string()));
+        payload.insert(
+            "toolOrigin".to_string(),
+            Value::String(tool_origin.to_string()),
+        );
+        payload.insert(
+            "requestArgsHex".to_string(),
+            Value::String(request_args_hex.to_string()),
+        );
+        self.ledger.append(Entry {
+            session_id: self.session_id.clone(),
+            entry_type: EntryType::ToolCall,
+            agent_identity_hash: self.agent_identity_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
+    }
+
+    /// Write a `tool_result` entry (v2). Pairs with a prior `tool_call`
+    /// via `tool_call_id`. Stores the result inline when ≤32 KB,
+    /// otherwise stores only the hash + a sidecar `resultPayloadRef`.
+    /// Sidecar emission itself is deferred (ADR-026 follow-up); the
+    /// 32 KB threshold is enforced here so existing tests don't bloat
+    /// ledger files.
+    pub(crate) fn write_tool_result_entry(
+        &mut self,
+        turn_number: u32,
+        tool_call_id: &str,
+        result_hash_hex: &str,
+        result_payload: serde_json::Value,
+    ) -> Result<()> {
+        const INLINE_THRESHOLD_BYTES: usize = 32 * 1024;
+        let mut payload = Map::new();
+        payload.insert("turnNumber".to_string(), Value::Number(turn_number.into()));
+        payload.insert(
+            "toolCallId".to_string(),
+            Value::String(tool_call_id.to_string()),
+        );
+        payload.insert(
+            "resultHashHex".to_string(),
+            Value::String(result_hash_hex.to_string()),
+        );
+        let approx_size = serde_json::to_string(&result_payload)
+            .map(|s| s.len())
+            .unwrap_or(usize::MAX);
+        if approx_size <= INLINE_THRESHOLD_BYTES {
+            payload.insert("resultPayload".to_string(), result_payload);
+        } else {
+            // Sidecar mechanism is deferred (ADR-026 follow-up). For
+            // now drop the inline payload and record the hash + a
+            // marker that downstream tooling can detect. This keeps
+            // chain integrity while signalling "blob too large to
+            // inline; sidecar emission TODO".
+            payload.insert(
+                "resultPayloadRef".to_string(),
+                Value::String(format!("pending-sidecar:{result_hash_hex}.{approx_size}b")),
+            );
+        }
+        self.ledger.append(Entry {
+            session_id: self.session_id.clone(),
+            entry_type: EntryType::ToolResult,
+            agent_identity_hash: self.agent_identity_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
     }
 
     /// Append an `AdversarialContent` Violation to the F9 ledger

--- a/crates/inference-engine/src/turn.rs
+++ b/crates/inference-engine/src/turn.rs
@@ -37,6 +37,9 @@ use std::fmt;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+use aegis_ledger_writer::LedgerSchemaVersion;
+use sha2::{Digest as _, Sha256};
+
 use crate::adversarial::{ClassifierVerdict, ToolOrigin};
 use crate::backend::{ChatMessage, ChatRole, InferRequest, ToolCall, ToolDecl};
 use crate::error::{Error, Result};
@@ -219,7 +222,9 @@ impl Session {
             role: ChatRole::User,
             content: user_message.to_string(),
         }];
-        let (outcome, _tokens) = self.run_one_turn(&messages, user_message)?;
+        // Single-turn legacy path does not emit v2 per-turn entries —
+        // turn_number is None to signal that to `run_one_turn`.
+        let (outcome, _tokens) = self.run_one_turn(&messages, user_message, None)?;
         Ok(outcome)
     }
 
@@ -263,6 +268,7 @@ impl Session {
         }];
         let mut turns: Vec<TurnOutcome> = Vec::with_capacity(limits.max_turns as usize);
         let mut tokens_consumed: u64 = 0;
+        let v2 = self.schema_version() == LedgerSchemaVersion::V2;
 
         // The driver runs as a for-loop with explicit cap checks at
         // the top so the bounds are visible without grep'ing for
@@ -294,8 +300,18 @@ impl Session {
                 )?);
             }
 
-            let (mut outcome, used) = self.run_one_turn(&messages, prompt)?;
-            tokens_consumed = tokens_consumed.saturating_add(used.unwrap_or(0));
+            // v2 turn_start lands *before* `run_one_turn` so the
+            // reasoning_step + tool_call/tool_result entries the inner
+            // dispatch emits all parent-by-position to this turn_start
+            // in the ledger stream.
+            if v2 {
+                let ctx_hex = sha256_hex_of_messages(&messages);
+                self.write_turn_start(turn_index, &ctx_hex)?;
+            }
+
+            let (mut outcome, used) = self.run_one_turn(&messages, prompt, Some(turn_index))?;
+            let tokens_this_turn = used.unwrap_or(0);
+            tokens_consumed = tokens_consumed.saturating_add(tokens_this_turn);
             let no_tool_calls = outcome.tool_calls.is_empty();
 
             // ADR-028 adversarial pre-filter — classify every tool
@@ -375,6 +391,16 @@ impl Session {
             }
             turns.push(outcome);
 
+            // v2 turn_end after the dispatch round + adversarial
+            // emissions, before the loop control decides whether to
+            // re-enter. On clean termination we return *after*
+            // emitting turn_end so the ledger always brackets the
+            // final turn.
+            if v2 {
+                let wallclock_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+                self.write_turn_end(turn_index, None, used, tokens_consumed, wallclock_ms)?;
+            }
+
             if no_tool_calls {
                 // Clean termination: the model produced text and no
                 // tool calls — the task is its own answer.
@@ -407,6 +433,7 @@ impl Session {
         &mut self,
         messages: &[ChatMessage],
         original_prompt: &str,
+        turn_number: Option<u32>,
     ) -> Result<(TurnOutcome, Option<u64>)> {
         let tools = self.tool_catalog();
 
@@ -431,9 +458,31 @@ impl Session {
         )?;
         let step_id = step_uuid.to_string();
 
+        // v2 per-turn entries fire only on the multi-turn path AND only
+        // when the ledger itself is v2. Both conditions must hold —
+        // emitting tool_call/tool_result on a v1 ledger would taint
+        // the chain with entry types v1 readers don't recognize as
+        // turn-scoped.
+        let emit_v2_entries =
+            turn_number.is_some() && self.schema_version() == LedgerSchemaVersion::V2;
+
         let mut outcomes = Vec::with_capacity(response.tool_calls.len());
-        for call in response.tool_calls {
+        for (call_index, call) in response.tool_calls.into_iter().enumerate() {
+            if emit_v2_entries {
+                let turn_n = turn_number.unwrap_or(0);
+                let tool_call_id = format!("turn-{turn_n}-call-{call_index}");
+                let origin = crate::turn::origin_of(&call.name);
+                let args_hex = sha256_hex_of_json(&call.arguments);
+                self.write_tool_call_entry(turn_n, &tool_call_id, &call.name, &origin, &args_hex)?;
+            }
             let outcome = self.dispatch_tool_call(call, Some(&step_id))?;
+            if emit_v2_entries {
+                let turn_n = turn_number.unwrap_or(0);
+                let tool_call_id = format!("turn-{turn_n}-call-{call_index}");
+                let result_value = tool_call_result_to_value(&outcome.result);
+                let result_hex = sha256_hex_of_json(&result_value);
+                self.write_tool_result_entry(turn_n, &tool_call_id, &result_hex, result_value)?;
+            }
             outcomes.push(outcome);
         }
 
@@ -846,6 +895,32 @@ fn u16_arg(args: &serde_json::Value, key: &str) -> Result<u16> {
 /// Format an MCP tool's qualified name for the LLM catalog.
 pub(crate) fn format_mcp_name(server: &str, tool: &str) -> String {
     format!("{server}__{tool}")
+}
+
+/// SHA-256 of the canonical serialization of a [`serde_json::Value`].
+/// Used by the v2 ledger path to hash tool-call args and tool-result
+/// payloads into `tool_call.requestArgsHex` / `tool_result.resultHashHex`.
+///
+/// `serde_json::Map` is backed by `BTreeMap` in this build (no
+/// `preserve_order` feature), so `to_string` is byte-deterministic
+/// across runs and across reimplementations of the verifier in other
+/// languages.
+fn sha256_hex_of_json(value: &serde_json::Value) -> String {
+    let canonical = serde_json::to_string(value).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// SHA-256 of the canonical serialization of a chat-message slice.
+/// Used by the v2 ledger path to populate `turn_start.contextDigestHex`
+/// so F8 replay can detect a manifest mutation or message-history
+/// tampering between turns.
+fn sha256_hex_of_messages(messages: &[ChatMessage]) -> String {
+    let canonical = serde_json::to_string(messages).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    hex::encode(hasher.finalize())
 }
 
 /// Inverse of [`format_mcp_name`]. Returns `None` when the name

--- a/crates/inference-engine/tests/integration.rs
+++ b/crates/inference-engine/tests/integration.rs
@@ -43,6 +43,7 @@ fn boot_cfg(dir: &Path, ca_dir: &Path, session_id: &str) -> BootConfig {
         workload_name: "research".to_string(),
         instance: "inst-001".to_string(),
         ledger_path,
+        ledger_schema: None,
     }
 }
 
@@ -143,6 +144,7 @@ tools: {}
         workload_name: "research".to_string(),
         instance: "inst-001".to_string(),
         ledger_path: dir.path().join("ledger.jsonl"),
+        ledger_schema: None,
     };
     let err = Session::boot(cfg).unwrap_err();
     assert!(matches!(err, Error::Policy(_)), "got {err:?}");

--- a/crates/inference-engine/tests/mediator.rs
+++ b/crates/inference-engine/tests/mediator.rs
@@ -39,6 +39,7 @@ fn boot(dir: &Path, ca_dir: &Path, session_id: &str, manifest_yaml: &str) -> (Se
         workload_name: "research".to_string(),
         instance: "inst-1".to_string(),
         ledger_path: ledger_path.clone(),
+        ledger_schema: None,
     };
     (Session::boot(cfg).unwrap(), ledger_path)
 }

--- a/crates/inference-engine/tests/run_multi_turn.rs
+++ b/crates/inference-engine/tests/run_multi_turn.rs
@@ -94,6 +94,7 @@ fn boot_session(dir: &Path, ca_dir: &Path) -> Session {
         workload_name: "loop".to_string(),
         instance: "inst-001".to_string(),
         ledger_path,
+        ledger_schema: None,
     };
     Session::boot(cfg).unwrap()
 }

--- a/crates/inference-engine/tests/run_multi_turn_v2.rs
+++ b/crates/inference-engine/tests/run_multi_turn_v2.rs
@@ -1,0 +1,281 @@
+//! Integration tests for the v2 hierarchical per-turn ledger
+//! protocol (ADR-026, issue #182). Drives the multi-turn loop with a
+//! `Session` booted under [`LedgerSchemaVersion::V2`] and asserts the
+//! emitted entry stream — order, types, payload fields, and chain
+//! integrity via `verify_file`.
+//!
+//! The v1 path is exercised by the existing `run_multi_turn.rs` suite;
+//! these tests only cover what v2 *adds*. Behaviour the two share
+//! (Triple-Bound Circuit Breaker, adversarial pre-filter, message
+//! accumulation) is not duplicated here.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use aegis_identity::LocalCa;
+use aegis_inference_engine::{
+    BackendError, BootConfig, InferRequest, InferResponse, LoadedModel, Session, ToolCall,
+    TurnLimits,
+};
+use aegis_ledger_writer::{verify_file, LedgerSchemaVersion, LEDGER_CONTEXT_V2};
+use serde_json::Value;
+
+const TRUST_DOMAIN: &str = "v2-ledger-test.local";
+
+struct MockLoadedModel {
+    queue: Arc<Mutex<Vec<Result<InferResponse, BackendError>>>>,
+}
+
+impl MockLoadedModel {
+    fn new(responses: Vec<InferResponse>) -> Self {
+        let queue = Arc::new(Mutex::new(
+            responses.into_iter().map(Ok).collect::<Vec<_>>(),
+        ));
+        Self { queue }
+    }
+}
+
+impl LoadedModel for MockLoadedModel {
+    fn infer(&mut self, _request: InferRequest) -> Result<InferResponse, BackendError> {
+        self.queue.lock().unwrap().remove(0)
+    }
+}
+
+fn write_manifest_with_read_grant(path: &Path) {
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "v2-test", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://v2-ledger-test.local/agent/loop/inst-001" }}
+tools:
+  filesystem:
+    read: ["{}"]
+"#,
+        path.parent().unwrap().display()
+    );
+    std::fs::write(path, yaml).unwrap();
+}
+
+fn boot_session(
+    dir: &Path,
+    ca_dir: &Path,
+    schema: Option<LedgerSchemaVersion>,
+) -> (Session, std::path::PathBuf) {
+    LocalCa::init(ca_dir, TRUST_DOMAIN).unwrap();
+
+    let manifest_path = dir.join("manifest.yaml");
+    let model_path = dir.join("model.gguf");
+    let ledger_path = dir.join("ledger.jsonl");
+    write_manifest_with_read_grant(&manifest_path);
+    std::fs::write(&model_path, b"fake-model-bytes").unwrap();
+
+    let cfg = BootConfig {
+        session_id: "session-v2".to_string(),
+        manifest_path,
+        model_path,
+        config_path: None,
+        chat_template_sidecar: None,
+        identity_dir: ca_dir.to_path_buf(),
+        workload_name: "loop".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path: ledger_path.clone(),
+        ledger_schema: schema,
+    };
+    (Session::boot(cfg).unwrap(), ledger_path)
+}
+
+fn final_text_response(text: &str) -> InferResponse {
+    InferResponse {
+        reasoning: text.to_string(),
+        tool_calls: vec![],
+        assistant_text: Some(text.to_string()),
+        tokens_used: None,
+    }
+}
+
+fn read_call_response(path: &str) -> InferResponse {
+    InferResponse {
+        reasoning: format!("reading {path}"),
+        tool_calls: vec![ToolCall {
+            name: "filesystem__read".to_string(),
+            arguments: serde_json::json!({"path": path}),
+        }],
+        assistant_text: None,
+        tokens_used: None,
+    }
+}
+
+fn read_entries(path: &Path) -> Vec<Value> {
+    let content = std::fs::read_to_string(path).unwrap();
+    content
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("valid jsonl"))
+        .collect()
+}
+
+/// Every entry the writer emits under V2 carries the v2 `@context`
+/// URL, and `verify_file` reports the same version back. Establishes
+/// the baseline: opt-in is wired through the boot path.
+#[test]
+fn v2_ledger_stamps_v2_context_on_every_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let (session, ledger_path) =
+        boot_session(dir.path(), ca_dir.path(), Some(LedgerSchemaVersion::V2));
+
+    let mock = MockLoadedModel::new(vec![final_text_response("hi")]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+    session
+        .run("greet me", TurnLimits::default())
+        .expect("clean termination");
+    let _ = session.shutdown();
+
+    let entries = read_entries(&ledger_path);
+    assert!(!entries.is_empty(), "ledger has at least one entry");
+    for (i, e) in entries.iter().enumerate() {
+        assert_eq!(
+            e["@context"].as_str().unwrap(),
+            LEDGER_CONTEXT_V2,
+            "entry {i} carries v2 context"
+        );
+    }
+
+    let summary = verify_file(&ledger_path).expect("v2 ledger verifies clean");
+    assert_eq!(summary.schema_version, Some(LedgerSchemaVersion::V2));
+}
+
+/// One full turn that issues a `filesystem__read` tool call should
+/// emit the canonical v2 entry sequence: turn_start → reasoning_step →
+/// tool_call → tool_result → ... → turn_end, with `tool_call.toolCallId`
+/// matching `tool_result.toolCallId` and both pinned to `turn 1`.
+#[test]
+fn v2_emits_turn_start_tool_call_tool_result_turn_end_in_order() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let (session, ledger_path) =
+        boot_session(dir.path(), ca_dir.path(), Some(LedgerSchemaVersion::V2));
+
+    // Create a real file the read mediator will accept (manifest grants
+    // the temp-dir prefix).
+    let target = dir.path().join("greeting.txt");
+    std::fs::write(&target, b"hello").unwrap();
+    let target_str = target.to_string_lossy().to_string();
+
+    let mock = MockLoadedModel::new(vec![
+        read_call_response(&target_str),
+        final_text_response("done"),
+    ]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+    session
+        .run("read the file", TurnLimits::default())
+        .expect("clean termination");
+    let _ = session.shutdown();
+
+    let entries = read_entries(&ledger_path);
+    let types: Vec<&str> = entries
+        .iter()
+        .map(|e| e["entryType"].as_str().unwrap())
+        .collect();
+
+    // Find the first turn's bracket markers and assert the expected
+    // ordering of children between them. We don't pin absolute indices
+    // because adversarial / access entries can interleave; we only
+    // assert the *partial order* the v2 protocol promises.
+    let first_turn_start = types
+        .iter()
+        .position(|t| *t == "turn_start")
+        .expect("turn_start present");
+    let first_turn_end = types
+        .iter()
+        .position(|t| *t == "turn_end")
+        .expect("turn_end present");
+    assert!(first_turn_end > first_turn_start);
+
+    let between = &types[first_turn_start + 1..first_turn_end];
+    let reasoning_at = between
+        .iter()
+        .position(|t| *t == "reasoning_step")
+        .expect("reasoning_step inside first turn");
+    let tool_call_at = between
+        .iter()
+        .position(|t| *t == "tool_call")
+        .expect("tool_call inside first turn");
+    let tool_result_at = between
+        .iter()
+        .position(|t| *t == "tool_result")
+        .expect("tool_result inside first turn");
+
+    assert!(reasoning_at < tool_call_at, "reasoning precedes tool_call");
+    assert!(
+        tool_call_at < tool_result_at,
+        "tool_call precedes tool_result"
+    );
+
+    // tool_call and tool_result share the same toolCallId, and both
+    // carry turnNumber: 1.
+    let tool_call_entry = entries
+        .iter()
+        .find(|e| e["entryType"] == "tool_call")
+        .unwrap();
+    let tool_result_entry = entries
+        .iter()
+        .find(|e| e["entryType"] == "tool_result")
+        .unwrap();
+    assert_eq!(tool_call_entry["turnNumber"].as_u64(), Some(1));
+    assert_eq!(tool_result_entry["turnNumber"].as_u64(), Some(1));
+    assert_eq!(
+        tool_call_entry["toolCallId"], tool_result_entry["toolCallId"],
+        "tool_call and tool_result share toolCallId"
+    );
+
+    // turn_start carries the model digest hex (lowercase 64-char hex).
+    let turn_start_entry = entries
+        .iter()
+        .find(|e| e["entryType"] == "turn_start")
+        .unwrap();
+    let model_hex = turn_start_entry["modelDigestHex"].as_str().unwrap();
+    assert_eq!(model_hex.len(), 64);
+    assert!(model_hex.bytes().all(|b| b.is_ascii_hexdigit()));
+
+    // Chain integrity holds across the new entry types.
+    let summary = verify_file(&ledger_path).expect("chain intact");
+    assert_eq!(summary.schema_version, Some(LedgerSchemaVersion::V2));
+}
+
+/// Default schema (None on BootConfig) still emits v1. The whole
+/// existing test corpus passes against v1 — this test exists only to
+/// pin the default behavior in one canonical place so a future
+/// regression in the unwrap_or_default plumbing is loud.
+#[test]
+fn default_schema_emits_v1_ledger() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let (session, ledger_path) = boot_session(dir.path(), ca_dir.path(), None);
+
+    let mock = MockLoadedModel::new(vec![final_text_response("hi")]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+    session
+        .run("greet me", TurnLimits::default())
+        .expect("clean termination");
+    let _ = session.shutdown();
+
+    let summary = verify_file(&ledger_path).expect("v1 ledger verifies clean");
+    assert_eq!(summary.schema_version, Some(LedgerSchemaVersion::V1));
+
+    let entries = read_entries(&ledger_path);
+    for e in &entries {
+        assert!(
+            !e["@context"].as_str().unwrap().ends_with("/v2"),
+            "no v2 entries on default schema"
+        );
+    }
+
+    // No v2-specific entry kinds present.
+    let v2_kinds = ["turn_start", "turn_end", "tool_call", "tool_result"];
+    for e in &entries {
+        let et = e["entryType"].as_str().unwrap();
+        assert!(!v2_kinds.contains(&et), "v1 ledger contains v2 kind {et:?}");
+    }
+}

--- a/crates/inference-engine/tests/run_turn.rs
+++ b/crates/inference-engine/tests/run_turn.rs
@@ -112,6 +112,7 @@ fn boot_session(dir: &Path, ca_dir: &Path) -> Session {
         workload_name: "research".to_string(),
         instance: "inst-001".to_string(),
         ledger_path,
+        ledger_schema: None,
     };
     Session::boot(cfg).unwrap()
 }
@@ -345,6 +346,7 @@ fn boot_session_with_manifest(
         workload_name: "research".to_string(),
         instance: "inst-001".to_string(),
         ledger_path,
+        ledger_schema: None,
     };
     Session::boot(cfg).unwrap()
 }
@@ -556,6 +558,7 @@ tools:
         workload_name: "research".to_string(),
         instance: "inst-001".to_string(),
         ledger_path: dir.path().join("ledger.jsonl"),
+        ledger_schema: None,
     };
     let err = Session::boot(cfg).unwrap_err();
     assert!(

--- a/crates/ledger-writer/examples/replay-fixture.rs
+++ b/crates/ledger-writer/examples/replay-fixture.rs
@@ -22,7 +22,7 @@
 
 use std::path::PathBuf;
 
-use aegis_ledger_writer::{verify_file, Entry, EntryType, LedgerWriter};
+use aegis_ledger_writer::{verify_file, Entry, EntryType, LedgerSchemaVersion, LedgerWriter};
 use chrono::{TimeZone, Utc};
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
@@ -57,9 +57,13 @@ fn main() {
         Uuid::from_bytes(bytes)
     };
 
-    let mut w =
-        LedgerWriter::create_with_uuid_generator(&out, session_id.clone(), Box::new(next_uuid))
-            .expect("open writer");
+    let mut w = LedgerWriter::create_with_uuid_generator(
+        &out,
+        session_id.clone(),
+        Box::new(next_uuid),
+        LedgerSchemaVersion::V1,
+    )
+    .expect("open writer");
 
     // Pinned agent identity hash for stability.
     let agent_hash = [0x3Bu8; 32];

--- a/crates/ledger-writer/src/lib.rs
+++ b/crates/ledger-writer/src/lib.rs
@@ -36,6 +36,43 @@ pub use verify::{verify_file, verify_reader, VerifyBreak, VerifyError, VerifySum
 /// JSON-LD `@context` URI for v1 ledger entries.
 pub const LEDGER_CONTEXT: &str = "https://aegis-node.dev/schemas/ledger/v1";
 
+/// JSON-LD `@context` URI for v2 ledger entries (ADR-026 — hierarchical
+/// per-turn ledger protocol). Carries the new `turn_start`, `turn_end`,
+/// `tool_call`, `tool_result`, and `approval_decision` entry types; the
+/// chain mechanics (sequenceNumber + prevHash + SHA-256) are identical
+/// to v1.
+pub const LEDGER_CONTEXT_V2: &str = "https://aegis-node.dev/schemas/ledger/v2";
+
+/// Schema version pinned on the `LedgerWriter` at construction time.
+/// Every entry the writer emits carries the corresponding `@context`
+/// URL ([`LEDGER_CONTEXT`] for v1, [`LEDGER_CONTEXT_V2`] for v2). The
+/// `aegis verify` reader detects the version on line 0 and requires
+/// every subsequent line to match — mixing versions within one ledger
+/// file is rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LedgerSchemaVersion {
+    /// v1 — the original flat entry stream. Default for back-compat;
+    /// new callers should opt in to [`Self::V2`] explicitly.
+    #[default]
+    V1,
+    /// v2 — hierarchical per-turn protocol (ADR-026). Adds `turn_start`,
+    /// `turn_end`, `tool_call`, `tool_result`, `approval_decision`
+    /// entry types and an optional `turnNumber` field on `access` and
+    /// `violation` entries.
+    V2,
+}
+
+impl LedgerSchemaVersion {
+    /// JSON-LD `@context` URL for this version.
+    pub fn context_url(self) -> &'static str {
+        match self {
+            Self::V1 => LEDGER_CONTEXT,
+            Self::V2 => LEDGER_CONTEXT_V2,
+        }
+    }
+}
+
 /// Genesis prev-hash: 32 zero bytes, used as the previous-hash for the first
 /// entry of every session.
 pub const GENESIS_PREV_HASH: [u8; 32] = [0u8; 32];
@@ -53,6 +90,13 @@ const RESERVED_KEYS: &[&str] = &[
 ];
 
 /// Kind of ledger entry. Mirrors `aegis.v1.EntryType` in the proto contract.
+///
+/// The variants `TurnStart`, `TurnEnd`, `ToolCall`, `ToolResult`, and
+/// `ApprovalDecision` are emitted only when the writer is constructed
+/// with [`LedgerSchemaVersion::V2`] (ADR-026). v1 readers encountering
+/// these as unknown `entryType` strings skip them per the existing
+/// forward-compat rule, but the writer is responsible for not mixing
+/// versions within one ledger.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EntryType {
@@ -66,6 +110,11 @@ pub enum EntryType {
     ApprovalTimedOut,
     Violation,
     NetworkAttestation,
+    TurnStart,
+    TurnEnd,
+    ToolCall,
+    ToolResult,
+    ApprovalDecision,
 }
 
 /// An entry to append. The writer fills in `entryId`, `sequenceNumber`,
@@ -102,13 +151,32 @@ pub struct LedgerWriter {
     next_sequence: u64,
     prev_hash: [u8; 32],
     uuid_generator: UuidGenerator,
+    schema_version: LedgerSchemaVersion,
 }
 
 impl LedgerWriter {
-    /// Create a new ledger file at `path`. Errors if the file already exists
-    /// — sessions own their ledger; reusing a path would imply tampering.
+    /// Create a new ledger file at `path` using the default v1 schema.
+    /// Errors if the file already exists — sessions own their ledger;
+    /// reusing a path would imply tampering. Equivalent to
+    /// [`Self::create_with_version`] with [`LedgerSchemaVersion::V1`].
     pub fn create<P: AsRef<Path>>(path: P, session_id: String) -> Result<Self> {
-        Self::create_with_uuid_generator(path, session_id, Box::new(Uuid::now_v7))
+        Self::create_with_uuid_generator(
+            path,
+            session_id,
+            Box::new(Uuid::now_v7),
+            LedgerSchemaVersion::V1,
+        )
+    }
+
+    /// Create a new ledger file pinned to the given schema version.
+    /// `aegis verify` detects the version on the first line and requires
+    /// every subsequent entry to carry the matching `@context`.
+    pub fn create_with_version<P: AsRef<Path>>(
+        path: P,
+        session_id: String,
+        schema_version: LedgerSchemaVersion,
+    ) -> Result<Self> {
+        Self::create_with_uuid_generator(path, session_id, Box::new(Uuid::now_v7), schema_version)
     }
 
     /// Like `create` but with an injectable UUID generator. Used by tests for
@@ -117,6 +185,7 @@ impl LedgerWriter {
         path: P,
         session_id: String,
         uuid_generator: UuidGenerator,
+        schema_version: LedgerSchemaVersion,
     ) -> Result<Self> {
         let file = OpenOptions::new().create_new(true).write(true).open(path)?;
         Ok(Self {
@@ -125,7 +194,14 @@ impl LedgerWriter {
             next_sequence: 0,
             prev_hash: GENESIS_PREV_HASH,
             uuid_generator,
+            schema_version,
         })
+    }
+
+    /// Schema version pinned at construction time. Determines the
+    /// `@context` URL stamped on every entry this writer emits.
+    pub fn schema_version(&self) -> LedgerSchemaVersion {
+        self.schema_version
     }
 
     /// Append an entry. Builds the canonical JSON-LD line, writes it +
@@ -150,7 +226,7 @@ impl LedgerWriter {
         let mut obj = Map::new();
         obj.insert(
             "@context".to_string(),
-            Value::String(LEDGER_CONTEXT.to_string()),
+            Value::String(self.schema_version.context_url().to_string()),
         );
         obj.insert("entryId".to_string(), Value::String(entry_id.to_string()));
         obj.insert(

--- a/crates/ledger-writer/src/verify.rs
+++ b/crates/ledger-writer/src/verify.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::{hash_line, GENESIS_PREV_HASH, LEDGER_CONTEXT};
+use crate::{hash_line, LedgerSchemaVersion, GENESIS_PREV_HASH, LEDGER_CONTEXT, LEDGER_CONTEXT_V2};
 
 /// Successful verification: chain intact, all entries well-formed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,6 +30,9 @@ pub struct VerifySummary {
     pub root_hash_hex: String,
     pub first_timestamp: Option<DateTime<Utc>>,
     pub last_timestamp: Option<DateTime<Utc>>,
+    /// Schema version detected from the first entry's `@context` URL.
+    /// `None` for an empty ledger.
+    pub schema_version: Option<LedgerSchemaVersion>,
 }
 
 /// Concrete reason the chain is broken. `line` is the 0-indexed line in
@@ -106,6 +109,11 @@ pub fn verify_file<P: AsRef<Path>>(path: P) -> Result<VerifySummary, VerifyError
 
 /// Verify a ledger from any [`BufRead`]. Streams line-by-line; suitable
 /// for very large ledgers without loading everything into memory.
+///
+/// Schema version is detected on line 0 (from the `@context` URL); every
+/// subsequent line must match. Mixing v1 + v2 contexts within one file
+/// returns a [`VerifyBreak::BadContext`] error pointing at the first
+/// non-matching line.
 pub fn verify_reader<R: BufRead>(mut reader: R) -> Result<VerifySummary, VerifyError> {
     let mut line_buf = String::new();
     let mut prev_hash = GENESIS_PREV_HASH;
@@ -113,6 +121,7 @@ pub fn verify_reader<R: BufRead>(mut reader: R) -> Result<VerifySummary, VerifyE
     let mut session_id: Option<String> = None;
     let mut first_ts: Option<DateTime<Utc>> = None;
     let mut last_ts: Option<DateTime<Utc>> = None;
+    let mut detected_version: Option<LedgerSchemaVersion> = None;
 
     loop {
         line_buf.clear();
@@ -133,11 +142,25 @@ pub fn verify_reader<R: BufRead>(mut reader: R) -> Result<VerifySummary, VerifyE
         })?;
 
         let ctx = required_str(&v, "@context", line_idx)?;
-        if ctx != LEDGER_CONTEXT {
-            return Err(VerifyError::Break(VerifyBreak::BadContext {
-                line: line_idx,
-                got: ctx.to_string(),
-            }));
+        let line_version = match ctx {
+            LEDGER_CONTEXT => LedgerSchemaVersion::V1,
+            LEDGER_CONTEXT_V2 => LedgerSchemaVersion::V2,
+            _ => {
+                return Err(VerifyError::Break(VerifyBreak::BadContext {
+                    line: line_idx,
+                    got: ctx.to_string(),
+                }));
+            }
+        };
+        match detected_version {
+            None => detected_version = Some(line_version),
+            Some(pinned) if pinned != line_version => {
+                return Err(VerifyError::Break(VerifyBreak::BadContext {
+                    line: line_idx,
+                    got: ctx.to_string(),
+                }));
+            }
+            _ => {}
         }
 
         let sid = required_str(&v, "sessionId", line_idx)?;
@@ -208,6 +231,7 @@ pub fn verify_reader<R: BufRead>(mut reader: R) -> Result<VerifySummary, VerifyE
         root_hash_hex: hex::encode(prev_hash),
         first_timestamp: first_ts,
         last_timestamp: last_ts,
+        schema_version: detected_version,
     })
 }
 

--- a/crates/ledger-writer/tests/integration.rs
+++ b/crates/ledger-writer/tests/integration.rs
@@ -4,7 +4,9 @@
 
 use std::fs;
 
-use aegis_ledger_writer::{hash_line, Entry, EntryType, Error, LedgerWriter, GENESIS_PREV_HASH};
+use aegis_ledger_writer::{
+    hash_line, Entry, EntryType, Error, LedgerSchemaVersion, LedgerWriter, GENESIS_PREV_HASH,
+};
 use chrono::{TimeZone, Utc};
 use serde_json::{Map, Value};
 use uuid::Uuid;
@@ -27,9 +29,13 @@ fn writes_and_chains_entries_end_to_end() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("session-test.jsonl");
 
-    let mut writer =
-        LedgerWriter::create_with_uuid_generator(&path, "session-test".to_string(), fixed_uuids())
-            .unwrap();
+    let mut writer = LedgerWriter::create_with_uuid_generator(
+        &path,
+        "session-test".to_string(),
+        fixed_uuids(),
+        LedgerSchemaVersion::V1,
+    )
+    .unwrap();
 
     let ts = Utc.with_ymd_and_hms(2026, 4, 27, 22, 0, 0).unwrap();
 
@@ -183,6 +189,7 @@ fn run_fixture() -> [u8; 32] {
         &path,
         "session-fixture".to_string(),
         fixed_uuids(),
+        LedgerSchemaVersion::V1,
     )
     .unwrap();
 

--- a/crates/ledger-writer/tests/verify_integration.rs
+++ b/crates/ledger-writer/tests/verify_integration.rs
@@ -6,8 +6,8 @@ use std::fs;
 use std::io::Write;
 
 use aegis_ledger_writer::{
-    verify_file, verify_reader, Entry, EntryType, LedgerWriter, VerifyBreak, VerifyError,
-    GENESIS_PREV_HASH,
+    verify_file, verify_reader, Entry, EntryType, LedgerSchemaVersion, LedgerWriter, VerifyBreak,
+    VerifyError, GENESIS_PREV_HASH,
 };
 use chrono::{TimeZone, Utc};
 use serde_json::{Map, Value};
@@ -25,9 +25,13 @@ fn fixed_uuids() -> Box<dyn FnMut() -> Uuid + Send> {
 }
 
 fn write_three_entries(path: &std::path::Path) -> [u8; 32] {
-    let mut writer =
-        LedgerWriter::create_with_uuid_generator(path, "session-verify".to_string(), fixed_uuids())
-            .unwrap();
+    let mut writer = LedgerWriter::create_with_uuid_generator(
+        path,
+        "session-verify".to_string(),
+        fixed_uuids(),
+        LedgerSchemaVersion::V1,
+    )
+    .unwrap();
     let ts = Utc.with_ymd_and_hms(2026, 4, 28, 0, 0, 0).unwrap();
     let agent_hash = [0xAAu8; 32];
     for i in 0..3u64 {
@@ -161,6 +165,77 @@ fn detects_invalid_json() {
         err,
         VerifyError::Break(VerifyBreak::InvalidJson { line: 0, .. })
     ));
+}
+
+/// ADR-026 §"Schema-version bump policy" — readers detect the
+/// version on line 0 and pin; any subsequent line carrying a
+/// different `@context` is a chain-break.
+#[test]
+fn mixing_v1_and_v2_contexts_within_one_ledger_is_a_break() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mixed.jsonl");
+    let _ = write_three_entries(&path);
+
+    let v1_url = "https://aegis-node.dev/schemas/ledger/v1";
+    let v2_url = "https://aegis-node.dev/schemas/ledger/v2";
+
+    let original = fs::read_to_string(&path).unwrap();
+    let mut lines: Vec<String> = original.lines().map(|s| s.to_string()).collect();
+    // Swap the second line's @context to v2 — chain integrity stays
+    // intact (we don't touch prevHash because the line bytes change,
+    // which also breaks the hash chain; that's fine — the BadContext
+    // break should fire first because it's checked before prevHash).
+    lines[1] = lines[1].replacen(v1_url, v2_url, 1);
+    let mut f = fs::File::create(&path).unwrap();
+    for line in &lines {
+        f.write_all(line.as_bytes()).unwrap();
+        f.write_all(b"\n").unwrap();
+    }
+    drop(f);
+
+    let err = verify_file(&path).unwrap_err();
+    let break_ = match err {
+        VerifyError::Break(b) => b,
+        other => panic!("expected Break, got {other:?}"),
+    };
+    assert!(
+        matches!(break_, VerifyBreak::BadContext { line: 1, .. }),
+        "expected BadContext at line 1, got {break_:?}"
+    );
+}
+
+/// A v2 ledger verifies clean and reports `schema_version: Some(V2)`
+/// on the summary. Catches plumbing regressions on the verifier's
+/// version-detection path.
+#[test]
+fn v2_ledger_verifies_and_reports_schema_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("v2.jsonl");
+    let mut writer = LedgerWriter::create_with_uuid_generator(
+        &path,
+        "session-v2".to_string(),
+        fixed_uuids(),
+        LedgerSchemaVersion::V2,
+    )
+    .unwrap();
+    let ts = Utc.with_ymd_and_hms(2026, 5, 18, 0, 0, 0).unwrap();
+    let agent_hash = [0xCCu8; 32];
+    let mut p = Map::new();
+    p.insert("idx".to_string(), Value::Number(0.into()));
+    writer
+        .append(Entry {
+            session_id: "session-v2".to_string(),
+            entry_type: EntryType::TurnStart,
+            agent_identity_hash: agent_hash,
+            timestamp: ts,
+            payload: p,
+        })
+        .unwrap();
+    let _ = writer.close().unwrap();
+
+    let summary = verify_file(&path).expect("v2 verifies");
+    assert_eq!(summary.schema_version, Some(LedgerSchemaVersion::V2));
+    assert_eq!(summary.entry_count, 1);
 }
 
 #[test]

--- a/crates/llama-backend/tests/run_turn_real_model.rs
+++ b/crates/llama-backend/tests/run_turn_real_model.rs
@@ -86,6 +86,7 @@ tools: {}
         workload_name: "research".to_string(),
         instance: "inst-001".to_string(),
         ledger_path: dir.path().join("ledger.jsonl"),
+        ledger_schema: None,
     };
     let session = Session::boot(cfg).expect("boot");
     let mut session = session.with_loaded_model(model);

--- a/docs/COMPATIBILITY_CHARTER.md
+++ b/docs/COMPATIBILITY_CHARTER.md
@@ -11,7 +11,7 @@ These artifacts are the **committed API**. Breaking any of them requires a major
 | Surface | Version axis | Current | Compatibility window |
 |---|---|---|---|
 | Permission Manifest | `schemaVersion` field in the manifest itself | `"1"` | Forever, unless superseded by `schemaVersion: "2"` with an explicit migration path |
-| Trajectory Ledger / Access Log | JSON-LD `@context` URI (`https://aegis-node.dev/schemas/ledger/v1#`) | `v1` | Forever for stored ledgers (read compatibility); writers may move to `v2` |
+| Trajectory Ledger / Access Log | JSON-LD `@context` URI (`https://aegis-node.dev/schemas/ledger/v1#` or `…/v2#`) | `v1` (default), `v2` (opt-in per ADR-026) | Forever for stored ledgers (read compatibility); writers may move to `v2`. v1 and v2 are both first-class — see §"Ledger v2 (ADR-026)" below |
 | IPC contract | proto package (`aegis.v1`) | `v1` | Forever for the wire format; new functionality lives in `aegis.v2` |
 | F1–F10 feature contracts | PRD §2 | n/a | The ten security-review questions are the product spec; their answers cannot be silently dropped |
 
@@ -54,6 +54,24 @@ When a breaking change is genuinely required:
 5. Existing v1 artifacts continue to round-trip.
 
 There is no plan to retire `v1` once `v2` ships. Removal would itself be a breaking change against deployed audit evidence.
+
+## Ledger v2 (ADR-026)
+
+[ADR-026](adrs/026-hierarchical-per-turn-ledger-protocol.md) introduces a hierarchical per-turn protocol on top of the v1 chain mechanics. The chain itself (`sequenceNumber`, `prevHash`, SHA-256 walk) is **identical** across versions — only the typed payload set differs.
+
+**Version detection.** Readers detect the version from the `@context` URL on the first entry (`session_start`). Every subsequent line MUST carry the same context URL — mixing v1 and v2 within one ledger file is a chain-break (rejected by `aegis verify` with `VerifyBreak::BadContext`).
+
+**Forward-compat rule for new entry types.** v1 consumers reading a v2 ledger encounter `entryType` values they don't recognize (`turn_start`, `turn_end`, `tool_call`, `tool_result`, `approval_decision`). They MUST skip these entries, advancing `prevHash` accounting through them. This is the same rule v1 already documented for itself; ADR-026 makes it concrete.
+
+**Per-turn entry shape.** v2 brackets each turn with `turn_start` / `turn_end` and emits `tool_call` / `tool_result` pairs (joined by `toolCallId`) for every model-initiated dispatch. Existing v1 entry types (`session_start`, `access`, `violation`, `network_attestation`, `session_end`) keep their shape; v2 may add an optional `turnNumber` field on `access` and `violation` for per-turn aggregation. Consumers that ignore `turnNumber` see no behavior change.
+
+**Default and opt-in.** As of the foundation PR, the writer default remains `v1` for back-compat. v2 is opt-in via `BootConfig::ledger_schema = Some(LedgerSchemaVersion::V2)`. The CLI default will flip to v2 once the deferred follow-ups land:
+
+- Sidecar blob mechanism for tool-result payloads >32 KB (ADR-026 §"Tool-result payload size policy").
+- Cross-language conformance fixtures (Go ↔ Rust) for the new entry kinds.
+- `aegis verify` CLI surface for the per-line schema-version report (the `VerifySummary.schema_version` field is already populated).
+- F8 replay viewer per-turn fold/unfold rendering.
+- `approval_decision` emission tied to F3 grants (the entry kind exists; emission is pending the approval-gate refactor).
 
 ## Storage and replay compatibility
 

--- a/schemas/ledger/v2/context.jsonld
+++ b/schemas/ledger/v2/context.jsonld
@@ -1,0 +1,142 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "aegis": "https://aegis-node.dev/schemas/ledger/v2#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "entryId": "aegis:entryId",
+    "sessionId": "aegis:sessionId",
+    "entryType": "aegis:entryType",
+    "timestamp": {
+      "@id": "aegis:timestamp",
+      "@type": "xsd:dateTime"
+    },
+    "agentIdentityHash": {
+      "@id": "aegis:agentIdentityHash",
+      "@type": "xsd:hexBinary"
+    },
+    "prevHash": {
+      "@id": "aegis:prevHash",
+      "@type": "xsd:hexBinary"
+    },
+    "sequenceNumber": {
+      "@id": "aegis:sequenceNumber",
+      "@type": "xsd:nonNegativeInteger"
+    },
+
+    "reasoningStepId": "aegis:reasoningStepId",
+    "input": "aegis:input",
+    "reasoning": "aegis:reasoning",
+    "toolsConsidered": {
+      "@id": "aegis:toolsConsidered",
+      "@container": "@list"
+    },
+    "toolSelected": "aegis:toolSelected",
+
+    "resourceUri": {
+      "@id": "aegis:resourceUri",
+      "@type": "@id"
+    },
+    "accessType": "aegis:accessType",
+    "bytesAccessed": {
+      "@id": "aegis:bytesAccessed",
+      "@type": "xsd:nonNegativeInteger"
+    },
+
+    "approverId": "aegis:approverId",
+    "actionSummary": "aegis:actionSummary",
+    "decision": "aegis:decision",
+    "decidedAt": {
+      "@id": "aegis:decidedAt",
+      "@type": "xsd:dateTime"
+    },
+    "expiresAt": {
+      "@id": "aegis:expiresAt",
+      "@type": "xsd:dateTime"
+    },
+
+    "violationReason": "aegis:violationReason",
+    "networkConnectionsObserved": {
+      "@id": "aegis:networkConnectionsObserved",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "ledgerRootHash": {
+      "@id": "aegis:ledgerRootHash",
+      "@type": "xsd:hexBinary"
+    },
+
+    "turnNumber": {
+      "@id": "aegis:turnNumber",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "toolCallId": "aegis:toolCallId",
+    "toolName": "aegis:toolName",
+    "toolOrigin": "aegis:toolOrigin",
+    "requestArgsHex": {
+      "@id": "aegis:requestArgsHex",
+      "@type": "xsd:hexBinary"
+    },
+    "resultHashHex": {
+      "@id": "aegis:resultHashHex",
+      "@type": "xsd:hexBinary"
+    },
+    "resultPayload": "aegis:resultPayload",
+    "resultPayloadRef": "aegis:resultPayloadRef",
+
+    "modelDigestHex": {
+      "@id": "aegis:modelDigestHex",
+      "@type": "xsd:hexBinary"
+    },
+    "contextDigestHex": {
+      "@id": "aegis:contextDigestHex",
+      "@type": "xsd:hexBinary"
+    },
+    "seed": {
+      "@id": "aegis:seed",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "temperature": {
+      "@id": "aegis:temperature",
+      "@type": "xsd:double"
+    },
+    "topP": {
+      "@id": "aegis:topP",
+      "@type": "xsd:double"
+    },
+    "topK": {
+      "@id": "aegis:topK",
+      "@type": "xsd:nonNegativeInteger"
+    },
+
+    "tokensIn": {
+      "@id": "aegis:tokensIn",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "tokensOut": {
+      "@id": "aegis:tokensOut",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "tokensCumulative": {
+      "@id": "aegis:tokensCumulative",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "wallclockMsCumulative": {
+      "@id": "aegis:wallclockMsCumulative",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "quotaSnapshots": {
+      "@id": "aegis:quotaSnapshots",
+      "@container": "@list"
+    },
+
+    "grantTtlSeconds": {
+      "@id": "aegis:grantTtlSeconds",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "grantArgHashHex": {
+      "@id": "aegis:grantArgHashHex",
+      "@type": "xsd:hexBinary"
+    },
+    "decidedBy": "aegis:decidedBy"
+  }
+}


### PR DESCRIPTION
Foundation PR for the v2 ledger schema (ADR-026). Builds directly on
[#193](https://github.com/tosin2013/aegis-node/pull/193) (multi-turn loop)
and [#194](https://github.com/tosin2013/aegis-node/pull/194) (adversarial
pre-filter).

Closes the **foundation** scope of #182; explicit follow-ups listed below.

## Summary

- New ledger schema `v2` opt-in via \`BootConfig::ledger_schema\`. Default stays v1 — every existing caller is unchanged.
- \`Session::run\` emits the canonical v2 sequence when the ledger is v2: \`turn_start\` → \`reasoning_step\` → \`tool_call\` / \`tool_result\` pairs (joined by \`toolCallId\`) → \`turn_end\`. Existing F4 \`access\` + F5 \`reasoning_step\` continue unchanged.
- \`aegis verify\` (\`verify_file\` / \`verify_reader\`) detects the version on line 0, pins it, and rejects mixing v1 and v2 within one ledger. \`VerifySummary.schema_version\` is populated.
- Compatibility Charter §\"Ledger v2 (ADR-026)\" documents version detection, forward-compat skip-unknown rule, default + opt-in policy, and the explicit deferred list.

## What ships

- \`schemas/ledger/v2/context.jsonld\` — new JSON-LD context (turnNumber, toolCallId, requestArgsHex, resultHashHex, modelDigestHex, contextDigestHex, tokens{In,Out,Cumulative}, wallclockMsCumulative, quotaSnapshots, grantTtlSeconds, …).
- \`LedgerSchemaVersion::{V1, V2}\` + \`LedgerWriter::create_with_version()\` on \`aegis-ledger-writer\`.
- New \`EntryType\` variants: \`TurnStart\`, \`TurnEnd\`, \`ToolCall\`, \`ToolResult\`, \`ApprovalDecision\`.
- Per-turn emissions wired into \`Session::run\`; \`Session::run_turn\` (single-turn legacy) unchanged.
- 5 new tests: 3 integration (v2 @context stamping, canonical per-turn order, default-emits-v1) + 2 verifier (mixed-version rejection, v2 chain validation).

## Intentionally deferred (tracked in PR body + Compatibility Charter)

These are real follow-ups before the CLI default flips to v2:

1. **Sidecar blob mechanism** for tool-result payloads >32 KB. Writer currently inlines ≤32 KB and writes a \`resultPayloadRef\` placeholder for larger payloads; the actual sidecar file emission is TODO.
2. **\`approval_decision\` emission** tied to F3 grants. Entry type exists in the writer; emission lives inside the approval gate and is a separate refactor.
3. **Cross-language conformance fixtures** (Go ↔ Rust) for the new entry kinds.
4. **\`aegis verify\` CLI surface** for the per-line schema-version report.
5. **F8 replay viewer** per-turn fold/unfold rendering.
6. **\`turnNumber\` on existing \`access\` and \`violation\` entries** for per-turn aggregation in tooling.

## Compatibility

- v1 ledger stream is byte-identical to before this PR. v2 is strict opt-in via \`BootConfig\`.
- \`BootConfig\` gained \`ledger_schema: Option<LedgerSchemaVersion>\` — all 7 test fixtures + 2 CLI boot sites updated to \`None\`.
- \`LedgerWriter::create_with_uuid_generator\` gained a 4th argument (schema_version) — 4 internal callers updated.
- No proto / manifest schema changes.

## Tests / verification

- \`cargo test --workspace --exclude aegis-llama-backend --exclude aegis-litertlm-sys --exclude aegis-litertlm-backend\` → 236 passing (was 231; +5).
- \`cargo clippy --workspace --tests ... -- -D warnings\` clean.
- \`cargo fmt --all -- --check\` clean.

## Test plan

- [ ] CI passes.
- [ ] Maintainer reviews \`schemas/ledger/v2/context.jsonld\` for JSON-LD term definitions.
- [ ] Maintainer confirms the deferred-list captures the right cut for foundation vs. follow-ups.
- [ ] \`docs/COMPATIBILITY_CHARTER.md\` §\"Ledger v2 (ADR-026)\" reviewed for downstream-tooling implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)