### PR TITLE
feat(identity, inference-engine): ADR-030 foundation — per-turn SPIFFE/SVID rebinding (#186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "hex",
  "rcgen",
  "serde",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "time",
@@ -108,6 +109,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 1.0.69",
+ "time",
  "uuid",
 ]
 

--- a/crates/identity/Cargo.toml
+++ b/crates/identity/Cargo.toml
@@ -22,6 +22,7 @@ rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem
 x509-parser = "0.16"
 time = { version = "0.3", features = ["std"] }
 hex = "0.4"
+sha2 = "0.10"
 thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/identity/src/ca.rs
+++ b/crates/identity/src/ca.rs
@@ -25,8 +25,8 @@ use time::{Duration, OffsetDateTime};
 use crate::error::{Error, Result};
 use crate::spiffe::SpiffeId;
 use crate::svid::{
-    Digest, DigestTriple, X509Svid, CHAT_TEMPLATE_BINDING_LEN, CHAT_TEMPLATE_BINDING_OID,
-    DIGEST_BINDING_OID,
+    Digest, DigestTriple, TurnBinding, X509Svid, CHAT_TEMPLATE_BINDING_LEN,
+    CHAT_TEMPLATE_BINDING_OID, DIGEST_BINDING_OID, TURN_BINDING_OID,
 };
 
 const CA_CERT_FILE: &str = "ca.crt";
@@ -215,6 +215,76 @@ impl LocalCa {
         })
     }
 
+    /// Issue a short-lived per-turn SVID (ADR-030). Identical to
+    /// [`Self::issue_svid_with_chat_template`] but additionally:
+    ///
+    /// - Stamps a [`TURN_BINDING_OID`] extension carrying the turn's
+    ///   audience URI (e.g., `aegis-turn://session-xyz/3`). A stolen
+    ///   turn-N SVID can't authenticate dispatches on turn M because
+    ///   the embedded audience won't match.
+    /// - Caps validity at `turn_ttl` (the runtime passes the remaining
+    ///   wallclock budget for the turn, bounded to a sensible minimum).
+    ///   Short-lived by design — defeats long-lived credential theft.
+    ///
+    /// The same `(model, manifest, config)` digest triple is bound as
+    /// on the session SVID, plus the optional chat-template. Verifiers
+    /// see one extra extension; they can detect "this is a turn SVID,
+    /// not a session SVID" by the presence of [`TURN_BINDING_OID`].
+    pub fn issue_turn_svid(
+        &self,
+        workload_name: &str,
+        instance: &str,
+        digests: DigestTriple,
+        chat_template: Option<Digest>,
+        audience: &str,
+        turn_ttl: Duration,
+    ) -> Result<X509Svid> {
+        let spiffe_id = SpiffeId::new(&self.trust_domain, workload_name, instance)?;
+        let now = OffsetDateTime::now_utc();
+
+        let mut params = CertificateParams::default();
+        params.not_before = now - Duration::minutes(5);
+        params.not_after = now + turn_ttl;
+        params
+            .distinguished_name
+            .push(DnType::CommonName, workload_name);
+        params.subject_alt_names = vec![SanType::URI(
+            Ia5String::try_from(spiffe_id.uri())
+                .map_err(|e| Error::CertParse(format!("SPIFFE URI not IA5-encodable: {e}")))?,
+        )];
+
+        let mut ext =
+            CustomExtension::from_oid_content(DIGEST_BINDING_OID, digests.encode().to_vec());
+        ext.set_criticality(false);
+        params.custom_extensions.push(ext);
+
+        if let Some(template) = chat_template {
+            let mut ct_ext =
+                CustomExtension::from_oid_content(CHAT_TEMPLATE_BINDING_OID, template.0.to_vec());
+            ct_ext.set_criticality(false);
+            params.custom_extensions.push(ct_ext);
+        }
+
+        let turn_binding = TurnBinding {
+            audience: audience.to_string(),
+        };
+        let mut turn_ext =
+            CustomExtension::from_oid_content(TURN_BINDING_OID, turn_binding.encode()?);
+        turn_ext.set_criticality(false);
+        params.custom_extensions.push(turn_ext);
+
+        let leaf_key = KeyPair::generate()?;
+        let leaf = params.signed_by(&leaf_key, &self.ca_cert, &self.ca_key)?;
+
+        Ok(X509Svid {
+            spiffe_id,
+            digests,
+            chat_template,
+            cert_pem: leaf.pem(),
+            key_pem: leaf_key.serialize_pem(),
+        })
+    }
+
     /// PEM of the CA root certificate. Useful for trust-bundle distribution.
     pub fn root_cert_pem(&self) -> String {
         self.ca_cert.pem()
@@ -306,6 +376,48 @@ pub fn extract_chat_template_from_pem(cert_pem: &str) -> Result<Option<Digest>> 
             }
             Ok(Some(Digest::from_bytes(ext.value)?))
         }
+        None => Ok(None),
+    }
+}
+
+/// Compute the SHA-256 thumbprint of a leaf cert from its PEM. Used
+/// by the F9 ledger to record which SVID was active during each turn
+/// (per ADR-030) without storing the full PEM in every entry.
+pub fn cert_thumbprint_hex(cert_pem: &str) -> Result<String> {
+    use sha2::{Digest as _, Sha256};
+    use x509_parser::pem::Pem;
+
+    let pem = Pem::iter_from_buffer(cert_pem.as_bytes())
+        .next()
+        .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
+        .map_err(|e| Error::CertParse(e.to_string()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&pem.contents);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Extract the [`TurnBinding`] from a per-turn SVID's PEM. Returns
+/// `Ok(None)` when the cert was not issued via
+/// [`LocalCa::issue_turn_svid`] — i.e., it's a session-long SVID and
+/// the absence of the extension is correct, not an error.
+pub fn extract_turn_binding_from_pem(cert_pem: &str) -> Result<Option<TurnBinding>> {
+    use x509_parser::parse_x509_certificate;
+    use x509_parser::pem::Pem;
+
+    let pem = Pem::iter_from_buffer(cert_pem.as_bytes())
+        .next()
+        .ok_or_else(|| Error::CertParse("no PEM block".to_string()))?
+        .map_err(|e| Error::CertParse(e.to_string()))?;
+    let (_, cert) =
+        parse_x509_certificate(&pem.contents).map_err(|e| Error::CertParse(e.to_string()))?;
+
+    let oid_str = oid_components_to_dotted(TURN_BINDING_OID);
+    match cert
+        .extensions()
+        .iter()
+        .find(|e| e.oid.to_id_string() == oid_str)
+    {
+        Some(ext) => Ok(Some(TurnBinding::decode(ext.value)?)),
         None => Ok(None),
     }
 }

--- a/crates/identity/src/lib.rs
+++ b/crates/identity/src/lib.rs
@@ -24,12 +24,13 @@ pub use binding::{
     verify_chat_template_binding, verify_digest_binding, DigestField, DigestMismatch,
 };
 pub use ca::{
-    extract_chat_template_from_pem, extract_digest_triple_from_pem, extract_spiffe_id_from_pem,
-    LocalCa,
+    cert_thumbprint_hex, extract_chat_template_from_pem, extract_digest_triple_from_pem,
+    extract_spiffe_id_from_pem, extract_turn_binding_from_pem, LocalCa,
 };
 pub use error::{Error, Result};
 pub use spiffe::SpiffeId;
 pub use svid::{
-    Digest, DigestTriple, X509Svid, CHAT_TEMPLATE_BINDING_LEN, CHAT_TEMPLATE_BINDING_OID,
-    DIGEST_BINDING_LEN, DIGEST_BINDING_OID,
+    Digest, DigestTriple, TurnBinding, X509Svid, CHAT_TEMPLATE_BINDING_LEN,
+    CHAT_TEMPLATE_BINDING_OID, DIGEST_BINDING_LEN, DIGEST_BINDING_OID, MAX_TURN_BINDING_LEN,
+    TURN_BINDING_OID,
 };

--- a/crates/identity/src/svid.rs
+++ b/crates/identity/src/svid.rs
@@ -35,6 +35,93 @@ pub const CHAT_TEMPLATE_BINDING_OID: &[u64] = &[1, 3, 6, 1, 4, 1, 99999, 2];
 /// Length of the chat-template-binding extension payload.
 pub const CHAT_TEMPLATE_BINDING_LEN: usize = 32;
 
+/// Aegis private turn-binding OID (ADR-030, F1 extension). Carried as a
+/// non-critical custom extension on per-turn SVIDs issued by
+/// [`crate::LocalCa::issue_turn_svid`]. Records the turn's audience
+/// claim so a stolen SVID from turn N cannot be replayed at turn M:
+/// verifiers reject a cert whose embedded audience disagrees with the
+/// turn the request is bound to.
+///
+/// The extension is **only emitted on per-turn SVIDs**. Session-long
+/// SVIDs ([`crate::LocalCa::issue_svid`] +
+/// [`crate::LocalCa::issue_svid_with_chat_template`]) omit it. A verifier
+/// that sees a TURN_BINDING extension knows the SVID is turn-scoped;
+/// a verifier that sees only DIGEST_BINDING (+ optional CHAT_TEMPLATE)
+/// knows the SVID is session-scoped.
+pub const TURN_BINDING_OID: &[u64] = &[1, 3, 6, 1, 4, 1, 99999, 3];
+
+/// Turn binding wire format inside the [`TURN_BINDING_OID`] extension.
+///
+/// Layout: `[2 bytes big-endian audience length N][N bytes UTF-8 audience]`.
+///
+/// The audience is a stable URI string of the form
+/// `aegis-turn://<session_id>/<turn_number>` (per ADR-030 §"Identity
+/// claim shape"). Length prefix lets future formats append more fields
+/// (turn context-digest, attestation selectors) without breaking
+/// existing parsers — they decode the prefix-bounded audience and stop.
+///
+/// Maximum encoded length is bounded by [`MAX_TURN_BINDING_LEN`] so
+/// the extension stays a fixed size budget; a session ID + small turn
+/// number always fits well inside it.
+pub const MAX_TURN_BINDING_LEN: usize = 2 + 512;
+
+/// Decoded turn-binding extension. `audience` is the freshly-minted
+/// URI for the per-turn SVID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnBinding {
+    pub audience: String,
+}
+
+impl TurnBinding {
+    /// Encode the turn binding into the wire format for the X.509
+    /// extension. Errors if the audience is too long to fit the
+    /// 2-byte length prefix or is empty.
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        let bytes = self.audience.as_bytes();
+        if bytes.is_empty() {
+            return Err(Error::CertParse(
+                "turn binding audience must not be empty".to_string(),
+            ));
+        }
+        if bytes.len() > u16::MAX as usize {
+            return Err(Error::CertParse(format!(
+                "turn binding audience too long: {} bytes",
+                bytes.len()
+            )));
+        }
+        let len = u16::try_from(bytes.len()).map_err(|_| {
+            Error::CertParse("turn binding audience exceeds u16 length".to_string())
+        })?;
+        let mut out = Vec::with_capacity(2 + bytes.len());
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(bytes);
+        Ok(out)
+    }
+
+    /// Decode the wire format. Errors on short input, mismatched
+    /// length prefix, or non-UTF-8 audience bytes.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < 2 {
+            return Err(Error::CertParse(format!(
+                "turn binding truncated: {} bytes",
+                bytes.len()
+            )));
+        }
+        let len = u16::from_be_bytes([bytes[0], bytes[1]]) as usize;
+        if bytes.len() < 2 + len {
+            return Err(Error::CertParse(format!(
+                "turn binding length prefix {} exceeds remaining {} bytes",
+                len,
+                bytes.len() - 2
+            )));
+        }
+        let audience = std::str::from_utf8(&bytes[2..2 + len])
+            .map_err(|e| Error::CertParse(format!("turn binding audience not utf-8: {e}")))?
+            .to_string();
+        Ok(Self { audience })
+    }
+}
+
 /// SHA-256 digest of one bound artifact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Digest(pub [u8; 32]);
@@ -109,4 +196,39 @@ pub struct X509Svid {
     pub chat_template: Option<Digest>,
     pub cert_pem: String,
     pub key_pem: String,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turn_binding_round_trip() {
+        let tb = TurnBinding {
+            audience: "aegis-turn://session-abc/3".to_string(),
+        };
+        let encoded = tb.encode().unwrap();
+        // 2 bytes length prefix + audience body
+        assert_eq!(encoded.len(), 2 + tb.audience.len());
+        let decoded = TurnBinding::decode(&encoded).unwrap();
+        assert_eq!(decoded, tb);
+    }
+
+    #[test]
+    fn turn_binding_rejects_empty_audience() {
+        let tb = TurnBinding {
+            audience: String::new(),
+        };
+        let err = tb.encode().unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn turn_binding_decode_rejects_short_input() {
+        assert!(TurnBinding::decode(&[]).is_err());
+        assert!(TurnBinding::decode(&[0]).is_err());
+        // Length prefix says 10 bytes but only 1 follows.
+        assert!(TurnBinding::decode(&[0, 10, b'x']).is_err());
+    }
 }

--- a/crates/identity/tests/integration.rs
+++ b/crates/identity/tests/integration.rs
@@ -3,9 +3,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use aegis_identity::{
-    extract_chat_template_from_pem, extract_digest_triple_from_pem, extract_spiffe_id_from_pem,
-    verify_chat_template_binding, verify_digest_binding, Digest, DigestField, DigestTriple, Error,
-    LocalCa, SpiffeId,
+    cert_thumbprint_hex, extract_chat_template_from_pem, extract_digest_triple_from_pem,
+    extract_spiffe_id_from_pem, extract_turn_binding_from_pem, verify_chat_template_binding,
+    verify_digest_binding, Digest, DigestField, DigestTriple, Error, LocalCa, SpiffeId,
 };
 
 const TRUST_DOMAIN: &str = "aegis-node.local";
@@ -179,6 +179,63 @@ fn verify_chat_template_binding_signals_drift() {
 }
 
 #[cfg(unix)]
+/// Per-turn SVID issuance round-trip (ADR-030). The cert carries
+/// the TurnBinding extension; `extract_turn_binding_from_pem`
+/// recovers the audience verbatim. Session SVIDs (issued via
+/// `issue_svid`) carry NO turn binding — the extractor returns None
+/// rather than an error.
+#[test]
+fn per_turn_svid_carries_audience_binding() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca = LocalCa::init(dir.path(), TRUST_DOMAIN).unwrap();
+    let digests = test_digests();
+    let audience = "aegis-turn://session-xyz/7";
+
+    let svid = ca
+        .issue_turn_svid(
+            "research",
+            "inst-001",
+            digests,
+            None,
+            audience,
+            time::Duration::seconds(60),
+        )
+        .unwrap();
+
+    let extracted = extract_turn_binding_from_pem(&svid.cert_pem)
+        .unwrap()
+        .expect("per-turn SVID carries turn binding");
+    assert_eq!(extracted.audience, audience);
+
+    // Digest binding still intact alongside the turn binding.
+    let dt = extract_digest_triple_from_pem(&svid.cert_pem).unwrap();
+    assert_eq!(dt, digests);
+
+    // Session SVIDs (no turn binding) → extractor returns None.
+    let session_svid = ca.issue_svid("research", "inst-001", digests).unwrap();
+    assert!(extract_turn_binding_from_pem(&session_svid.cert_pem)
+        .unwrap()
+        .is_none());
+
+    // Thumbprints are 64-char lowercase hex.
+    let tp = cert_thumbprint_hex(&svid.cert_pem).unwrap();
+    assert_eq!(tp.len(), 64);
+    assert!(tp.bytes().all(|b| b.is_ascii_hexdigit()));
+    // Two distinct issuances → distinct thumbprints (fresh key per cert).
+    let svid2 = ca
+        .issue_turn_svid(
+            "research",
+            "inst-001",
+            digests,
+            None,
+            audience,
+            time::Duration::seconds(60),
+        )
+        .unwrap();
+    let tp2 = cert_thumbprint_hex(&svid2.cert_pem).unwrap();
+    assert_ne!(tp, tp2);
+}
+
 #[test]
 fn ca_key_file_has_owner_only_permissions() {
     use std::os::unix::fs::MetadataExt;

--- a/crates/inference-engine/Cargo.toml
+++ b/crates/inference-engine/Cargo.toml
@@ -31,6 +31,12 @@ hmac = "0.12"
 # adversarial pattern matching.
 regex = { version = "1", default-features = false, features = ["std", "perf", "unicode-case", "unicode-perl"] }
 thiserror = "1"
+# `time` ties the per-turn SVID lifetime to the multi-turn loop's
+# wallclock budget (ADR-030). aegis-identity exposes
+# `LocalCa::issue_turn_svid` with a `time::Duration` argument; we
+# re-export the dep here so session.rs can construct it without
+# pulling in the whole `time` API surface.
+time = { version = "0.3", default-features = false, features = ["std"] }
 uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use aegis_approval_gate::ApprovalChannel;
 use aegis_identity::{
     verify_chat_template_binding, verify_digest_binding, Digest, DigestField, DigestTriple,
-    LocalCa, SpiffeId,
+    LocalCa, SpiffeId, X509Svid,
 };
 use aegis_ledger_writer::{Entry, EntryType, LedgerSchemaVersion, LedgerWriter};
 use aegis_mcp_client::McpClient;
@@ -81,6 +81,14 @@ pub struct Session {
     pub(crate) manifest_path: PathBuf,
     pub(crate) model_path: PathBuf,
     pub(crate) config_path: Option<PathBuf>,
+    /// Local CA directory — retained so the multi-turn driver can
+    /// re-load the CA each turn to mint a fresh per-turn SVID
+    /// (ADR-030). The CA is cheap to load (couple of file reads); we
+    /// don't cache it on Session because the load path also surfaces
+    /// any post-boot CA tampering as a typed error.
+    pub(crate) identity_dir: PathBuf,
+    pub(crate) workload_name: String,
+    pub(crate) instance: String,
     /// F3 approval channel — routes `Decision::RequireApproval`. None
     /// means the legacy halt-on-RequireApproval behavior; set via
     /// [`Session::with_approval_channel`] after boot.
@@ -110,6 +118,12 @@ pub struct Session {
     /// tool class otherwise. Reset on each [`Self::boot`] — there is
     /// no cross-session quota state by design.
     pub(crate) aggregate_state: SessionAggregateState,
+    /// Per-turn SVID (ADR-030). Issued at `turn_start` by the
+    /// multi-turn driver; dropped at `turn_end`. `None` outside a turn
+    /// — the session SVID
+    /// ([`Self::svid_cert_pem`] / [`Self::svid_key_pem`]) takes over
+    /// for single-turn paths and mediator calls invoked directly.
+    pub(crate) current_turn_svid: Option<X509Svid>,
 }
 
 /// One observed network-connection attempt + the gate's decision.
@@ -266,12 +280,16 @@ impl Session {
             manifest_path: cfg.manifest_path,
             model_path: cfg.model_path,
             config_path: cfg.config_path,
+            identity_dir: cfg.identity_dir,
+            workload_name: cfg.workload_name,
+            instance: cfg.instance,
             approval_channel: None,
             network_log: Vec::new(),
             mcp_client: None,
             loaded_model: None,
             adversarial_classifier: crate::adversarial::default_classifier(),
             aggregate_state: SessionAggregateState::new(),
+            current_turn_svid: None,
         })
     }
 
@@ -358,17 +376,24 @@ impl Session {
         self.ledger.schema_version()
     }
 
-    /// Write a `turn_start` entry (v2, ADR-026 §"Per-turn entry sequence").
-    /// Records the turn number, the bound model digest, and a SHA-256
-    /// of the canonical-serialized input context so F8 replay can
-    /// detect mid-session context tampering. Caller is responsible for
-    /// only invoking this on v2 ledgers — emitting it on a v1 file
-    /// would taint the chain with an entry type v1 consumers don't
-    /// expect.
+    /// Write a `turn_start` entry (v2, ADR-026 §"Per-turn entry
+    /// sequence" + ADR-030 §"Interaction with the F9 ledger"). Records
+    /// the turn number, the bound model digest, the SHA-256 of the
+    /// canonical-serialized input context, the per-turn SVID's
+    /// thumbprint, and the SVID's audience claim. F8 replay reads
+    /// `contextDigestHex` to detect mid-session context tampering;
+    /// auditors cross-check `svidThumbprintHex` against access entries
+    /// from this turn (cross-check itself is a deferred follow-up).
+    ///
+    /// Caller is responsible for only invoking this on v2 ledgers —
+    /// emitting it on a v1 file would taint the chain with an entry
+    /// type v1 consumers don't expect.
     pub(crate) fn write_turn_start(
         &mut self,
         turn_number: u32,
         context_digest_hex: &str,
+        svid_thumbprint_hex: &str,
+        spiffe_id_aud: &str,
     ) -> Result<()> {
         let mut payload = Map::new();
         payload.insert("turnNumber".to_string(), Value::Number(turn_number.into()));
@@ -380,6 +405,14 @@ impl Session {
             "contextDigestHex".to_string(),
             Value::String(context_digest_hex.to_string()),
         );
+        payload.insert(
+            "svidThumbprintHex".to_string(),
+            Value::String(svid_thumbprint_hex.to_string()),
+        );
+        payload.insert(
+            "spiffeIdAud".to_string(),
+            Value::String(spiffe_id_aud.to_string()),
+        );
         self.ledger.append(Entry {
             session_id: self.session_id.clone(),
             entry_type: EntryType::TurnStart,
@@ -388,6 +421,51 @@ impl Session {
             payload,
         })?;
         Ok(())
+    }
+
+    /// Drop the active per-turn SVID. Called by the multi-turn driver
+    /// at `turn_end` (ADR-030 §"Per-turn rebinding lifecycle"). Memory
+    /// containing the key material falls out of scope; Rust's drop
+    /// semantics handle the zero-out at the `Drop` impl of the
+    /// underlying buffer types. The session-long SVID is unaffected.
+    pub(crate) fn drop_turn_svid(&mut self) {
+        self.current_turn_svid = None;
+    }
+
+    /// Issue a per-turn SVID (ADR-030). Loads the local CA from disk,
+    /// hashes the live digest triple, mints a short-lived SVID with a
+    /// `TURN_BINDING` extension carrying `audience`, stashes it as
+    /// `self.current_turn_svid`, and returns the cert's SHA-256
+    /// thumbprint so the caller can record it in `turn_start` without
+    /// re-borrowing `self`. The session-long SVID
+    /// ([`Self::cert_pem`]) remains in place for dispatch paths
+    /// outside the multi-turn loop.
+    ///
+    /// TTL caps at 60s + the remaining wallclock budget for the
+    /// session so the per-turn SVID can never outlive the loop that
+    /// issued it. Bounded to ≥60s so a near-empty budget still mints
+    /// a usable cert.
+    pub(crate) fn issue_turn_svid(
+        &mut self,
+        audience: &str,
+        wallclock_remaining_seconds: u64,
+    ) -> Result<String> {
+        let ttl_secs = wallclock_remaining_seconds.saturating_add(60).max(60);
+        let ttl = time::Duration::seconds(i64::try_from(ttl_secs).unwrap_or(i64::MAX));
+
+        let live_digests = self.compute_live_digests()?;
+        let ca = LocalCa::load(&self.identity_dir)?;
+        let svid = ca.issue_turn_svid(
+            &self.workload_name,
+            &self.instance,
+            live_digests,
+            self.bound_chat_template,
+            audience,
+            ttl,
+        )?;
+        let thumbprint = aegis_identity::cert_thumbprint_hex(&svid.cert_pem)?;
+        self.current_turn_svid = Some(svid);
+        Ok(thumbprint)
     }
 
     /// Write a `turn_end` entry (v2). Closes a turn with cumulative

--- a/crates/inference-engine/src/turn.rs
+++ b/crates/inference-engine/src/turn.rs
@@ -303,10 +303,17 @@ impl Session {
             // v2 turn_start lands *before* `run_one_turn` so the
             // reasoning_step + tool_call/tool_result entries the inner
             // dispatch emits all parent-by-position to this turn_start
-            // in the ledger stream.
+            // in the ledger stream. ADR-030: mint the per-turn SVID
+            // here so the audience + thumbprint can be recorded in the
+            // turn_start payload; the SVID is dropped at turn_end.
             if v2 {
                 let ctx_hex = sha256_hex_of_messages(&messages);
-                self.write_turn_start(turn_index, &ctx_hex)?;
+                let audience = format!("aegis-turn://{}/{}", self.session_id(), turn_index);
+                let remaining = limits
+                    .max_seconds
+                    .saturating_sub(started.elapsed().as_secs());
+                let thumbprint = self.issue_turn_svid(&audience, remaining)?;
+                self.write_turn_start(turn_index, &ctx_hex, &thumbprint, &audience)?;
             }
 
             let (mut outcome, used) = self.run_one_turn(&messages, prompt, Some(turn_index))?;
@@ -395,10 +402,12 @@ impl Session {
             // emissions, before the loop control decides whether to
             // re-enter. On clean termination we return *after*
             // emitting turn_end so the ledger always brackets the
-            // final turn.
+            // final turn. ADR-030: drop the per-turn SVID — it lives
+            // only for the duration of the turn that issued it.
             if v2 {
                 let wallclock_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
                 self.write_turn_end(turn_index, None, used, tokens_consumed, wallclock_ms)?;
+                self.drop_turn_svid();
             }
 
             if no_tool_calls {

--- a/crates/inference-engine/tests/per_turn_svid.rs
+++ b/crates/inference-engine/tests/per_turn_svid.rs
@@ -1,0 +1,230 @@
+//! Integration tests for the per-turn SVID rebinding lifecycle
+//! (ADR-030, issue #186). Drives the multi-turn loop with a v2
+//! ledger and asserts each `turn_start` entry carries a fresh,
+//! distinct SVID thumbprint plus a correctly-shaped audience claim.
+//!
+//! The TurnBinding extension itself is unit-tested in
+//! `crates/identity/src/svid.rs`. These tests confirm wiring is
+//! correct end-to-end: the multi-turn driver actually mints + drops
+//! per-turn SVIDs and writes their identities into the ledger where
+//! auditors will look.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use aegis_identity::LocalCa;
+use aegis_inference_engine::{
+    BackendError, BootConfig, InferRequest, InferResponse, LoadedModel, Session, ToolCall,
+    TurnLimits,
+};
+use aegis_ledger_writer::LedgerSchemaVersion;
+use serde_json::Value;
+
+const TRUST_DOMAIN: &str = "per-turn-svid-test.local";
+
+struct MockLoadedModel {
+    queue: Arc<Mutex<Vec<InferResponse>>>,
+}
+impl MockLoadedModel {
+    fn new(rs: Vec<InferResponse>) -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(rs)),
+        }
+    }
+}
+impl LoadedModel for MockLoadedModel {
+    fn infer(&mut self, _r: InferRequest) -> Result<InferResponse, BackendError> {
+        Ok(self.queue.lock().unwrap().remove(0))
+    }
+}
+
+fn boot_v2(dir: &Path, ca_dir: &Path) -> (Session, PathBuf) {
+    LocalCa::init(ca_dir, TRUST_DOMAIN).unwrap();
+    let manifest_path = dir.join("manifest.yaml");
+    let model_path = dir.join("model.gguf");
+    let ledger_path = dir.join("ledger.jsonl");
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "svid-test", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://per-turn-svid-test.local/agent/loop/inst-001" }}
+tools:
+  filesystem:
+    read: ["{}"]
+"#,
+        dir.display()
+    );
+    std::fs::write(&manifest_path, yaml).unwrap();
+    std::fs::write(&model_path, b"fake-model-bytes").unwrap();
+    let cfg = BootConfig {
+        session_id: "session-svid".to_string(),
+        manifest_path,
+        model_path,
+        config_path: None,
+        chat_template_sidecar: None,
+        identity_dir: ca_dir.to_path_buf(),
+        workload_name: "loop".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path: ledger_path.clone(),
+        ledger_schema: Some(LedgerSchemaVersion::V2),
+    };
+    (Session::boot(cfg).unwrap(), ledger_path)
+}
+
+fn read_entries(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("valid json"))
+        .collect()
+}
+
+fn read_call_response(path: &str) -> InferResponse {
+    InferResponse {
+        reasoning: format!("reading {path}"),
+        tool_calls: vec![ToolCall {
+            name: "filesystem__read".to_string(),
+            arguments: serde_json::json!({"path": path}),
+        }],
+        assistant_text: None,
+        tokens_used: None,
+    }
+}
+
+fn final_text_response(text: &str) -> InferResponse {
+    InferResponse {
+        reasoning: text.to_string(),
+        tool_calls: vec![],
+        assistant_text: Some(text.to_string()),
+        tokens_used: None,
+    }
+}
+
+/// Two turns produce two distinct `turn_start` entries with distinct
+/// `svidThumbprintHex` values — proving per-turn rebinding actually
+/// minted two separate SVIDs (not just recorded the same one twice).
+#[test]
+fn two_turn_session_emits_two_distinct_svid_thumbprints() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("note.txt");
+    std::fs::write(&target, b"hi").unwrap();
+    let target_str = target.to_string_lossy().to_string();
+
+    let (session, ledger_path) = boot_v2(dir.path(), ca_dir.path());
+    let mock = MockLoadedModel::new(vec![
+        read_call_response(&target_str),
+        final_text_response("done"),
+    ]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+    session
+        .run("two turns please", TurnLimits::default())
+        .unwrap();
+    let _ = session.shutdown();
+
+    let entries = read_entries(&ledger_path);
+    let starts: Vec<&Value> = entries
+        .iter()
+        .filter(|e| e["entryType"] == "turn_start")
+        .collect();
+    assert_eq!(starts.len(), 2, "two turns means two turn_start entries");
+
+    let tp0 = starts[0]["svidThumbprintHex"].as_str().unwrap();
+    let tp1 = starts[1]["svidThumbprintHex"].as_str().unwrap();
+    assert_eq!(tp0.len(), 64, "sha256 hex");
+    assert!(tp0.bytes().all(|b| b.is_ascii_hexdigit()));
+    assert_ne!(tp0, tp1, "each turn mints a fresh SVID");
+}
+
+/// Audience claim format matches `aegis-turn://<session>/<turn>` and
+/// pins to the correct turn number on each entry.
+#[test]
+fn audience_claim_format_matches_adr_030() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("a.txt");
+    std::fs::write(&target, b"x").unwrap();
+    let target_str = target.to_string_lossy().to_string();
+
+    let (session, ledger_path) = boot_v2(dir.path(), ca_dir.path());
+    let mock = MockLoadedModel::new(vec![
+        read_call_response(&target_str),
+        final_text_response("ok"),
+    ]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+    session.run("aud check", TurnLimits::default()).unwrap();
+    let _ = session.shutdown();
+
+    let entries = read_entries(&ledger_path);
+    let starts: Vec<&Value> = entries
+        .iter()
+        .filter(|e| e["entryType"] == "turn_start")
+        .collect();
+
+    assert_eq!(
+        starts[0]["spiffeIdAud"].as_str().unwrap(),
+        "aegis-turn://session-svid/1"
+    );
+    assert_eq!(
+        starts[1]["spiffeIdAud"].as_str().unwrap(),
+        "aegis-turn://session-svid/2"
+    );
+}
+
+/// v1 ledger doesn't carry the new fields — `turn_start` entries
+/// aren't emitted at all on v1, so `svidThumbprintHex` and
+/// `spiffeIdAud` never surface there. Pins the back-compat promise.
+#[test]
+fn v1_ledger_does_not_emit_svid_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    LocalCa::init(ca_dir.path(), TRUST_DOMAIN).unwrap();
+
+    let manifest_path = dir.path().join("manifest.yaml");
+    let model_path = dir.path().join("model.gguf");
+    let ledger_path = dir.path().join("ledger.jsonl");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"schemaVersion: "1"
+agent: {{ name: "svid-v1", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://per-turn-svid-test.local/agent/loop/inst-001" }}
+tools:
+  filesystem:
+    read: ["{}"]
+"#,
+            dir.path().display()
+        ),
+    )
+    .unwrap();
+    std::fs::write(&model_path, b"fake-model-bytes").unwrap();
+
+    let cfg = BootConfig {
+        session_id: "session-v1-svid".to_string(),
+        manifest_path,
+        model_path,
+        config_path: None,
+        chat_template_sidecar: None,
+        identity_dir: ca_dir.path().to_path_buf(),
+        workload_name: "loop".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path: ledger_path.clone(),
+        ledger_schema: None, // v1 default
+    };
+    let session = Session::boot(cfg).unwrap();
+    let mock = MockLoadedModel::new(vec![final_text_response("hi")]);
+    let mut session = session.with_loaded_model(Box::new(mock));
+    session.run("v1 check", TurnLimits::default()).unwrap();
+    let _ = session.shutdown();
+
+    let entries = read_entries(&ledger_path);
+    for e in &entries {
+        assert_ne!(e["entryType"], "turn_start", "no turn_start on v1");
+        assert!(
+            e.get("svidThumbprintHex").is_none(),
+            "no per-turn SVID metadata on v1 entries: {e:?}"
+        );
+    }
+}

--- a/docs/COMPATIBILITY_CHARTER.md
+++ b/docs/COMPATIBILITY_CHARTER.md
@@ -55,6 +55,28 @@ When a breaking change is genuinely required:
 
 There is no plan to retire `v1` once `v2` ships. Removal would itself be a breaking change against deployed audit evidence.
 
+## Per-turn workload attestation (ADR-030)
+
+[ADR-030](adrs/030-per-turn-spiffe-mtls-attestation.md) introduces fresh, short-lived SVIDs at every turn boundary in the multi-turn loop. The session-long SVID minted at `Session::boot` is **unchanged** — it still binds the agent's identity for non-turn paths (single-turn `run_turn`, mediator calls outside the loop).
+
+**Per-turn SVID lifecycle.** `Session::run` issues a turn SVID at `turn_start`, stashes it as `current_turn_svid`, and drops it at `turn_end`. Each per-turn SVID carries:
+
+- the bound `(model, manifest, config)` digest triple (unchanged from session SVIDs),
+- the optional chat-template digest (unchanged),
+- a NEW `TURN_BINDING` custom extension (OID `1.3.6.1.4.1.99999.3`) carrying a 2-byte-length-prefixed UTF-8 audience string of the form `aegis-turn://<session_id>/<turn_number>`.
+
+A verifier seeing the `TURN_BINDING` extension knows the SVID is turn-scoped; absence means it's a session SVID. v1 ledger consumers that don't parse the extension at all see a regular SVID with one extra non-critical extension — TLS libraries pass it through cleanly.
+
+**Audience replay protection.** A stolen turn-N SVID cannot be replayed at turn M because the embedded audience disagrees. Foundation PR records the audience + thumbprint in `turn_start.spiffeIdAud` and `turn_start.svidThumbprintHex`; the dispatch-side cross-check ("every access entry's signing SVID matches the active turn's SVID") is a deferred follow-up.
+
+**Foundation PR scope.** Per-turn SVID issuance with the TurnBinding extension; ledger `turn_start` carries `svidThumbprintHex` + `spiffeIdAud`. Deferred follow-ups:
+
+- The <50 ms latency benchmark + HKDF-derived fallback if attestation runs slow (ADR-030 §"Latency budget").
+- MCP-over-network mTLS transport adoption of the per-turn SVID (ADR-022 dependency).
+- `aegis verify` cross-check of access entries' signing SVID against their turn-bracket SVID.
+- Process-attestation selector expansion (`process:binary_digest`, etc.).
+- ADR-029 approval-channel cross-binding (resume must re-attest before next turn).
+
 ## Aggregate quotas (ADR-027)
 
 [ADR-027](adrs/027-aggregate-quota-schema.md) extends the F2 Permission Manifest with optional `tools.<class>.quota` blocks. The schema bump is **non-breaking**: every existing manifest stays valid because `quota` is an optional sub-object on each tool class.


### PR DESCRIPTION
Foundation PR for ADR-030 per-turn workload attestation. Builds on the multi-turn loop (#193) and the v2 ledger \`turn_start\` payload (#195).

## Summary

- New TURN_BINDING X.509 extension (OID \`1.3.6.1.4.1.99999.3\`) carrying a 2-byte-length-prefixed UTF-8 audience string of the form \`aegis-turn://<session_id>/<turn_number>\`.
- \`LocalCa::issue_turn_svid()\` mints short-lived per-turn SVIDs with the binding extension. TTL = remaining wallclock + 60s capped ≥60s.
- \`Session::run\` issues a fresh SVID at every \`turn_start\`, records its thumbprint + audience in the ledger (new v2 \`turn_start\` fields: \`svidThumbprintHex\`, \`spiffeIdAud\`), drops it at \`turn_end\`. Session-long SVID unchanged for non-turn paths.
- A stolen turn-N SVID cannot be replayed at turn M because the embedded audience disagrees. Foundation records the audience + thumbprint; the dispatch-side cross-check is a deferred follow-up.

## Tests

- 3 unit tests for TurnBinding encode/decode.
- 1 integration test for the cert round-trip (issue → parse → extract; session SVIDs have no turn binding; thumbprints distinct per issuance).
- 3 integration tests for end-to-end behaviour (two distinct thumbprints across turns; audience format \`aegis-turn://session/N\`; v1 ledger doesn't emit the new fields).
- 252 workspace tests passing (was 245; +7).
- Clippy clean, fmt clean.

## Intentionally deferred (also in Compatibility Charter §\"Per-turn workload attestation\")

1. **<50ms per-turn rebind latency benchmark** + HKDF-derived fallback path if attestation runs slow (ADR-030 §\"Latency budget\").
2. **MCP-over-network mTLS adoption** of the per-turn SVID — depends on ADR-022 trust-boundary work.
3. **\`aegis verify\` cross-check** of access entries' signing SVID against the active turn's SVID. Foundation records the SVID in \`turn_start\` only; threading it into every access entry is a separate refactor.
4. **Process-attestation selector expansion** (\`process:binary_digest\`, etc.) — today's local CA is a static issuer, not an attestor.
5. **ADR-029 cross-binding** for approval-channel pause/resume — resume must re-attest before next turn fires. Tracked as implementation note for ADR-029.

## Compatibility

- Session SVIDs (\`LocalCa::issue_svid\`) unchanged on the wire. Pre-existing SVIDs continue to work.
- TURN_BINDING extension is **only present on per-turn SVIDs**. Non-critical; rustls / webpki accept it. Verifiers that don't parse it see a regular SVID with one extra extension.
- v1 ledger emission unchanged. v2 \`turn_start\` gains \`svidThumbprintHex\` + \`spiffeIdAud\` — additive, no consumer needs to know about them to keep parsing v2.
- No proto changes.

## Test plan

- [ ] CI green.
- [ ] Maintainer reviews TurnBinding wire format — the 2-byte length prefix is a contract that lets future iterations append more fields (turn context-digest, attestation selectors) without breaking existing parsers.
- [ ] Maintainer reviews TTL logic (remaining wallclock + 60s capped ≥60s) — keeps the per-turn SVID from outliving the loop that issued it but allows for graceful expiry inside a turn.
- [ ] Maintainer confirms the deferred-list captures the right cut for foundation vs. full ADR-030 compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)