### PR TITLE
feat(approval-gate, policy, inference-engine): ADR-029 foundation — task-scoped approval grants (#185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tiny_http",

--- a/crates/approval-gate/Cargo.toml
+++ b/crates/approval-gate/Cargo.toml
@@ -26,7 +26,10 @@ x509-parser = "0.16"
 tiny_http = "0.12"
 rand = "0.8"
 hex = "0.4"
-uuid = { version = "1", features = ["v7"] }
+# ADR-029 task-scoped grant table — sha256(canonical args) is the
+# binding that lets identical retries auto-consume without re-prompting.
+sha2 = "0.10"
+uuid = { version = "1", features = ["v7", "serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/approval-gate/src/grants.rs
+++ b/crates/approval-gate/src/grants.rs
@@ -1,0 +1,288 @@
+//! Task-scoped ephemeral approval grants (ADR-029).
+//!
+//! When an operator approves a tool dispatch via the F3 gate, the
+//! runtime issues an `ApprovalGrant` bound to the **exact**
+//! `(tool_name, sha256(canonical_args))` tuple for a TTL. Identical
+//! retries within that window auto-consume the grant without
+//! re-prompting — the auditor's view is "one approval, N identical
+//! calls" rather than "approval fatigue from N prompts."
+//!
+//! Argument drift voids the match: `database.execute("UPDATE users
+//! SET tier='gold' WHERE id=42")` and the same SQL without the WHERE
+//! clause hash differently, so the second call surfaces a fresh
+//! prompt.
+//!
+//! ## Scope (foundation PR)
+//!
+//! - Auto-consume on identical `(tool_name, arg_hash)` within TTL.
+//! - Grants vaporize at session end (in-memory only, per ADR-029
+//!   §"Grant token shape").
+//! - `Decision::Allow` and `Decision::Deny` grants both recognized;
+//!   denied grants short-circuit subsequent identical retries with
+//!   the original deny reason.
+//!
+//! ## Deferred (called out in PR body)
+//!
+//! - Cryptographic signature over the grant (ADR-029's `signature` field).
+//!   Foundation stores the grant in-memory only; signing is needed
+//!   when grants persist across processes (pause/resume work).
+//! - Grant revocation (`aegis revoke <session-id> <grant-id>`).
+//! - F8 replay viewer rendering of grant lineage.
+
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+/// One approval grant in the in-memory session grant table. Carries
+/// enough state to reproduce the approval decision on every
+/// auto-consume — both the bound tuple and the decision payload (so
+/// denied grants short-circuit identical retries without re-asking).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApprovalGrant {
+    /// UUIDv7 — referenced from `approval_decision` ledger entries
+    /// (`source_grant` field) so auditors can correlate the original
+    /// prompt with every retry it covered.
+    pub grant_id: Uuid,
+    /// Wallclock at which the operator decided. TTL accounting uses
+    /// this anchor; replays of the ledger reconstruct the same
+    /// decision history.
+    pub issued_at: SystemTime,
+    /// How long the grant remains valid. Configurable per tool class
+    /// via the manifest (ADR-029 §"Risk-tiered approval scopes").
+    pub ttl: Duration,
+    /// Bound tool name in `<namespace>__<tool>` form, exactly as the
+    /// model emitted it. Argument drift on retries is caught by the
+    /// `arg_hash` field; tool drift is caught here.
+    pub bound_tool_name: String,
+    /// SHA-256 of the canonical-JSON serialization of the args the
+    /// model passed at the time of the original prompt. Auto-consume
+    /// requires an exact match; any drift forces a fresh prompt.
+    pub bound_arg_hash: [u8; 32],
+    /// What the operator (or policy) decided.
+    pub decision: GrantDecision,
+}
+
+/// Decision payload on a grant. Mirrors `Decision::Allow` /
+/// `Decision::Deny` from `aegis-policy` but kept local to the
+/// approval-gate crate to avoid a circular dependency.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum GrantDecision {
+    /// Operator (or policy tier) approved the action. Identical
+    /// retries within TTL dispatch silently.
+    Allow,
+    /// Operator (or policy tier) rejected the action. Identical
+    /// retries within TTL short-circuit with the cached reason rather
+    /// than re-asking — defends against "ask until you get a yes."
+    Deny { reason: String },
+}
+
+impl ApprovalGrant {
+    /// Build an `Allow` grant for `(tool_name, args)` valid for `ttl`
+    /// from now. Computes the canonical arg hash internally.
+    pub fn allow(tool_name: impl Into<String>, args: &serde_json::Value, ttl: Duration) -> Self {
+        Self {
+            grant_id: Uuid::now_v7(),
+            issued_at: SystemTime::now(),
+            ttl,
+            bound_tool_name: tool_name.into(),
+            bound_arg_hash: canonical_arg_hash(args),
+            decision: GrantDecision::Allow,
+        }
+    }
+
+    /// Build a `Deny` grant. Useful when an operator explicitly
+    /// rejects — subsequent identical retries within TTL are
+    /// short-circuited without re-asking.
+    pub fn deny(
+        tool_name: impl Into<String>,
+        args: &serde_json::Value,
+        ttl: Duration,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            grant_id: Uuid::now_v7(),
+            issued_at: SystemTime::now(),
+            ttl,
+            bound_tool_name: tool_name.into(),
+            bound_arg_hash: canonical_arg_hash(args),
+            decision: GrantDecision::Deny {
+                reason: reason.into(),
+            },
+        }
+    }
+
+    /// `true` when `now < issued_at + ttl`. Wallclock-anchored — a
+    /// hung process or paused session won't extend the grant's life.
+    pub fn is_live_at(&self, now: SystemTime) -> bool {
+        match now.duration_since(self.issued_at) {
+            Ok(elapsed) => elapsed < self.ttl,
+            Err(_) => true, // clock went backward; treat as still-fresh
+        }
+    }
+
+    /// Hex-encoded arg hash for ledger emission convenience.
+    pub fn arg_hash_hex(&self) -> String {
+        hex::encode(self.bound_arg_hash)
+    }
+}
+
+/// SHA-256 of the canonical JSON serialization of `args`. Since
+/// `serde_json::Map` is `BTreeMap`-backed (the workspace does not enable
+/// `preserve_order`), `serde_json::to_string` produces sorted-keys
+/// no-whitespace output — byte-deterministic across runs and across
+/// reimplementations of the hash in other languages.
+pub fn canonical_arg_hash(args: &serde_json::Value) -> [u8; 32] {
+    let canonical = serde_json::to_string(args).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&hasher.finalize());
+    out
+}
+
+/// Session-scoped grant table. Keyed by `(tool_name, arg_hash)` so a
+/// lookup is O(1) and only requires hashing the incoming args once.
+/// Reset on session start; grants vaporize when the session ends.
+#[derive(Debug, Default)]
+pub struct SessionGrantTable {
+    grants: HashMap<(String, [u8; 32]), ApprovalGrant>,
+}
+
+impl SessionGrantTable {
+    pub fn new() -> Self {
+        Self {
+            grants: HashMap::new(),
+        }
+    }
+
+    /// Look up a live grant for `(tool_name, args)`. Returns
+    /// `Some(&ApprovalGrant)` only when a grant exists AND its TTL is
+    /// not yet exhausted at `now`. Expired grants are left in the
+    /// table for the next [`Self::insert`] to overwrite — pruning
+    /// during lookup would require `&mut self`, and that's friction
+    /// the mediator doesn't need.
+    pub fn lookup(
+        &self,
+        tool_name: &str,
+        args: &serde_json::Value,
+        now: SystemTime,
+    ) -> Option<&ApprovalGrant> {
+        let key = (tool_name.to_string(), canonical_arg_hash(args));
+        self.grants.get(&key).filter(|g| g.is_live_at(now))
+    }
+
+    /// Store a freshly-issued grant. Overwrites any prior grant for
+    /// the same `(tool_name, arg_hash)` — a subsequent operator
+    /// decision supersedes a stale one in the same window.
+    pub fn insert(&mut self, grant: ApprovalGrant) {
+        let key = (grant.bound_tool_name.clone(), grant.bound_arg_hash);
+        self.grants.insert(key, grant);
+    }
+
+    /// Number of grants currently in the table. Used by tests and
+    /// future `aegis ledger inspect` tooling.
+    pub fn len(&self) -> usize {
+        self.grants.len()
+    }
+
+    /// Whether the table holds zero grants.
+    pub fn is_empty(&self) -> bool {
+        self.grants.is_empty()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn canonical_hash_stable_across_key_orders() {
+        // serde_json::Map is BTreeMap-backed, so re-orderings of input
+        // keys produce identical canonical JSON.
+        let a = serde_json::json!({"path": "/tmp/a", "bytes": 4});
+        let b = serde_json::json!({"bytes": 4, "path": "/tmp/a"});
+        assert_eq!(canonical_arg_hash(&a), canonical_arg_hash(&b));
+    }
+
+    #[test]
+    fn arg_drift_changes_hash() {
+        let a = serde_json::json!({"path": "/tmp/a"});
+        let b = serde_json::json!({"path": "/tmp/b"});
+        assert_ne!(canonical_arg_hash(&a), canonical_arg_hash(&b));
+    }
+
+    #[test]
+    fn lookup_returns_live_grant() {
+        let mut t = SessionGrantTable::new();
+        let args = serde_json::json!({"path": "/tmp/x"});
+        let grant = ApprovalGrant::allow("filesystem__read", &args, Duration::from_secs(60));
+        t.insert(grant);
+
+        let now = SystemTime::now();
+        let hit = t.lookup("filesystem__read", &args, now);
+        assert!(hit.is_some(), "live grant should be returned");
+        assert!(matches!(hit.unwrap().decision, GrantDecision::Allow));
+    }
+
+    #[test]
+    fn lookup_misses_on_arg_drift() {
+        let mut t = SessionGrantTable::new();
+        let args = serde_json::json!({"path": "/tmp/x"});
+        t.insert(ApprovalGrant::allow(
+            "filesystem__read",
+            &args,
+            Duration::from_secs(60),
+        ));
+        let drifted = serde_json::json!({"path": "/tmp/y"});
+        assert!(t
+            .lookup("filesystem__read", &drifted, SystemTime::now())
+            .is_none());
+    }
+
+    #[test]
+    fn lookup_misses_on_tool_drift() {
+        let mut t = SessionGrantTable::new();
+        let args = serde_json::json!({"path": "/tmp/x"});
+        t.insert(ApprovalGrant::allow(
+            "filesystem__read",
+            &args,
+            Duration::from_secs(60),
+        ));
+        assert!(t
+            .lookup("filesystem__write", &args, SystemTime::now())
+            .is_none());
+    }
+
+    #[test]
+    fn expired_grant_is_not_returned() {
+        let mut t = SessionGrantTable::new();
+        let args = serde_json::json!({"path": "/tmp/x"});
+        let mut grant = ApprovalGrant::allow("filesystem__read", &args, Duration::from_millis(1));
+        // Backdate so the grant is already expired.
+        grant.issued_at = SystemTime::now() - Duration::from_secs(60);
+        t.insert(grant);
+
+        let now = SystemTime::now();
+        assert!(t.lookup("filesystem__read", &args, now).is_none());
+    }
+
+    #[test]
+    fn deny_grant_short_circuits_with_reason() {
+        let args = serde_json::json!({"program": "rm"});
+        let grant = ApprovalGrant::deny(
+            "exec__run",
+            &args,
+            Duration::from_secs(60),
+            "operator declined",
+        );
+        match &grant.decision {
+            GrantDecision::Deny { reason } => assert_eq!(reason, "operator declined"),
+            _ => panic!("expected Deny"),
+        }
+    }
+}

--- a/crates/approval-gate/src/lib.rs
+++ b/crates/approval-gate/src/lib.rs
@@ -20,11 +20,13 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub mod file;
+pub mod grants;
 pub mod mtls;
 pub mod tty;
 pub mod web;
 
 pub use file::FileApprovalChannel;
+pub use grants::{canonical_arg_hash, ApprovalGrant, GrantDecision, SessionGrantTable};
 pub use mtls::MtlsApprovalChannel;
 pub use tty::TtyApprovalChannel;
 pub use web::WebApprovalChannel;

--- a/crates/inference-engine/src/mediator.rs
+++ b/crates/inference-engine/src/mediator.rs
@@ -25,14 +25,18 @@ use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Command, Output};
 
+use std::time::{Duration, SystemTime};
+
 use aegis_access_log::{
     emit_access, emit_reasoning_step, AccessEvent, AccessType, ReasoningStepEvent,
 };
-use aegis_approval_gate::{ApprovalOutcome, ApprovalRequest, DEFAULT_TIMEOUT};
+use aegis_approval_gate::{
+    ApprovalGrant, ApprovalOutcome, ApprovalRequest, GrantDecision, DEFAULT_TIMEOUT,
+};
 use aegis_ledger_writer::{Entry, EntryType};
 use aegis_policy::{
     check_identity_binding,
-    manifest::{PreValidateClause, PreValidateKind},
+    manifest::{ApprovalPolicy, ApprovalTier, PreValidateClause, PreValidateKind},
     Decision, NetworkProto, ToolClass,
 };
 use chrono::Utc;
@@ -82,8 +86,16 @@ impl Session {
         self.rebind()?;
         let decision = self.policy().check_filesystem_read(path);
         let resource_uri = file_uri(path);
-        let decision =
-            self.route_through_approval(decision, &resource_uri, "read", reasoning_step_id)?;
+        let canonical_args = serde_json::json!({"path": path.display().to_string()});
+        let decision = self.route_through_approval(
+            decision,
+            &resource_uri,
+            "read",
+            reasoning_step_id,
+            ToolClass::Filesystem,
+            "filesystem__read",
+            &canonical_args,
+        )?;
         match decision {
             Decision::Allow => {
                 self.enforce_aggregate_quota(ToolClass::Filesystem, &resource_uri, "read")?;
@@ -118,8 +130,29 @@ impl Session {
             .policy()
             .check_filesystem_write(path, now, session_start);
         let resource_uri = file_uri(path);
-        let decision =
-            self.route_through_approval(decision, &resource_uri, "write", reasoning_step_id)?;
+        // Hash contents into the canonical arg signature so write
+        // grants don't auto-consume across changed bodies — same path
+        // + same bytes is the same operation; same path + new bytes
+        // is a fresh prompt.
+        let contents_hex = hex::encode({
+            use sha2::{Digest as _, Sha256};
+            let mut h = Sha256::new();
+            h.update(contents);
+            h.finalize()
+        });
+        let canonical_args = serde_json::json!({
+            "path": path.display().to_string(),
+            "contentsSha256": contents_hex,
+        });
+        let decision = self.route_through_approval(
+            decision,
+            &resource_uri,
+            "write",
+            reasoning_step_id,
+            ToolClass::Filesystem,
+            "filesystem__write",
+            &canonical_args,
+        )?;
         match decision {
             Decision::Allow => {
                 self.enforce_aggregate_quota(ToolClass::Filesystem, &resource_uri, "write")?;
@@ -153,8 +186,16 @@ impl Session {
             .policy()
             .check_filesystem_delete(path, now, session_start);
         let resource_uri = file_uri(path);
-        let decision =
-            self.route_through_approval(decision, &resource_uri, "delete", reasoning_step_id)?;
+        let canonical_args = serde_json::json!({"path": path.display().to_string()});
+        let decision = self.route_through_approval(
+            decision,
+            &resource_uri,
+            "delete",
+            reasoning_step_id,
+            ToolClass::Filesystem,
+            "filesystem__delete",
+            &canonical_args,
+        )?;
         match decision {
             Decision::Allow => {
                 self.enforce_aggregate_quota(ToolClass::Filesystem, &resource_uri, "delete")?;
@@ -186,18 +227,26 @@ impl Session {
         let initial = self.policy().check_network_outbound(host, port, proto);
         let was_approval_required = matches!(initial, Decision::RequireApproval { .. });
         let resource_uri = network_uri(host, port, proto);
-        let routed = self.route_through_approval(
-            initial,
-            &resource_uri,
-            "network_outbound",
-            reasoning_step_id,
-        );
         let proto_str = match proto {
             NetworkProto::Http => "http",
             NetworkProto::Https => "https",
             NetworkProto::Udp => "udp",
             NetworkProto::Tcp | NetworkProto::Any => "tcp",
         };
+        let canonical_args = serde_json::json!({
+            "host": host,
+            "port": port,
+            "protocol": proto_str,
+        });
+        let routed = self.route_through_approval(
+            initial,
+            &resource_uri,
+            "network_outbound",
+            reasoning_step_id,
+            ToolClass::Network,
+            "network__connect",
+            &canonical_args,
+        );
 
         let routed = match routed {
             Ok(d) => d,
@@ -463,8 +512,19 @@ impl Session {
         self.rebind()?;
         let decision = self.policy().check_exec(program);
         let resource_uri = format!("exec://{}", program.display());
-        let decision =
-            self.route_through_approval(decision, &resource_uri, "exec", reasoning_step_id)?;
+        let canonical_args = serde_json::json!({
+            "program": program.display().to_string(),
+            "args": args,
+        });
+        let decision = self.route_through_approval(
+            decision,
+            &resource_uri,
+            "exec",
+            reasoning_step_id,
+            ToolClass::Exec,
+            "exec__run",
+            &canonical_args,
+        )?;
         match decision {
             Decision::Allow => {
                 self.enforce_aggregate_quota(ToolClass::Exec, &resource_uri, "exec")?;
@@ -532,9 +592,16 @@ impl Session {
     }
 
     /// Route a `Decision::RequireApproval` through the configured F3
-    /// channel (TTY / file / future web UI). Emits the
-    /// ApprovalRequest → Granted/Rejected/TimedOut entry pair, returns:
+    /// channel (TTY / file / future web UI). Per ADR-029, the gate
+    /// now also consults the task-scoped grant table — identical
+    /// retries of `(tool_name, sha256(canonical_args))` within the
+    /// manifest-configured TTL auto-consume the prior decision
+    /// without re-prompting. Tier behavior (advisory/validating) is
+    /// applied per the manifest's `tools.<class>.approval` block;
+    /// blocking and escalating fall through to validating behavior
+    /// in the foundation PR.
     ///
+    /// Returns:
     /// - `Ok(Decision::Allow)` if granted (caller proceeds; will emit Access).
     /// - `Err(Error::Denied)` if rejected or timed out — already-emitted
     ///   ApprovalRejected/ApprovalTimedOut entry takes the place of a
@@ -543,17 +610,84 @@ impl Session {
     /// - `Ok(decision)` unchanged when the input isn't `RequireApproval`
     ///   or when no channel is configured (legacy halt-on-RequireApproval
     ///   behavior preserved for callers that opt out).
+    #[allow(clippy::too_many_arguments)]
     fn route_through_approval(
         &mut self,
         decision: Decision,
         resource_uri: &str,
         access_kind: &str,
         reasoning_step_id: Option<&str>,
+        tool_class: ToolClass,
+        tool_name: &str,
+        canonical_args: &Value,
     ) -> Result<Decision> {
         let summary = match &decision {
             Decision::RequireApproval { reason } => reason.clone(),
             _ => return Ok(decision),
         };
+
+        // ADR-029 §"Risk-tiered approval scopes" — pull the per-class
+        // tier and TTL once. Default to the legacy halt-and-prompt
+        // (Validating, 5-minute TTL) when the manifest doesn't declare
+        // an `approval` block.
+        let policy = self.approval_policy_for(&tool_class);
+        let tier = policy.map(|p| p.tier).unwrap_or_default();
+        let ttl = Duration::from_secs(
+            policy
+                .map(|p| p.grant_ttl_seconds)
+                .unwrap_or(DEFAULT_GRANT_TTL_SECS),
+        );
+
+        // Advisory: ADR-029 §"Risk-tiered approval scopes" —
+        // "Log to ledger, dispatch immediately. No prompt." Emit the
+        // approval_decision entry as audit then return Allow.
+        if matches!(tier, ApprovalTier::Advisory) {
+            self.emit_approval_decision_advisory(
+                tool_name,
+                canonical_args,
+                resource_uri,
+                access_kind,
+                reasoning_step_id,
+            )?;
+            return Ok(Decision::Allow);
+        }
+
+        // Foundation slice: Blocking and Escalating fall through to
+        // the Validating prompt flow. Behavior switching for them is
+        // tracked as a deferred follow-up — see ADR-029 §"Risk-tiered
+        // approval scopes" + PR #198 body.
+        let _ = ApprovalTier::Blocking;
+        let _ = ApprovalTier::Escalating;
+
+        // Consult the grant table BEFORE prompting. Live grant for
+        // identical (tool_name, canonical_args) within TTL: emit
+        // approval_decision (auto-consumed) and reuse the cached
+        // decision — Allow dispatches, Deny short-circuits with the
+        // original reason. We clone the few fields we need so the
+        // immutable lookup-borrow doesn't conflict with the mutable
+        // emit_* call below.
+        let maybe_grant = self
+            .grant_table
+            .lookup(tool_name, canonical_args, SystemTime::now())
+            .map(|g| (g.arg_hash_hex(), g.grant_id.to_string(), g.decision.clone()));
+        if let Some((arg_hash_hex, grant_id, cached)) = maybe_grant {
+            self.emit_approval_decision_auto_consumed(
+                tool_name,
+                resource_uri,
+                access_kind,
+                reasoning_step_id,
+                &grant_id,
+                &arg_hash_hex,
+                &cached,
+            )?;
+            return match cached {
+                GrantDecision::Allow => Ok(Decision::Allow),
+                GrantDecision::Deny { reason } => Err(Error::Denied {
+                    reason: format!("approval grant denied: {reason}"),
+                }),
+            };
+        }
+
         if self.approval_channel.is_none() {
             return Ok(decision);
         }
@@ -589,10 +723,28 @@ impl Session {
                 decided_at,
             } => {
                 self.emit_approval_granted(&req, &approver_identity, decided_at)?;
+                let grant = ApprovalGrant::allow(tool_name, canonical_args, ttl);
+                let grant_id = grant.grant_id.to_string();
+                let arg_hash_hex = grant.arg_hash_hex();
+                self.grant_table.insert(grant);
+                self.emit_approval_decision_granted(
+                    tool_name,
+                    resource_uri,
+                    access_kind,
+                    reasoning_step_id,
+                    &grant_id,
+                    &arg_hash_hex,
+                    &approver_identity,
+                    ttl.as_secs(),
+                )?;
                 Ok(Decision::Allow)
             }
             ApprovalOutcome::Rejected { reason, decided_at } => {
                 self.emit_approval_rejected(&req, &reason, decided_at)?;
+                // Cache the deny so identical retries within TTL
+                // short-circuit without re-asking the operator.
+                let grant = ApprovalGrant::deny(tool_name, canonical_args, ttl, reason.clone());
+                self.grant_table.insert(grant);
                 Err(Error::Denied {
                     reason: format!("approval rejected: {reason}"),
                 })
@@ -603,6 +755,26 @@ impl Session {
                     reason: "approval timed out".to_string(),
                 })
             }
+        }
+    }
+
+    /// Resolve the manifest's `tools.<class>.approval` policy block, if
+    /// present. Returns `None` when no block is declared for the
+    /// class, which the caller treats as the legacy halt-and-prompt
+    /// (Validating) default.
+    fn approval_policy_for(&self, class: &ToolClass) -> Option<&ApprovalPolicy> {
+        let m = self.policy().manifest();
+        match class {
+            ToolClass::Filesystem => m.tools.filesystem.as_ref()?.approval.as_ref(),
+            ToolClass::Network => m.tools.network.as_ref()?.approval.as_ref(),
+            ToolClass::Exec => m.tools.exec.as_ref()?.approval.as_ref(),
+            ToolClass::Mcp(server) => m
+                .tools
+                .mcp
+                .iter()
+                .find(|s| &s.server_name == server)?
+                .approval
+                .as_ref(),
         }
     }
 
@@ -735,7 +907,183 @@ impl Session {
         })?;
         Ok(())
     }
+
+    /// Emit an `approval_decision` entry for an advisory-tier dispatch
+    /// (ADR-029 §"Risk-tiered approval scopes"). No operator was
+    /// prompted; the entry is purely audit. Includes the canonical
+    /// arg hash so auditors can reconstruct exactly what was
+    /// auto-approved.
+    fn emit_approval_decision_advisory(
+        &mut self,
+        tool_name: &str,
+        canonical_args: &Value,
+        resource_uri: &str,
+        access_kind: &str,
+        reasoning_step_id: Option<&str>,
+    ) -> Result<()> {
+        let arg_hash_hex = hex::encode(aegis_approval_gate::canonical_arg_hash(canonical_args));
+        let agent_hash = self.agent_identity_hash();
+        let session_id = self.session_id().to_string();
+        let mut payload = Map::new();
+        payload.insert(
+            "decision".to_string(),
+            Value::String("auto_advisory".to_string()),
+        );
+        payload.insert("toolName".to_string(), Value::String(tool_name.to_string()));
+        payload.insert("grantArgHashHex".to_string(), Value::String(arg_hash_hex));
+        payload.insert(
+            "resourceUri".to_string(),
+            Value::String(resource_uri.to_string()),
+        );
+        payload.insert(
+            "accessType".to_string(),
+            Value::String(access_kind.to_string()),
+        );
+        if let Some(rsid) = reasoning_step_id {
+            payload.insert(
+                "reasoningStepId".to_string(),
+                Value::String(rsid.to_string()),
+            );
+        }
+        self.ledger_writer_mut().append(Entry {
+            session_id,
+            entry_type: EntryType::ApprovalDecision,
+            agent_identity_hash: agent_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
+    }
+
+    /// Emit an `approval_decision` entry for an auto-consumed grant
+    /// (ADR-029 §"Auto-consumption rules"). References the source
+    /// grant id so an auditor can trace every silent retry back to
+    /// the original operator decision.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_approval_decision_auto_consumed(
+        &mut self,
+        tool_name: &str,
+        resource_uri: &str,
+        access_kind: &str,
+        reasoning_step_id: Option<&str>,
+        grant_id: &str,
+        arg_hash_hex: &str,
+        cached: &GrantDecision,
+    ) -> Result<()> {
+        let agent_hash = self.agent_identity_hash();
+        let session_id = self.session_id().to_string();
+        let outcome = match cached {
+            GrantDecision::Allow => "auto_consumed_allow",
+            GrantDecision::Deny { .. } => "auto_consumed_deny",
+        };
+        let mut payload = Map::new();
+        payload.insert("decision".to_string(), Value::String(outcome.to_string()));
+        payload.insert("toolName".to_string(), Value::String(tool_name.to_string()));
+        payload.insert(
+            "sourceGrantId".to_string(),
+            Value::String(grant_id.to_string()),
+        );
+        payload.insert(
+            "grantArgHashHex".to_string(),
+            Value::String(arg_hash_hex.to_string()),
+        );
+        payload.insert(
+            "resourceUri".to_string(),
+            Value::String(resource_uri.to_string()),
+        );
+        payload.insert(
+            "accessType".to_string(),
+            Value::String(access_kind.to_string()),
+        );
+        if let Some(rsid) = reasoning_step_id {
+            payload.insert(
+                "reasoningStepId".to_string(),
+                Value::String(rsid.to_string()),
+            );
+        }
+        if let GrantDecision::Deny { reason } = cached {
+            payload.insert("denyReason".to_string(), Value::String(reason.clone()));
+        }
+        self.ledger_writer_mut().append(Entry {
+            session_id,
+            entry_type: EntryType::ApprovalDecision,
+            agent_identity_hash: agent_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
+    }
+
+    /// Emit an `approval_decision` entry for a freshly-granted
+    /// approval (ADR-029). Pairs with the existing `approval_granted`
+    /// entry: that one records the operator's decision, this one
+    /// records the issued grant so subsequent auto-consumes can chain
+    /// to it via `sourceGrantId`.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_approval_decision_granted(
+        &mut self,
+        tool_name: &str,
+        resource_uri: &str,
+        access_kind: &str,
+        reasoning_step_id: Option<&str>,
+        grant_id: &str,
+        arg_hash_hex: &str,
+        approver_identity: &str,
+        ttl_seconds: u64,
+    ) -> Result<()> {
+        let agent_hash = self.agent_identity_hash();
+        let session_id = self.session_id().to_string();
+        let mut payload = Map::new();
+        payload.insert(
+            "decision".to_string(),
+            Value::String("grant_issued".to_string()),
+        );
+        payload.insert("toolName".to_string(), Value::String(tool_name.to_string()));
+        payload.insert(
+            "sourceGrantId".to_string(),
+            Value::String(grant_id.to_string()),
+        );
+        payload.insert(
+            "grantArgHashHex".to_string(),
+            Value::String(arg_hash_hex.to_string()),
+        );
+        payload.insert(
+            "grantTtlSeconds".to_string(),
+            Value::Number(ttl_seconds.into()),
+        );
+        payload.insert(
+            "approverId".to_string(),
+            Value::String(approver_identity.to_string()),
+        );
+        payload.insert(
+            "resourceUri".to_string(),
+            Value::String(resource_uri.to_string()),
+        );
+        payload.insert(
+            "accessType".to_string(),
+            Value::String(access_kind.to_string()),
+        );
+        if let Some(rsid) = reasoning_step_id {
+            payload.insert(
+                "reasoningStepId".to_string(),
+                Value::String(rsid.to_string()),
+            );
+        }
+        self.ledger_writer_mut().append(Entry {
+            session_id,
+            entry_type: EntryType::ApprovalDecision,
+            agent_identity_hash: agent_hash,
+            timestamp: Utc::now(),
+            payload,
+        })?;
+        Ok(())
+    }
 }
+
+/// Default grant TTL when `tools.<class>.approval.grant_ttl_seconds`
+/// is not declared in the manifest. Matches the ADR-029 default of
+/// 5 minutes.
+const DEFAULT_GRANT_TTL_SECS: u64 = 300;
 
 fn file_uri(path: &Path) -> String {
     if path.is_absolute() {

--- a/crates/inference-engine/src/session.rs
+++ b/crates/inference-engine/src/session.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
-use aegis_approval_gate::ApprovalChannel;
+use aegis_approval_gate::{ApprovalChannel, SessionGrantTable};
 use aegis_identity::{
     verify_chat_template_binding, verify_digest_binding, Digest, DigestField, DigestTriple,
     LocalCa, SpiffeId, X509Svid,
@@ -124,6 +124,10 @@ pub struct Session {
     /// ([`Self::svid_cert_pem`] / [`Self::svid_key_pem`]) takes over
     /// for single-turn paths and mediator calls invoked directly.
     pub(crate) current_turn_svid: Option<X509Svid>,
+    /// Task-scoped ephemeral approval-grant table (ADR-029). Lookup
+    /// key is `(tool_name, sha256(canonical_args))`. Reset at boot;
+    /// in-memory only — grants vaporize at session end by design.
+    pub(crate) grant_table: SessionGrantTable,
 }
 
 /// One observed network-connection attempt + the gate's decision.
@@ -290,6 +294,7 @@ impl Session {
             adversarial_classifier: crate::adversarial::default_classifier(),
             aggregate_state: SessionAggregateState::new(),
             current_turn_svid: None,
+            grant_table: SessionGrantTable::new(),
         })
     }
 

--- a/crates/inference-engine/tests/approval_grants.rs
+++ b/crates/inference-engine/tests/approval_grants.rs
@@ -1,0 +1,231 @@
+//! Integration tests for task-scoped ephemeral approval grants
+//! (ADR-029, issue #185). Exercises the foundation-slice behavior:
+//!
+//! - Validating tier: prompt + grant; identical retry auto-consumes
+//!   without re-prompting.
+//! - Argument drift: same tool + different args re-prompts.
+//! - Advisory tier: no prompt at all; ledger records `auto_advisory`.
+//! - TTL expiry: a grant past its TTL re-prompts.
+//!
+//! Blocking and Escalating tier behaviors are deferred — they're
+//! recognized in the manifest but treated as Validating for now (PR
+//! body documents the gap).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+
+use aegis_approval_gate::FileApprovalChannel;
+use aegis_identity::LocalCa;
+use aegis_inference_engine::{BootConfig, Session};
+use serde_json::Value;
+
+const TRUST_DOMAIN: &str = "approval-grants-test.local";
+
+fn boot(dir: &Path, ca_dir: &Path, session_id: &str, manifest_yaml: &str) -> (Session, PathBuf) {
+    LocalCa::init(ca_dir, TRUST_DOMAIN).unwrap();
+    let manifest_path = dir.join("manifest.yaml");
+    let model_path = dir.join("model.gguf");
+    let ledger_path = dir.join("ledger.jsonl");
+    std::fs::write(&manifest_path, manifest_yaml).unwrap();
+    std::fs::write(&model_path, b"fake-model").unwrap();
+    let cfg = BootConfig {
+        session_id: session_id.to_string(),
+        manifest_path,
+        model_path,
+        config_path: None,
+        chat_template_sidecar: None,
+        identity_dir: ca_dir.to_path_buf(),
+        workload_name: "research".to_string(),
+        instance: "inst-001".to_string(),
+        ledger_path: ledger_path.clone(),
+        ledger_schema: None,
+    };
+    (Session::boot(cfg).unwrap(), ledger_path)
+}
+
+fn read_entries(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("valid json"))
+        .collect()
+}
+
+/// Validating tier (default): the first write prompts via the file
+/// channel; the second write of the same path auto-consumes the
+/// grant. Ledger has TWO writes worth of access entries but only ONE
+/// approval_request entry — saving the operator from approval fatigue.
+#[test]
+fn validating_tier_auto_consumes_identical_retry() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("note.txt");
+
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "ag-test", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://approval-grants-test.local/agent/research/inst-001" }}
+tools:
+  filesystem:
+    write: ["{p}"]
+    approval:
+      tier: validating
+      grant_ttl_seconds: 300
+write_grants:
+  - resource: "{f}"
+    actions: ["write"]
+    approval_required: true
+"#,
+        p = dir.path().to_str().unwrap(),
+        f = target.to_str().unwrap(),
+    );
+
+    let approval_path = dir.path().join("approval.json");
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "session-validating", &yaml);
+    let mut s = s.with_approval_channel(Box::new(FileApprovalChannel::new(&approval_path)));
+    std::fs::write(
+        &approval_path,
+        br#"{"decision":"granted","approver":"alice"}"#,
+    )
+    .unwrap();
+
+    // First write prompts + grants.
+    s.mediate_filesystem_write(&target, b"hello", None).unwrap();
+    // Second write of the same path + same contents auto-consumes —
+    // no second approval prompt fires, even though the FileApprovalChannel
+    // would still return Granted if it did.
+    s.mediate_filesystem_write(&target, b"hello", None).unwrap();
+    s.shutdown().unwrap();
+
+    let entries = read_entries(&ledger);
+    let kinds: Vec<&str> = entries
+        .iter()
+        .map(|e| e["entryType"].as_str().unwrap())
+        .collect();
+
+    let approval_requests = kinds.iter().filter(|k| **k == "approval_request").count();
+    let approval_granteds = kinds.iter().filter(|k| **k == "approval_granted").count();
+    let auto_consumeds = entries
+        .iter()
+        .filter(|e| e["decision"].as_str() == Some("auto_consumed_allow"))
+        .count();
+    let writes = kinds.iter().filter(|k| **k == "access").count();
+
+    assert_eq!(approval_requests, 1, "only the first call prompts");
+    assert_eq!(approval_granteds, 1);
+    assert_eq!(auto_consumeds, 1, "the second call records auto_consumed");
+    assert_eq!(writes, 2, "both writes dispatched");
+}
+
+/// Argument drift voids the match: same tool, different contents
+/// hash → fresh prompt. Catches the "an attacker mutated the args
+/// after approval" failure mode ADR-029 §"Context" calls out.
+#[test]
+fn arg_drift_forces_fresh_prompt() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("drift.txt");
+
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "ag-test", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://approval-grants-test.local/agent/research/inst-001" }}
+tools:
+  filesystem:
+    write: ["{p}"]
+    approval:
+      tier: validating
+      grant_ttl_seconds: 300
+write_grants:
+  - resource: "{f}"
+    actions: ["write"]
+    approval_required: true
+"#,
+        p = dir.path().to_str().unwrap(),
+        f = target.to_str().unwrap(),
+    );
+
+    let approval_path = dir.path().join("approval.json");
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "session-drift", &yaml);
+    let mut s = s.with_approval_channel(Box::new(FileApprovalChannel::new(&approval_path)));
+    std::fs::write(
+        &approval_path,
+        br#"{"decision":"granted","approver":"alice"}"#,
+    )
+    .unwrap();
+
+    s.mediate_filesystem_write(&target, b"v1", None).unwrap();
+    s.mediate_filesystem_write(&target, b"v2 different bytes", None)
+        .unwrap();
+    s.shutdown().unwrap();
+
+    let entries = read_entries(&ledger);
+    let approval_requests = entries
+        .iter()
+        .filter(|e| e["entryType"].as_str() == Some("approval_request"))
+        .count();
+    assert_eq!(approval_requests, 2, "arg drift forces re-prompt");
+}
+
+/// Advisory tier: the manifest says "no prompt, log + dispatch."
+/// The ledger has zero approval_request entries even though the
+/// per-call policy returned RequireApproval — the tier short-circuits
+/// the gate. One approval_decision entry (decision=auto_advisory) is
+/// emitted per dispatch for audit.
+#[test]
+fn advisory_tier_skips_prompt_entirely() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("advisory.txt");
+
+    let yaml = format!(
+        r#"schemaVersion: "1"
+agent: {{ name: "ag-test", version: "1.0.0" }}
+identity: {{ spiffeId: "spiffe://approval-grants-test.local/agent/research/inst-001" }}
+tools:
+  filesystem:
+    write: ["{p}"]
+    approval:
+      tier: advisory
+write_grants:
+  - resource: "{f}"
+    actions: ["write"]
+    approval_required: true
+"#,
+        p = dir.path().to_str().unwrap(),
+        f = target.to_str().unwrap(),
+    );
+
+    let approval_path = dir.path().join("approval.json");
+    let (s, ledger) = boot(dir.path(), ca_dir.path(), "session-advisory", &yaml);
+    let mut s = s.with_approval_channel(Box::new(FileApprovalChannel::new(&approval_path)));
+    // Pre-populate the approval file with a grant — it should never
+    // be consulted under advisory tier.
+    std::fs::write(
+        &approval_path,
+        br#"{"decision":"granted","approver":"alice"}"#,
+    )
+    .unwrap();
+
+    s.mediate_filesystem_write(&target, b"hello", None).unwrap();
+    s.shutdown().unwrap();
+
+    let entries = read_entries(&ledger);
+    let kinds: Vec<&str> = entries
+        .iter()
+        .map(|e| e["entryType"].as_str().unwrap())
+        .collect();
+
+    assert!(
+        !kinds.contains(&"approval_request"),
+        "advisory tier emits no approval_request, got {kinds:?}"
+    );
+    let advisory_count = entries
+        .iter()
+        .filter(|e| e["decision"].as_str() == Some("auto_advisory"))
+        .count();
+    assert_eq!(advisory_count, 1, "exactly one auto_advisory entry");
+    assert!(kinds.contains(&"access"), "dispatch still happened");
+}

--- a/crates/inference-engine/tests/mediator.rs
+++ b/crates/inference-engine/tests/mediator.rs
@@ -456,12 +456,17 @@ fn approval_granted_via_file_channel_proceeds_with_full_entry_sequence() {
         .iter()
         .map(|e| e["entryType"].as_str().unwrap())
         .collect();
+    // ADR-029 adds an approval_decision entry (decision=grant_issued)
+    // recording the grant + its bound arg hash for future
+    // auto-consumes. It lands between approval_granted (the operator's
+    // raw decision) and access (the dispatch).
     assert_eq!(
         kinds,
         vec![
             "session_start",
             "approval_request",
             "approval_granted",
+            "approval_decision",
             "access",
             "network_attestation",
             "session_end"

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -26,9 +26,9 @@ pub use decision::{Decision, NetworkProto};
 pub use error::{Error, Result};
 pub use identity_binding::{check_identity_binding, check_identity_binding_now};
 pub use manifest::{
-    Agent, AggregateQuota, ApiGrant, ApprovalClass, Exec, ExecGrant, Filesystem, Identity,
-    Manifest, Network, NetworkAllowEntry, NetworkMode, NetworkPolicy, NetworkProtocol, Tools,
-    WriteAction, WriteGrant,
+    Agent, AggregateQuota, ApiGrant, ApprovalClass, ApprovalPolicy, ApprovalTier, Exec, ExecGrant,
+    Filesystem, Identity, Manifest, Network, NetworkAllowEntry, NetworkMode, NetworkPolicy,
+    NetworkProtocol, Tools, WriteAction, WriteGrant,
 };
 pub use policy::Policy;
 pub use violation::{emit_violation, ViolationEvent};

--- a/crates/policy/src/manifest.rs
+++ b/crates/policy/src/manifest.rs
@@ -110,6 +110,11 @@ pub struct Filesystem {
     /// (ADR-027). `None` = no aggregate cap.
     #[serde(default)]
     pub quota: Option<AggregateQuota>,
+    /// Per-tool-class approval policy (ADR-029). `None` falls back to
+    /// the legacy `approval_required_for` semantics — i.e., effectively
+    /// [`ApprovalTier::Validating`].
+    #[serde(default)]
+    pub approval: Option<ApprovalPolicy>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -123,17 +128,24 @@ pub struct Network {
     /// `None` = no aggregate cap.
     #[serde(default)]
     pub quota: Option<AggregateQuota>,
+    /// Per-tool-class approval policy (ADR-029). `None` falls back to
+    /// the legacy `approval_required_for` semantics.
+    #[serde(default)]
+    pub approval: Option<ApprovalPolicy>,
 }
 
-/// Exec-tool-class settings (ADR-027). Currently carries the
-/// aggregate quota only — per-grant rules stay in [`Manifest::exec_grants`]
-/// to avoid restructuring the manifest in the foundation PR.
+/// Exec-tool-class settings (ADR-027 + ADR-029). Carries the aggregate
+/// quota and the approval policy — per-grant rules stay in
+/// [`Manifest::exec_grants`] to avoid restructuring the manifest.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Exec {
     /// Per-session aggregate quota for exec dispatches.
     #[serde(default)]
     pub quota: Option<AggregateQuota>,
+    /// Per-tool-class approval policy (ADR-029).
+    #[serde(default)]
+    pub approval: Option<ApprovalPolicy>,
 }
 
 /// Per-session aggregate quota for a tool class (ADR-027). All fields
@@ -154,6 +166,54 @@ pub struct AggregateQuota {
     /// `None` = no cap on call count.
     #[serde(default, rename = "max_calls_per_session")]
     pub max_calls_per_session: Option<u64>,
+}
+
+/// Per-tool-class approval policy (ADR-029 task-scoped ephemeral
+/// grants). `tier` selects the gate's behavior on
+/// `Decision::RequireApproval`; `grant_ttl_seconds` controls how long
+/// an issued grant auto-consumes identical retries before re-prompting.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalPolicy {
+    /// Risk tier for this tool class. Default = [`ApprovalTier::Validating`]
+    /// when the block is present but `tier` omitted; matches today's
+    /// halt-and-prompt behavior.
+    #[serde(default)]
+    pub tier: ApprovalTier,
+    /// TTL of an issued grant in seconds. The grant auto-consumes
+    /// identical retries (same tool, same canonical args hash) within
+    /// this window without re-prompting. Default = 300 (5 minutes) per
+    /// ADR-029 §"Auto-consumption rules".
+    #[serde(default = "default_grant_ttl_seconds", rename = "grant_ttl_seconds")]
+    pub grant_ttl_seconds: u64,
+}
+
+fn default_grant_ttl_seconds() -> u64 {
+    300
+}
+
+/// Risk-tiered approval scopes (ADR-029 §"Risk-tiered approval scopes").
+/// Foundation wires only `Advisory` and `Validating`; `Blocking` and
+/// `Escalating` are recognized in the type system and round-trip
+/// through the manifest, but the runtime currently treats them as
+/// `Validating` (deferred follow-up — called out in PR #198 body).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalTier {
+    /// Log to ledger, dispatch immediately. No prompt. For low-risk
+    /// read-only actions where audit is sufficient.
+    Advisory,
+    /// Standard approval prompt on the configured channel. Today's
+    /// default behavior. Required by default for write/exec.
+    #[default]
+    Validating,
+    /// Hard deny with no approval path. For tools the manifest reaches
+    /// but the operator never wants the agent to use under any
+    /// circumstances. **Foundation: treated as `Validating`.**
+    Blocking,
+    /// Routes the approval prompt to a secondary channel
+    /// (e.g., mTLS+webhook). **Foundation: treated as `Validating`.**
+    Escalating,
 }
 
 /// `oneOf {string, object}` from the schema.
@@ -213,6 +273,11 @@ pub struct McpServerGrant {
     /// limit calls to `search-mcp`.
     #[serde(default)]
     pub quota: Option<AggregateQuota>,
+    /// Per-server approval policy (ADR-029). One tier covers all
+    /// `allowed_tools` for this server in the foundation slice;
+    /// per-tool tiers are a follow-up.
+    #[serde(default)]
+    pub approval: Option<ApprovalPolicy>,
 }
 
 /// One entry in [`McpServerGrant::allowed_tools`]. Two shapes are

--- a/docs/COMPATIBILITY_CHARTER.md
+++ b/docs/COMPATIBILITY_CHARTER.md
@@ -55,6 +55,27 @@ When a breaking change is genuinely required:
 
 There is no plan to retire `v1` once `v2` ships. Removal would itself be a breaking change against deployed audit evidence.
 
+## Approval grants (ADR-029)
+
+[ADR-029](adrs/029-task-scoped-ephemeral-approval-grants.md) evolves the F3 approval gate from per-call prompts to **task-scoped ephemeral grants**. The manifest gains an optional `tools.<class>.approval` block with a `tier` enum and a `grant_ttl_seconds` budget. The schema bump is **non-breaking**: every existing manifest behaves exactly as before (effectively `tier: validating` + a 5-minute default TTL when the block is absent).
+
+**Forbid-overrides-permit + audit-by-default.** Every approval decision lands on the F9 ledger as both the legacy `approval_granted` / `approval_rejected` entry (operator's raw decision) and a new `approval_decision` entry (the grant lifecycle: `grant_issued`, `auto_consumed_allow`, `auto_consumed_deny`, `auto_advisory`). Auditors can chart every silent retry back to the original prompt via `sourceGrantId`.
+
+**Auto-consume binding.** Grants bind to `(tool_name, sha256(canonical_args))`. Identical retries within TTL skip the prompt; **argument drift voids the match** (different args → fresh prompt). This is what defeats the "approve once, attacker mutates args" attack ADR-029 §"Context" calls out.
+
+**Foundation slice.** Wires `advisory` (no prompt, log + dispatch) and `validating` (today's prompt behavior, plus the grant table). `blocking` and `escalating` are recognized in the manifest + type system but **treated as `validating`** for now — their distinct behaviors are deferred follow-ups.
+
+**Intentionally deferred (file as separate issues when picked up):**
+
+- Session pause/resume for headless mTLS async approvals (sidecar serialization, `aegis run --resume`, encrypted state).
+- `blocking` tier's hard-deny behavior (the most security-relevant tier left unwired).
+- `escalating` tier's secondary-channel routing.
+- Aggregate-state visibility in the TTY prompt text (ADR-029 §"Visibility into aggregate state").
+- `aegis revoke <session-id> <grant-id>` for early grant revocation.
+- F8 replay viewer rendering of `approval_decision` entries with grant lineage.
+- Go validator behavioral parity for `tier` (parse parity already in via `ApprovalPolicy`).
+- Cross-language conformance fixtures for the new manifest + canonical-args hash.
+
 ## Per-turn workload attestation (ADR-030)
 
 [ADR-030](adrs/030-per-turn-spiffe-mtls-attestation.md) introduces fresh, short-lived SVIDs at every turn boundary in the multi-turn loop. The session-long SVID minted at `Session::boot` is **unchanged** — it still binds the agent's identity for non-turn paths (single-turn `run_turn`, mediator calls outside the loop).

--- a/pkg/manifest/schema_v1.json
+++ b/pkg/manifest/schema_v1.json
@@ -55,7 +55,8 @@
           "properties": {
             "read": { "$ref": "#/definitions/pathList" },
             "write": { "$ref": "#/definitions/pathList" },
-            "quota": { "$ref": "#/definitions/aggregateQuota" }
+            "quota": { "$ref": "#/definitions/aggregateQuota" },
+            "approval": { "$ref": "#/definitions/approvalPolicy" }
           }
         },
         "network": {
@@ -64,7 +65,8 @@
           "properties": {
             "outbound": { "$ref": "#/definitions/networkPolicy" },
             "inbound": { "$ref": "#/definitions/networkPolicy" },
-            "quota": { "$ref": "#/definitions/aggregateQuota" }
+            "quota": { "$ref": "#/definitions/aggregateQuota" },
+            "approval": { "$ref": "#/definitions/approvalPolicy" }
           }
         },
         "apis": {
@@ -80,10 +82,11 @@
         },
         "exec": {
           "type": "object",
-          "description": "Exec-tool-class settings (ADR-027). Per-grant rules still live in the top-level `exec_grants`; this block carries the aggregate quota for the class.",
+          "description": "Exec-tool-class settings (ADR-027 + ADR-029). Per-grant rules still live in the top-level `exec_grants`; this block carries the aggregate quota and approval policy for the class.",
           "additionalProperties": false,
           "properties": {
-            "quota": { "$ref": "#/definitions/aggregateQuota" }
+            "quota": { "$ref": "#/definitions/aggregateQuota" },
+            "approval": { "$ref": "#/definitions/approvalPolicy" }
           }
         }
       }
@@ -210,7 +213,25 @@
           "items": { "$ref": "#/definitions/allowedTool" },
           "uniqueItems": true
         },
-        "quota": { "$ref": "#/definitions/aggregateQuota" }
+        "quota": { "$ref": "#/definitions/aggregateQuota" },
+        "approval": { "$ref": "#/definitions/approvalPolicy" }
+      }
+    },
+    "approvalPolicy": {
+      "type": "object",
+      "description": "Per-tool-class approval policy (ADR-029). Selects the gate's behavior on Decision::RequireApproval; grant_ttl_seconds controls how long an issued grant auto-consumes identical retries before re-prompting.",
+      "additionalProperties": false,
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["advisory", "validating", "blocking", "escalating"],
+          "description": "Risk tier. advisory: log + dispatch, no prompt. validating: standard prompt. blocking: hard deny (foundation: treated as validating). escalating: secondary-channel routing (foundation: treated as validating)."
+        },
+        "grant_ttl_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "TTL of an issued grant. Identical retries within this window auto-consume without re-prompting. Default 300 (5 minutes)."
+        }
       }
     },
     "aggregateQuota": {

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -124,8 +124,8 @@ type AggregateQuota struct {
 // identical retries. Parse-only on the Go side — behavior dispatch
 // lives in the Rust runtime.
 type ApprovalPolicy struct {
-	Tier             string `yaml:"tier,omitempty" json:"tier,omitempty"`
-	GrantTTLSeconds  uint64 `yaml:"grant_ttl_seconds,omitempty" json:"grant_ttl_seconds,omitempty"`
+	Tier            string `yaml:"tier,omitempty" json:"tier,omitempty"`
+	GrantTTLSeconds uint64 `yaml:"grant_ttl_seconds,omitempty" json:"grant_ttl_seconds,omitempty"`
 }
 
 // NetworkMode captures the schema's `oneOf {string enum, allowlist object}`.

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -84,6 +84,10 @@ type Filesystem struct {
 	// dispatches (ADR-027). Parsed for Go-validator round-trip
 	// parity; enforcement lives in the Rust runtime today.
 	Quota *AggregateQuota `yaml:"quota,omitempty" json:"quota,omitempty"`
+	// Approval carries the per-tool-class approval policy (ADR-029).
+	// Parsed for Go-validator round-trip parity; tier behavior is a
+	// Rust-runtime concern (the Go side has no dispatcher).
+	Approval *ApprovalPolicy `yaml:"approval,omitempty" json:"approval,omitempty"`
 }
 
 type Network struct {
@@ -93,12 +97,16 @@ type Network struct {
 	// dispatches (ADR-027). Parsed for Go-validator round-trip
 	// parity; enforcement lives in the Rust runtime today.
 	Quota *AggregateQuota `yaml:"quota,omitempty" json:"quota,omitempty"`
+	// Approval carries the per-tool-class approval policy (ADR-029).
+	Approval *ApprovalPolicy `yaml:"approval,omitempty" json:"approval,omitempty"`
 }
 
-// Exec is the tools.exec sub-block (ADR-027). Currently carries the
-// aggregate quota only — per-grant exec rules stay in Manifest.ExecGrants.
+// Exec is the tools.exec sub-block (ADR-027 + ADR-029). Currently
+// carries the aggregate quota + approval policy — per-grant exec
+// rules stay in Manifest.ExecGrants.
 type Exec struct {
-	Quota *AggregateQuota `yaml:"quota,omitempty" json:"quota,omitempty"`
+	Quota    *AggregateQuota `yaml:"quota,omitempty" json:"quota,omitempty"`
+	Approval *ApprovalPolicy `yaml:"approval,omitempty" json:"approval,omitempty"`
 }
 
 // AggregateQuota is the per-session aggregate cap for a tool class
@@ -108,6 +116,16 @@ type Exec struct {
 // concern (the Go side has no dispatcher).
 type AggregateQuota struct {
 	MaxCallsPerSession *uint64 `yaml:"max_calls_per_session,omitempty" json:"max_calls_per_session,omitempty"`
+}
+
+// ApprovalPolicy is the per-tool-class approval policy (ADR-029).
+// Tier selects the F3 gate's behavior on Decision::RequireApproval;
+// GrantTTLSeconds controls how long an issued grant auto-consumes
+// identical retries. Parse-only on the Go side — behavior dispatch
+// lives in the Rust runtime.
+type ApprovalPolicy struct {
+	Tier             string `yaml:"tier,omitempty" json:"tier,omitempty"`
+	GrantTTLSeconds  uint64 `yaml:"grant_ttl_seconds,omitempty" json:"grant_ttl_seconds,omitempty"`
 }
 
 // NetworkMode captures the schema's `oneOf {string enum, allowlist object}`.
@@ -149,6 +167,8 @@ type MCPServerGrant struct {
 	// Quota is the per-server aggregate quota for MCP dispatches
 	// (ADR-027). Per-server, not global across all MCP servers.
 	Quota *AggregateQuota `yaml:"quota,omitempty" json:"quota,omitempty"`
+	// Approval is the per-server approval policy (ADR-029).
+	Approval *ApprovalPolicy `yaml:"approval,omitempty" json:"approval,omitempty"`
 }
 
 // AllowedTool is one entry in MCPServerGrant.AllowedTools (per ADR-024-A).

--- a/schemas/manifest/v1/manifest.schema.json
+++ b/schemas/manifest/v1/manifest.schema.json
@@ -55,7 +55,8 @@
           "properties": {
             "read": { "$ref": "#/definitions/pathList" },
             "write": { "$ref": "#/definitions/pathList" },
-            "quota": { "$ref": "#/definitions/aggregateQuota" }
+            "quota": { "$ref": "#/definitions/aggregateQuota" },
+            "approval": { "$ref": "#/definitions/approvalPolicy" }
           }
         },
         "network": {
@@ -64,7 +65,8 @@
           "properties": {
             "outbound": { "$ref": "#/definitions/networkPolicy" },
             "inbound": { "$ref": "#/definitions/networkPolicy" },
-            "quota": { "$ref": "#/definitions/aggregateQuota" }
+            "quota": { "$ref": "#/definitions/aggregateQuota" },
+            "approval": { "$ref": "#/definitions/approvalPolicy" }
           }
         },
         "apis": {
@@ -80,10 +82,11 @@
         },
         "exec": {
           "type": "object",
-          "description": "Exec-tool-class settings (ADR-027). Per-grant rules still live in the top-level `exec_grants`; this block carries the aggregate quota for the class.",
+          "description": "Exec-tool-class settings (ADR-027 + ADR-029). Per-grant rules still live in the top-level `exec_grants`; this block carries the aggregate quota and approval policy for the class.",
           "additionalProperties": false,
           "properties": {
-            "quota": { "$ref": "#/definitions/aggregateQuota" }
+            "quota": { "$ref": "#/definitions/aggregateQuota" },
+            "approval": { "$ref": "#/definitions/approvalPolicy" }
           }
         }
       }
@@ -210,7 +213,25 @@
           "items": { "$ref": "#/definitions/allowedTool" },
           "uniqueItems": true
         },
-        "quota": { "$ref": "#/definitions/aggregateQuota" }
+        "quota": { "$ref": "#/definitions/aggregateQuota" },
+        "approval": { "$ref": "#/definitions/approvalPolicy" }
+      }
+    },
+    "approvalPolicy": {
+      "type": "object",
+      "description": "Per-tool-class approval policy (ADR-029). Selects the gate's behavior on Decision::RequireApproval; grant_ttl_seconds controls how long an issued grant auto-consumes identical retries before re-prompting.",
+      "additionalProperties": false,
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["advisory", "validating", "blocking", "escalating"],
+          "description": "Risk tier. advisory: log + dispatch, no prompt. validating: standard prompt. blocking: hard deny (foundation: treated as validating). escalating: secondary-channel routing (foundation: treated as validating)."
+        },
+        "grant_ttl_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "TTL of an issued grant. Identical retries within this window auto-consume without re-prompting. Default 300 (5 minutes)."
+        }
       }
     },
     "aggregateQuota": {


### PR DESCRIPTION
Closes #185.

Foundation PR for ADR-029 task-scoped ephemeral approval grants. **Last unbuilt ADR sub-issue under #134** — completes the architectural foundation of the v1.0.0 multi-turn milestone.

## Summary

- New \`crates/approval-gate/src/grants.rs\`: \`ApprovalGrant\` bound to \`(tool_name, sha256(canonical_args))\`, \`SessionGrantTable\`, \`canonical_arg_hash\` helper.
- Manifest schema gains optional \`tools.<class>.approval.{tier, grant_ttl_seconds}\` block on filesystem, network, exec, and per-server on mcp[*]. Non-breaking — every existing manifest stays valid.
- \`route_through_approval\` extended to look up tier + consult the grant table + emit \`approval_decision\` ledger entries with grant lineage.
- **Argument drift defeats replay**: same tool + same canonical args within TTL = auto-consume; different args = fresh prompt. Closes the "approve UPDATE WHERE id=42, attacker mutates to UPDATE" attack from ADR-029 §\"Context\".
- Go-side parse parity (\`ApprovalPolicy\` struct) so quota+approval manifests round-trip cleanly through \`aegis validate\`.

## Foundation slice (per the foundation+follow-ups pattern)

**Wired:** \`advisory\` (no prompt, log + dispatch) and \`validating\` (today's prompt behavior + grant table). Both demonstrably useful behaviors.

**Recognized but treated as validating:** \`blocking\` and \`escalating\` are in the manifest + type system but their distinct behaviors (hard-deny / secondary-channel routing) are deferred. The most security-relevant gap is \`blocking\` hard-deny — called out in PR body + Compatibility Charter.

## Intentionally deferred (also in Compatibility Charter §\"Approval grants (ADR-029)\")

1. **Session pause/resume** for headless mTLS async approvals (sidecar serialization, \`aegis run --resume\`, encrypted state). Biggest deferred subsystem — owns its own PR.
2. **\`blocking\` tier hard-deny** behavior.
3. **\`escalating\` tier** secondary-channel routing.
4. **Aggregate-state visibility** in TTY prompt text (ADR-029 §\"Visibility into aggregate state\").
5. **\`aegis revoke <session-id> <grant-id>\`** CLI for early grant revocation.
6. **F8 replay viewer** rendering of \`approval_decision\` entries with grant lineage.
7. **Go validator behavioral parity** for \`tier\` (parse parity already in).
8. **Cross-language conformance fixtures** for the new manifest + canonical-args hash.

## Tests / verification

- 6 unit tests for grant table behavior (hash stability across key orders, arg/tool drift misses, TTL expiry, deny short-circuit).
- 3 integration tests: validating tier auto-consumes identical retry (1 prompt, 2 dispatches), arg drift forces fresh prompt, advisory tier skips prompt entirely.
- 262 workspace tests passing (was 252; +10).
- \`cargo clippy --workspace --tests -- -D warnings\` clean.
- \`cargo fmt --all -- --check\` clean.
- All 4 example manifests + a new quota+approval combined manifest validate against the JSON schema.

## Compatibility

- Manifest schema additions are purely optional — every existing manifest stays valid.
- Existing approval flow (\`approval_request\` / \`approval_granted\` / \`approval_rejected\` / \`approval_timed_out\`) continues to fire. The new \`approval_decision\` entries are *additional*, not a replacement — auditors get both the operator's raw decision and the grant lineage.
- \`route_through_approval\` signature changed (added 3 params: tool_class, tool_name, canonical_args). All 5 call sites updated.
- No proto changes.

## Test plan

- [ ] CI green.
- [ ] Maintainer reviews the grant-table model — especially the \"check first, increment if allowed\" semantics for denied grants (cached denies short-circuit identical retries with the original reason rather than re-asking).
- [ ] Maintainer reviews the canonical-args hash format. \`serde_json::Map\` is BTreeMap-backed (no \`preserve_order\` feature in workspace), giving byte-deterministic JSON across runs and language reimplementations.
- [ ] Maintainer confirms the deferred-list captures the right cut for foundation vs. full ADR-029 — \`blocking\` hard-deny in particular is the most security-relevant gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)